### PR TITLE
Dev fix tests

### DIFF
--- a/test/src/storage/trie/trie_storage/supergenius_codec_node_encoding_test.cpp
+++ b/test/src/storage/trie/trie_storage/supergenius_codec_node_encoding_test.cpp
@@ -14,45 +14,57 @@ using namespace storage;
 using namespace trie;
 using namespace testing;
 
-struct Case {
-  std::shared_ptr<SuperGeniusNode> node;
-  Buffer encoded_header;   
+struct Case
+{
+    std::shared_ptr<SuperGeniusNode> node;
+    Buffer                           encoded_header;
 
-  friend std::ostream &operator<<(std::ostream &out, const Case &test_struct)
-  {
-    return out; 
-  };
+    friend std::ostream& operator<<(std::ostream& out,
+                                    const Case&   test_struct)
+    {
+        return out;
+    };
 };
 
-struct NodeEncodingTest : public ::testing::TestWithParam<Case> {
-  std::unique_ptr<SuperGeniusCodec> codec = std::make_unique<SuperGeniusCodec>();
+struct NodeEncodingTest : public ::testing::TestWithParam<Case>
+{
+    std::unique_ptr<SuperGeniusCodec> codec =
+        std::make_unique<SuperGeniusCodec>();
 
-   friend std::ostream &operator<<(std::ostream &out, const NodeEncodingTest &test_struct)
-  {
-    return out; 
-  };
-
+    friend std::ostream& operator<<(std::ostream&           out,
+                                    const NodeEncodingTest& test_struct)
+    {
+        return out;
+    };
 };
 
-TEST_P(NodeEncodingTest, GetHeader) {
-  auto testCase = GetParam();
+TEST_P(NodeEncodingTest, GetHeader)
+{
+    auto testCase = GetParam();
 
-  EXPECT_OUTCOME_TRUE_2(actual, codec->encodeHeader(*(testCase.node)));
-  EXPECT_EQ(actual.toHex(), testCase.encoded_header.toHex());
+    EXPECT_OUTCOME_TRUE_2(actual, codec->encodeHeader(*(testCase.node)));
+    EXPECT_EQ(actual.toHex(), testCase.encoded_header.toHex());
 }
 
+/**
+ * @brief       Makes a Supergenius derived node
+ * @param[in]   key_nibbles: nibbles to assign to node
+ * @param[in]   value: Value to assign to node
+ * @return      Supergenius derived class
+ */
 template <typename T>
-std::shared_ptr<SuperGeniusNode> make(const base::Buffer &key_nibbles,
-                                   const base::Buffer &value) {
-    auto node = std::make_shared<T>();
+std::shared_ptr<SuperGeniusNode> make(const base::Buffer& key_nibbles,
+                                      const base::Buffer& value)
+{
+    auto node         = std::make_shared<T>();
     node->key_nibbles = key_nibbles;
-    node->value = value;
+    node->value       = value;
     return node;
 }
-
+//TODO - Improve this cases and check if this is even relevant
 static const std::vector<Case> CASES = {
-    {make<LeafNode>("010203"_hex2buf, "abcdef"_hex2buf),"43"_hex2buf},
-    {make<LeafNode>(base::Buffer(64,0xffu), base::Buffer(64,0xfeu)),"7f01"_hex2buf}
-};
+    {make<LeafNode>("010203"_hex2buf, "abcdef"_hex2buf), "43"_hex2buf},
+    {make<LeafNode>(base::Buffer(64, 0xffu), base::Buffer(64, 0xfeuF)),
+     "7f01"_hex2buf}};
 
 INSTANTIATE_TEST_CASE_P(SuperGeniusCodec, NodeEncodingTest, ValuesIn(CASES));

--- a/test/src/storage/trie/trie_storage/supergenius_codec_node_encoding_test.cpp
+++ b/test/src/storage/trie/trie_storage/supergenius_codec_node_encoding_test.cpp
@@ -34,71 +34,12 @@ struct NodeEncodingTest : public ::testing::TestWithParam<Case> {
 
 };
 
-
-  // std::ostream &operator<<(std::ostream &out,  NodeEncodingTest &test_struct)
-  // {
-  //   return out; 
-  // };
-
 TEST_P(NodeEncodingTest, GetHeader) {
   auto testCase = GetParam();
 
   EXPECT_OUTCOME_TRUE_2(actual, codec->encodeHeader(*(testCase.node)));
   EXPECT_EQ(actual.toHex(), testCase.encoded_header.toHex());
 }
-
-// template <typename T>
-// std::shared_ptr<SuperGeniusNode> make(const base::Buffer &key_nibbles,
-//                                    boost::optional<base::Buffer> value) {
-//   auto node = std::make_shared<T>();
-//   node->key_nibbles = key_nibbles;
-//   node->value = value;
-//   return node;
-// }
-
-// using T = SuperGeniusNode::Type;
-
-// constexpr uint8_t LEAF = (uint8_t)T::Leaf << 6u;
-// constexpr uint8_t BRANCH_VAL = (uint8_t)T::BranchWithValue << 6u;
-// constexpr uint8_t BRANCH_NO_VAL = (uint8_t)T::BranchEmptyValue << 6u;
-
-// static const std::vector<Case> CASES = {
-//     {make<LeafNode>({}, boost::none), {LEAF}},                         // 0
-//     {make<LeafNode>({0}, boost::none), {LEAF | 1u}},                   // 1
-//     {make<LeafNode>({0, 0, 0xf, 0x3}, boost::none), {LEAF | 4u}},      // 2
-//     {make<LeafNode>(Buffer(62, 0xf), boost::none), {LEAF | 62u}},      // 3
-//     {make<LeafNode>(Buffer(63, 0xf), boost::none), {LEAF | 63u, 0}},   // 4
-//     {make<LeafNode>(Buffer(64, 0xf), Buffer{0x01}), {LEAF | 63u, 1}},  // 5
-//     {make<LeafNode>(Buffer(318, 0xf), Buffer{0x01}),
-//      {LEAF | 63u, 255, 0}},  // 6
-//     {make<LeafNode>(Buffer(573, 0xf), Buffer{0x01}),
-//      {LEAF | 63u, 255, 255, 0}},  // 7
-
-//     {make<BranchNode>({}, boost::none), {BRANCH_NO_VAL}},        // 8
-//     {make<BranchNode>({0}, boost::none), {BRANCH_NO_VAL | 1u}},  // 9
-//     {make<BranchNode>({0, 0, 0xf, 0x3}, boost::none),
-//      {BRANCH_NO_VAL | 4u}},                                            // 10
-//     {make<BranchNode>({}, Buffer{0x01}), {BRANCH_VAL}},                // 11
-//     {make<BranchNode>({0}, Buffer{0x01}), {BRANCH_VAL | 1u}},          // 12
-//     {make<BranchNode>({0, 0}, Buffer{0x01}), {BRANCH_VAL | 2u}},       // 13
-//     {make<BranchNode>({0, 0, 0xf}, Buffer{0x01}), {BRANCH_VAL | 3u}},  // 14
-//     {make<BranchNode>(Buffer(62, 0xf), boost::none),
-//      {BRANCH_NO_VAL | 62u}},  // 15
-//     {make<BranchNode>(Buffer(62, 0xf), Buffer{0x01}),
-//      {BRANCH_VAL | 62u}},  // 16
-//     {make<BranchNode>(Buffer(63, 0xf), boost::none),
-//      {BRANCH_NO_VAL | 63u, 0}},  // 17
-//     {make<BranchNode>(Buffer(64, 0xf), boost::none),
-//      {BRANCH_NO_VAL | 63u, 1}},  // 18
-//     {make<BranchNode>(Buffer(64, 0xf), Buffer{0x01}),
-//      {BRANCH_VAL | 63u, 1}},  // 19
-//     {make<BranchNode>(Buffer(317, 0xf), Buffer{0x01}),
-//      {BRANCH_VAL | 63u, 254}},  // 20
-//     {make<BranchNode>(Buffer(318, 0xf), Buffer{0x01}),
-//      {BRANCH_VAL | 63u, 255, 0}},  // 21
-//     {make<BranchNode>(Buffer(573, 0xf), Buffer{0x01}),
-//      {BRANCH_VAL | 63u, 255, 255, 0}},  // 22
-// };
 
 template <typename T>
 std::shared_ptr<SuperGeniusNode> make(const base::Buffer &key_nibbles,

--- a/test/src/verification/finality/vote_tracker_test.cpp
+++ b/test/src/verification/finality/vote_tracker_test.cpp
@@ -129,6 +129,7 @@ TEST_F(VoteTrackerTest, TestVoteEquivocatory) {
     }	    
 
     // test for equivocatory votes
+    t_block_hash_[0] = 0x42;
     Timestamp timestamp = dist(rng); 
     Prevote vote( t_block_number_, t_block_hash_);
     Id id{};


### PR DESCRIPTION
- Changed one byte of the block hash so that the vote was not evaluated as a duplicate.
- Made the header encoding test pass. It didn't because there was no case and the GetHeader didn't ran.
- Reviewed Coding standard and set clang format accordingly (let me know if there's something non compliant to the coding standard.