### PR TITLE
Dev warningcleanup

### DIFF
--- a/build/CompilationFlags.cmake
+++ b/build/CompilationFlags.cmake
@@ -20,7 +20,9 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(AppleClang|Clang|GNU)$")
     add_flag(-Wno-unused-function) # prints too many useless warnings
     add_flag(-Wno-format-nonliteral) # prints way too many warnings from spdlog
     add_flag(-Wno-gnu-zero-variadic-macro-arguments) # https://stackoverflow.com/questions/21266380/is-the-gnu-zero-variadic-macro-arguments-safe-to-ignore
-
+	add_flag(-Wno-unused-result) #Every logger call generates this
+	add_flag(-Wno-pessimizing-move) #Warning was irrelevant to situation
+	
     # promote to errors
     # add_flag(-Werror=unused-lambda-capture)  # error if lambda capture is unused
     # add_flag(-Werror=return-type)      # warning: control reaches end of non-void function [-Wreturn-type]

--- a/example/AsyncFile/MNNExample.cpp
+++ b/example/AsyncFile/MNNExample.cpp
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
     //    // Do nothing
     //};
     FileManager::GetInstance().InitializeSingletons();
-    for (int i = 0; i < file_names.size(); i++)
+    for (size_t i = 0; i < file_names.size(); i++)
     {
         std::cout << "LoadASync: " << file_names[i] << std::endl;
         auto data = FileManager::GetInstance().LoadASync(file_names[i], false, true, ioc, [](const sgns::AsyncError::CustomResult& status)

--- a/example/echo_client/echo_client.cpp
+++ b/example/echo_client/echo_client.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
   using libp2p::crypto::PrivateKey;
   using libp2p::crypto::PublicKey;
   using GossipPubSub = sgns::ipfs_pubsub::GossipPubSub;
-  using GossipPubSubTopic = sgns::ipfs_pubsub::GossipPubSubTopic;
+  //using GossipPubSubTopic = sgns::ipfs_pubsub::GossipPubSubTopic;
   namespace po = boost::program_options;
 
   int portNumber = 0;

--- a/example/mnn_chunkprocess/multiPose.cpp
+++ b/example/mnn_chunkprocess/multiPose.cpp
@@ -109,7 +109,7 @@ static int decodePoseImpl(float curScore, int curId, const CV::Point& originalOn
     const int height              = heatmaps->height();
     const int width               = heatmaps->width();
     std::map<std::string, int> poseNamesID;
-    for (int i = 0; i < PoseNames.size(); ++i) {
+    for (size_t i = 0; i < PoseNames.size(); ++i) {
         poseNamesID[PoseNames[i]] = i;
     }
 
@@ -154,7 +154,7 @@ static int decodePoseImpl(float curScore, int curId, const CV::Point& originalOn
         }
     }
 
-    for (int edge = 0; edge < PoseChain.size(); ++edge) {
+    for (size_t edge = 0; edge < PoseChain.size(); ++edge) {
         const int sourceKeypointID = poseNamesID[PoseChain[edge].first];
         const int targetKeypointID = poseNamesID[PoseChain[edge].second];
         if (instanceKeypointScores[sourceKeypointID] > 0.0 && instanceKeypointScores[targetKeypointID] == 0.0) {
@@ -226,7 +226,7 @@ static int decodeMultiPose(const Tensor* offsets, const Tensor* displacementFwd,
 
     auto withinNMSRadius = [=, &poseKeypointCoords](const CV::Point& point, const int id) {
         bool withinThisPointRadius = false;
-        for (int i = 0; i < poseKeypointCoords.size(); ++i) {
+        for (size_t i = 0; i < poseKeypointCoords.size(); ++i) {
             const auto& curPoint = poseKeypointCoords[i][id];
             const auto sum       = powf((curPoint.fX - point.fX), 2) + powf((curPoint.fY - point.fY), 2);
             if (sum <= squareNMSRadius) {

--- a/example/processing_mnn/processing_mnn.cpp
+++ b/example/processing_mnn/processing_mnn.cpp
@@ -249,14 +249,12 @@ int main(int argc, char* argv[])
         nChunks,
         false);
 
-    int chunkopt = 0;
     for (auto& task : tasks)
     {
         std::cout << "subtask" << std::endl;
         std::list<SGProcessing::SubTask> subTasks;
         taskSplitter.SplitTask(task, subTasks, imagesplit, chunkOptions);
         taskQueue->EnqueueTask(task, subTasks);
-        chunkopt++;
     }
     
     //Run ASIO

--- a/example/processing_mnn/processing_mnn.hpp
+++ b/example/processing_mnn/processing_mnn.hpp
@@ -107,7 +107,6 @@ namespace
         }
     private:
         size_t m_nSubTasks;
-        size_t m_nChunks;
         bool m_addValidationSubtask;
     };
 

--- a/example/processing_mnn/processing_mnn.hpp
+++ b/example/processing_mnn/processing_mnn.hpp
@@ -34,7 +34,6 @@ namespace
             size_t nChunks,
             bool addValidationSubtask)
             : m_nSubTasks(nSubTasks)
-            , m_nChunks(nChunks)
             , m_addValidationSubtask(addValidationSubtask)
         {
         }

--- a/example/processing_room/processing_app.cpp
+++ b/example/processing_room/processing_app.cpp
@@ -100,7 +100,7 @@ namespace
 
         void EnqueueTask(
             const SGProcessing::Task& task,
-            const std::list<SGProcessing::SubTask>& subTasks)
+            const std::list<SGProcessing::SubTask>& subTasks) override
         {
             m_tasks.push_back(task);
             m_subTasks.emplace(task.ipfs_block_id(), subTasks);
@@ -108,7 +108,7 @@ namespace
 
         bool GetSubTasks(
             const std::string& taskId,
-            std::list<SGProcessing::SubTask>& subTasks)
+            std::list<SGProcessing::SubTask>& subTasks) override
         {
             auto it = m_subTasks.find(taskId);
             if (it != m_subTasks.end())

--- a/src/account/EscrowTransaction.cpp
+++ b/src/account/EscrowTransaction.cpp
@@ -14,10 +14,10 @@ namespace sgns
                                           const uint256_t &dest_addr, const float &cut,
                                           const SGTransaction::DAGStruct &dag ) :
         IGeniusTransactions( "escrow", SetDAGWithType( dag, "escrow" ) ), //
-        utxo_params_( params ),                                           //
+        num_chunks_(num_chunks),                                         //
         dev_addr( dest_addr ),                                            //
         dev_cut( cut ),                                                   //
-        num_chunks_( num_chunks )                                         //
+        utxo_params_(params)                                           //
     {
         auto hasher_ = std::make_shared<sgns::crypto::HasherImpl>();
         auto hash    = hasher_->blake2b_256( SerializeByteVector() );

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -43,6 +43,12 @@ namespace sgns
         auto loggerDAGSyncer = base::createLogger( "GraphsyncDAGSyncer" );
         loggerDAGSyncer->set_level( spdlog::level::off );
 
+        //auto loggerAutonat = base::createLogger("Autonat");
+        //loggerDAGSyncer->set_level(spdlog::level::trace);
+
+        //auto loggerAutonatMsg = base::createLogger("AutonatMsgProcessor");
+        //loggerDAGSyncer->set_level(spdlog::level::trace);
+
         auto logkad = sgns::base::createLogger( "Kademlia" );
         logkad->set_level( spdlog::level::off );
 

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -32,12 +32,12 @@ namespace sgns
         db_m( std::move( db ) ),                                                                                    //
         ctx_m( std::move( ctx ) ),                                                                                  //
         account_m( std::move( account ) ),                                                                          //
+        timer_m(std::make_shared<boost::asio::steady_timer>(*ctx_m, boost::asio::chrono::milliseconds(300))),       //
+        last_block_id_m(0),                                                                                         //
+        last_trans_on_block_id(0),                                                                                  //
+        block_storage_m(std::move(block_storage)),                                                                  //
         hasher_m( std::move( hasher ) ),                                                                            //
-        block_storage_m( std::move( block_storage ) ),                                                              //
-        processing_finished_cb_m( processing_finished_cb ),                                                         //
-        timer_m( std::make_shared<boost::asio::steady_timer>( *ctx_m, boost::asio::chrono::milliseconds( 300 ) ) ), //
-        last_block_id_m( 0 ),                                                                                       //
-        last_trans_on_block_id( 0 )                                                                                 //
+        processing_finished_cb_m( processing_finished_cb )                                                          //
 
     {
         m_logger->set_level( spdlog::level::debug );

--- a/src/crdt/globaldb/globaldb.cpp
+++ b/src/crdt/globaldb/globaldb.cpp
@@ -41,8 +41,8 @@ GlobalDB::GlobalDB(
     : m_context(std::move(context))
     , m_databasePath(std::move(databasePath))
     , m_dagSyncPort(dagSyncPort)
-    , m_broadcastChannel(std::move(broadcastChannel))
     , m_graphSyncAddrs(gsaddresses)
+    , m_broadcastChannel(std::move(broadcastChannel))
 {
 }
 

--- a/src/processing/impl/processing_core_impl.cpp
+++ b/src/processing/impl/processing_core_impl.cpp
@@ -66,7 +66,7 @@ namespace sgns::processing
         FileManager::GetInstance().InitializeSingletons();
         string fileURL = "https://ipfs.filebase.io/ipfs/" + cid + "/settings.json";
         std::cout << "FILE URLL: " << fileURL << std::endl;
-        auto data = FileManager::GetInstance().LoadASync(fileURL, false, false, ioc, [ioc, this](const sgns::AsyncError::CustomResult& status)
+        auto data = FileManager::GetInstance().LoadASync(fileURL, false, false, ioc, [ioc](const sgns::AsyncError::CustomResult& status)
             {
                 if (status.has_value())
                 {
@@ -75,7 +75,7 @@ namespace sgns::processing
                 else {
                     std::cout << "Error: " << status.error() << std::endl;
                 }
-            }, [ioc, &mainbuffers, this](std::shared_ptr<std::pair<std::vector<std::string>, std::vector<std::vector<char>>>> buffers)
+            }, [ioc, &mainbuffers](std::shared_ptr<std::pair<std::vector<std::string>, std::vector<std::vector<char>>>> buffers)
                 {
                     std::cout << "Final Callback" << std::endl;
 
@@ -177,7 +177,7 @@ namespace sgns::processing
     void ProcessingCoreImpl::GetSubCidForProc(std::shared_ptr<boost::asio::io_context> ioc,std::string url, std::shared_ptr<std::pair<std::vector<std::string>, std::vector<std::vector<char>>>>& results)
     {
         //std::pair<std::vector<std::string>, std::vector<std::vector<char>>> results;
-        auto modeldata = FileManager::GetInstance().LoadASync(url, false, false, ioc, [this](const sgns::AsyncError::CustomResult& status)
+        auto modeldata = FileManager::GetInstance().LoadASync(url, false, false, ioc, [](const sgns::AsyncError::CustomResult& status)
             {
                 if (status.has_value())
                 {
@@ -186,7 +186,7 @@ namespace sgns::processing
                 else {
                     std::cout << "Error: " << status.error() << std::endl;
                 }
-            }, [&results, this](std::shared_ptr<std::pair<std::vector<std::string>, std::vector<std::vector<char>>>> buffers)
+            }, [&results](std::shared_ptr<std::pair<std::vector<std::string>, std::vector<std::vector<char>>>> buffers)
                 {
                     results->first.insert(results->first.end(), buffers->first.begin(), buffers->first.end());
                     results->second.insert(results->second.end(), buffers->second.begin(), buffers->second.end());
@@ -216,6 +216,7 @@ namespace sgns::processing
                 else
                 {
                     std::cerr << "No processor by name in settings json" << std::endl;
+                    return false;
                 }
             }
             else {

--- a/src/processing/impl/processing_core_impl.hpp
+++ b/src/processing/impl/processing_core_impl.hpp
@@ -26,10 +26,10 @@ namespace sgns::processing
             size_t subTaskProcessingTime,
             size_t maximalProcessingSubTaskCount)
             : m_db(db)
-            , m_subTaskProcessingTime(subTaskProcessingTime)
+            //, m_subTaskProcessingTime(subTaskProcessingTime)
             , m_maximalProcessingSubTaskCount(maximalProcessingSubTaskCount)
-            , m_processingSubTaskCount(0)
             , m_processor(nullptr)
+            , m_processingSubTaskCount(0)
         {
         }
 
@@ -88,7 +88,7 @@ namespace sgns::processing
         std::shared_ptr<sgns::crdt::GlobalDB> m_db;
         std::unique_ptr<ProcessingProcessor> m_processor;
         std::unordered_map<std::string, std::function<std::unique_ptr<ProcessingProcessor>()>> m_processorFactories;
-        size_t m_subTaskProcessingTime;
+        //size_t m_subTaskProcessingTime;
         size_t m_maximalProcessingSubTaskCount;
 
         std::mutex m_subTaskCountMutex;

--- a/src/processing/impl/processing_core_impl.hpp
+++ b/src/processing/impl/processing_core_impl.hpp
@@ -27,8 +27,8 @@ namespace sgns::processing
             size_t maximalProcessingSubTaskCount)
             : m_db(db)
             //, m_subTaskProcessingTime(subTaskProcessingTime)
-            , m_maximalProcessingSubTaskCount(maximalProcessingSubTaskCount)
             , m_processor(nullptr)
+            , m_maximalProcessingSubTaskCount(maximalProcessingSubTaskCount)
             , m_processingSubTaskCount(0)
         {
         }

--- a/src/processing/processing_service.cpp
+++ b/src/processing/processing_service.cpp
@@ -37,11 +37,11 @@ namespace sgns::processing
         m_subTaskStateStorage( subTaskStateStorage ),                   //
         m_subTaskResultStorage( subTaskResultStorage ),                 //
         m_processingCore( processingCore ),                             //
-        userCallbackSuccess_( userCallbackSuccess ),                    //
-        userCallbackError_( userCallbackError ),                        //
         m_timerChannelListRequestTimeout( *m_context.get() ),           //
         m_channelListRequestTimeout( boost::posix_time::seconds( 5 ) ), //
-        m_isStopped( true )                                             //
+        m_isStopped( true ),                                            //
+        userCallbackSuccess_(userCallbackSuccess),                      //
+        userCallbackError_(userCallbackError)                           //
     {
     }
 

--- a/src/processing/processing_tasksplit.cpp
+++ b/src/processing/processing_tasksplit.cpp
@@ -11,7 +11,7 @@ namespace sgns
     {
         ProcessTaskSplitter::ProcessTaskSplitter( size_t nSubTasks, size_t nChunks, bool addValidationSubtask ) :
             m_nSubTasks( nSubTasks ), //
-            m_nChunks( nChunks ),     //
+            //m_nChunks( nChunks ),     //
             m_addValidationSubtask( addValidationSubtask )
         {
         }

--- a/src/processing/processing_tasksplit.hpp
+++ b/src/processing/processing_tasksplit.hpp
@@ -26,7 +26,7 @@ namespace sgns
 
         private:
             size_t m_nSubTasks;
-            size_t m_nChunks;
+            //size_t m_nChunks;
             bool   m_addValidationSubtask;
         };
 

--- a/src/processing/processors/processing_processor_mnn_posenet.cpp
+++ b/src/processing/processors/processing_processor_mnn_posenet.cpp
@@ -13,6 +13,7 @@ namespace sgns::processing
                                                        const SGProcessing::Task    &task,
                                                        const SGProcessing::SubTask &subTask )
     {
+        std::vector<uint8_t> subTaskResultHash(SHA256_DIGEST_LENGTH);
         for ( auto image : *imageData_ )
         {
             std::vector<uint8_t> output( image.size() );
@@ -25,7 +26,7 @@ namespace sgns::processing
             ImageSplitter ChunkSplit( animageSplit.GetPart( dataindex ), basechunk.line_stride(), basechunk.stride(),
                                       animageSplit.GetPartHeightActual( dataindex ) / basechunk.subchunk_height() *
                                           basechunk.line_stride() );
-            std::vector<uint8_t> subTaskResultHash( SHA256_DIGEST_LENGTH );
+            
             for ( int chunkIdx = 0; chunkIdx < subTask.chunkstoprocess_size(); ++chunkIdx )
             {
                 std::cout << "Chunk IDX:  " << chunkIdx << "Total: " << subTask.chunkstoprocess_size() << std::endl;
@@ -63,6 +64,7 @@ namespace sgns::processing
             }
             return subTaskResultHash;
         }
+        return subTaskResultHash;
     }
 
     void MNN_PoseNet::SetData(


### PR DESCRIPTION
Some warnings remain, specifically 
/Users/fuu/gnus/SuperGenius/src/account/TransactionManager.hpp:67:58: warning: private field 'last_trans_on_block_id'
Left this alone due to assumption we may intend to use this.

ld: warning: ignoring duplicate libraries 
Many of these occur. 

clang: warning: argument unused during compilation: '-Xlink=-force:multiple'
Might be able to suppress this or manage it in a way it's only used in libraries that need it.

/src/crypto/bip39/mnemonic.cpp:23:33: warning: 'codecvt_utf8_utf16<wchar_t>' is deprecated [-Wdeprecated-declarations]
/src/crypto/bip39/mnemonic.cpp:23:12: warning: 'wstring_convert<std::codecvt_utf8_utf16<wchar_t>>' is deprecated
I don't know if we even plan to use bip39

stb_image_write.h has some warnings, but we won't even be using it. 

src/base/hexutil.hpp:84:14: warning: shift count >= width of type
I feel like the shift beyond width of type is the entire point of the function, in order to detect that. 

src/storage/database_error.cpp:31:5: warning: all paths through this function will call itself
This should possibly be dealt, it seems like a test setup though. 