### PR TITLE
dev_child_token to develop

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,7 +49,7 @@ jobs:
             abi: arm64-v8a
             build-type: "Release"
           - target: Android
-            host: ubuntu-22.04
+            host: gv-Linux-large
             abi: arm64-v8a
             build-type: "Debug"
           - target: Android

--- a/example/account_handling/AccountHelper.cpp
+++ b/example/account_handling/AccountHelper.cpp
@@ -33,7 +33,7 @@ namespace sgns
     AccountHelper::AccountHelper( const AccountKey2   &priv_key_data,
                                   const DevConfig_st2 &dev_config,
                                   const char          *eth_private_key ) :
-        account_( std::make_shared<GeniusAccount>( 0, "", eth_private_key ) ),
+        account_( std::make_shared<GeniusAccount>( "0", "GNUS Token", eth_private_key ) ),
         io_( std::make_shared<boost::asio::io_context>() ),
         dev_config_( dev_config )
     {

--- a/example/account_handling/AccountHelper.cpp
+++ b/example/account_handling/AccountHelper.cpp
@@ -33,7 +33,7 @@ namespace sgns
     AccountHelper::AccountHelper( const AccountKey2   &priv_key_data,
                                   const DevConfig_st2 &dev_config,
                                   const char          *eth_private_key ) :
-        account_( std::make_shared<GeniusAccount>( "0", "GNUS Token", eth_private_key ) ),
+        account_( std::make_shared<GeniusAccount>( "GNUS Token", "", eth_private_key ) ),
         io_( std::make_shared<boost::asio::io_context>() ),
         dev_config_( dev_config )
     {

--- a/example/node_test/NodeExample.cpp
+++ b/example/node_test/NodeExample.cpp
@@ -366,7 +366,7 @@ std::string generate_eth_private_key() {
     return oss.str();
 }
 
-DevConfig_st DEV_CONFIG{ "0xcafe", "0.65", "1.0", 0 , "./"};
+DevConfig_st DEV_CONFIG{ "0xcafe", "0.65", "1.0", "GNUS Token" , "./"};
 
 int main(int argc, char *argv[])
 {

--- a/example/node_test/NodeExample.cpp
+++ b/example/node_test/NodeExample.cpp
@@ -366,7 +366,7 @@ std::string generate_eth_private_key() {
     return oss.str();
 }
 
-DevConfig_st DEV_CONFIG{ "0xcafe", "0.65", 1.0, 0 , "./"};
+DevConfig_st DEV_CONFIG{ "0xcafe", "0.65", "1.0", 0 , "./"};
 
 int main(int argc, char *argv[])
 {

--- a/example/processing_mnn/processing_mnn_p.cpp
+++ b/example/processing_mnn/processing_mnn_p.cpp
@@ -13,6 +13,7 @@
 #include "processing_mnn.hpp"
 #include <ipfs_lite/ipfs/graphsync/impl/network/network.hpp>
 #include <ipfs_lite/ipfs/graphsync/impl/local_requests.hpp>
+#include <string>
 
 using GossipPubSub = sgns::ipfs_pubsub::GossipPubSub;
 const std::string logger_config( R"(
@@ -67,6 +68,8 @@ int main( int argc, char *argv[] )
     //Inputs
     char  *endPtr;
     size_t serviceindex = std::strtoul( argv[1], &endPtr, 10 );
+    auto tokenId = std::to_string( serviceindex );
+
 
     //Split Image into RGBA bytes
     //ImageSplitter imagesplit(inputImageFileName, 128, 128);
@@ -117,7 +120,7 @@ int main( int argc, char *argv[] )
     auto enqueuer2  = std::make_shared<SubTaskEnqueuerImpl>( taskQueue2 );
 
     //Processing Core
-    auto processingCore2 = std::make_shared<ProcessingCoreImpl>( globalDB2, 1000000, 2 );
+    auto processingCore2 = std::make_shared<ProcessingCoreImpl>( globalDB2, 1000000, 2, tokenId );
     processingCore2->RegisterProcessorFactory( "mnnimage", []() { return std::make_unique<MNN_Image>(); } );
     //processingCore2->SetProcessorByName("posenet");
     //Set Imagesplit, this replaces bitswap getting of file for now. Should use AsyncIOmanager in the future

--- a/src/account/EscrowReleaseTransaction.cpp
+++ b/src/account/EscrowReleaseTransaction.cpp
@@ -104,7 +104,7 @@ namespace sgns
         for ( int i = 0; i < utxo_proto_params->outputs_size(); ++i )
         {
             const auto &out_proto = utxo_proto_params->outputs( i );
-            outputs.push_back( { out_proto.encrypted_amount(), out_proto.dest_addr() } );
+            outputs.push_back( { out_proto.encrypted_amount(), out_proto.dest_addr(), out_proto.token_id() } );
         }
         UTXOTxParameters utxo_params( inputs, outputs );
         auto             releaseTx = std::make_shared<EscrowReleaseTransaction>(

--- a/src/account/EscrowTransaction.cpp
+++ b/src/account/EscrowTransaction.cpp
@@ -57,6 +57,7 @@ namespace sgns
             SGTransaction::TransferOutput *output_proto = utxo_proto_params->add_outputs();
             output_proto->set_encrypted_amount( output.encrypted_amount );
             output_proto->set_dest_addr( output.dest_address );
+            output_proto->set_token_id( output.token_id );
         }
         tx_struct.set_amount( amount_ );
         tx_struct.set_dev_addr( dev_addr_ );
@@ -93,7 +94,7 @@ namespace sgns
         {
             const SGTransaction::TransferOutput &output_proto = utxo_proto_params->outputs( i );
 
-            OutputDestInfo curr{ output_proto.encrypted_amount(), output_proto.dest_addr() };
+            OutputDestInfo curr{ output_proto.encrypted_amount(), output_proto.dest_addr(), output_proto.token_id() };
             outputs.push_back( curr );
         }
         uint64_t amount    = tx_struct.amount();

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -25,8 +25,8 @@ namespace sgns
 {
     const std::array<uint8_t, 32> GeniusAccount::ELGAMAL_PUBKEY_PREDEFINED = get_elgamal_pubkey();
 
-    GeniusAccount::GeniusAccount( const uint8_t token_type, std::string_view base_path, const char *eth_private_key ) :
-        token( token_type ), nonce( 0 )
+    GeniusAccount::GeniusAccount( std::string token_id, std::string_view base_path, const char *eth_private_key ) :
+        token( token_id ), nonce( 0 )
     {
         if ( auto maybe_address = GenerateGeniusAddress( base_path, eth_private_key ); maybe_address.has_value() )
         {

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -107,18 +107,4 @@ namespace sgns
         return balance;
     }
 
-    uint64_t GeniusAccount::GetBalance( const std::vector<std::string> &token_ids ) const
-    {
-        std::unordered_set<std::string> token_set( token_ids.begin(), token_ids.end() );
-        uint64_t                        balance = 0;
-        for ( const auto &utxo : utxos )
-        {
-            if ( !utxo.GetLock() && token_set.count( utxo.GetTokenID() ) )
-            {
-                balance += utxo.GetAmount();
-            }
-        }
-        return balance;
-    }
-
 }

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -32,8 +32,8 @@ namespace sgns
         {
             auto [temp_elgamal_address, temp_eth_address] = maybe_address.value();
 
-            eth_address = std::make_shared<ethereum::EthereumKeyGenerator>(std::move(temp_eth_address));
-            elgamal_address = std::make_shared<KeyGenerator::ElGamal>(std::move(temp_elgamal_address));
+            eth_address     = std::make_shared<ethereum::EthereumKeyGenerator>( std::move( temp_eth_address ) );
+            elgamal_address = std::make_shared<KeyGenerator::ElGamal>( std::move( temp_elgamal_address ) );
         }
         else
         {
@@ -93,4 +93,32 @@ namespace sgns
 
         return std::make_pair( std::move( elgamal_key ), std::move( eth_key ) );
     }
+
+    uint64_t GeniusAccount::GetBalance( const std::string &token_id ) const
+    {
+        uint64_t balance = 0;
+        for ( const auto &utxo : utxos )
+        {
+            if ( !utxo.GetLock() && utxo.GetTokenID() == token_id )
+            {
+                balance += utxo.GetAmount();
+            }
+        }
+        return balance;
+    }
+
+    uint64_t GeniusAccount::GetBalance( const std::vector<std::string> &token_ids ) const
+    {
+        std::unordered_set<std::string> token_set( token_ids.begin(), token_ids.end() );
+        uint64_t                        balance = 0;
+        for ( const auto &utxo : utxos )
+        {
+            if ( !utxo.GetLock() && token_set.count( utxo.GetTokenID() ) )
+            {
+                balance += utxo.GetAmount();
+            }
+        }
+        return balance;
+    }
+
 }

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -28,7 +28,7 @@ namespace sgns
     public:
         static const std::array<uint8_t, 32> ELGAMAL_PUBKEY_PREDEFINED;
 
-        GeniusAccount( uint8_t token_type, std::string_view base_path, const char *eth_private_key );
+        GeniusAccount( std::string token_id, std::string_view base_path, const char *eth_private_key );
 
         ~GeniusAccount()
         {
@@ -73,7 +73,8 @@ namespace sgns
 
         [[nodiscard]] std::string GetToken() const
         {
-            return "GNUS Token";
+            return token;
+            // return "GNUS Token";
         }
 
         [[nodiscard]] std::string GetNonce() const
@@ -124,7 +125,7 @@ namespace sgns
         std::shared_ptr<KeyGenerator::ElGamal>          elgamal_address;
         std::shared_ptr<ethereum::EthereumKeyGenerator> eth_address;
 
-        uint8_t                 token; //GNUS SGNUS ETC...
+        std::string             token; //GNUS SGNUS ETC...
         uint64_t                nonce;
         std::vector<GeniusUTXO> utxos;
 

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -75,8 +75,6 @@ namespace sgns
 
         uint64_t GetBalance( const std::string &token_id ) const;
 
-        uint64_t GetBalance( const std::vector<std::string> &token_ids ) const;
-
         [[nodiscard]] std::string GetToken() const
         {
             return token;

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -18,6 +18,8 @@
 #include "account/GeniusUTXO.hpp"
 #include "account/UTXOTxParameters.hpp"
 #include "outcome/outcome.hpp"
+#include <vector>
+#include <array>
 
 namespace sgns
 {
@@ -70,6 +72,10 @@ namespace sgns
         {
             return std::to_string( GetBalance<uint64_t>() );
         }
+
+        uint64_t GetBalance( const std::string &token_id ) const;
+
+        uint64_t GetBalance( const std::vector<std::string> &token_ids ) const;
 
         [[nodiscard]] std::string GetToken() const
         {

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -852,6 +852,44 @@ namespace sgns
         return transaction_manager_->GetBalance();
     }
 
+    outcome::result<std::pair<std::string, uint64_t>> GeniusNode::MintChildTokens(
+        uint64_t /*amount*/,
+        const std::string & /*transaction_hash*/,
+        const std::string & /*chain_id*/,
+        const std::string & /*token_id*/,
+        std::chrono::milliseconds /*timeout*/ )
+    {
+        // TODO: implement child-token mint logic
+        return outcome::failure( boost::system::errc::make_error_code( boost::system::errc::function_not_supported ) );
+    }
+
+    outcome::result<uint64_t> GeniusNode::GetChildBalance() const
+    {
+        // TODO: implement child-token balance retrieval
+        return outcome::success<uint64_t>( 0 );
+    }
+
+    outcome::result<std::pair<std::string, uint64_t>> GeniusNode::TransferChildTokens(
+        uint64_t /*amount*/,
+        const std::string & /*destination*/,
+        std::chrono::milliseconds /*timeout*/ )
+    {
+        // TODO: implement transfer child tokens
+        return outcome::failure( boost::system::errc::make_error_code( boost::system::errc::function_not_supported ) );
+    }
+
+    std::string GeniusNode::FormatChildTokens( uint64_t /*amount*/ ) const
+    {
+        // TODO: implement formatting of child-token amounts
+        return std::string{};
+    }
+
+    outcome::result<uint64_t> GeniusNode::ParseChildTokens( const std::string & /*amount_str*/ ) const
+    {
+        // TODO: implement parsing of child-token amounts
+        return outcome::failure( boost::system::errc::make_error_code( boost::system::errc::function_not_supported ) );
+    }
+
     void GeniusNode::ProcessingDone( const std::string &task_id, const SGProcessing::TaskResult &taskresult )
     {
         node_logger->info( "[ {} ] SUCCESS PROCESSING TASK {}", account_->GetAddress(), task_id );

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -856,11 +856,6 @@ namespace sgns
         return account_->GetBalance( token_id );
     }
 
-    uint64_t GeniusNode::GetBalance( const std::vector<std::string> &token_ids )
-    {
-        return account_->GetBalance( token_ids );
-    }
-
     std::string GeniusNode::FormatChildTokens( uint64_t amount ) const
     {
         auto maybe_child_token = TokenAmount::ConvertToChildToken( amount, dev_config_.TokenValueInGNUS );

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -91,9 +91,7 @@ namespace sgns
                             bool                isprocessor,
                             uint16_t            base_port,
                             bool                is_full_node ) :
-        account_( std::make_shared<GeniusAccount>( dev_config.TokenID,
-                                                   dev_config.BaseWritePath,
-                                                   eth_private_key ) ),
+        account_( std::make_shared<GeniusAccount>( dev_config.TokenID, dev_config.BaseWritePath, eth_private_key ) ),
         io_( std::make_shared<boost::asio::io_context>() ),
         write_base_path_( dev_config.BaseWritePath ),
         autodht_( autodht ),
@@ -194,7 +192,7 @@ namespace sgns
 
         auto tokenid = dev_config_.TokenID;
 
-        auto pubsubport = GenerateRandomPort( base_port, account_->GetAddress() +  tokenid );
+        auto pubsubport = GenerateRandomPort( base_port, account_->GetAddress() + tokenid );
 
         std::vector<std::string> addresses;
         // UPNP
@@ -851,6 +849,16 @@ namespace sgns
     uint64_t GeniusNode::GetBalance()
     {
         return transaction_manager_->GetBalance();
+    }
+
+    uint64_t GeniusNode::GetBalance( const std::string &token_id )
+    {
+        return account_->GetBalance( token_id );
+    }
+
+    uint64_t GeniusNode::GetBalance( const std::vector<std::string> &token_ids )
+    {
+        return account_->GetBalance( token_ids );
     }
 
     std::string GeniusNode::FormatChildTokens( uint64_t amount ) const

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -853,22 +853,9 @@ namespace sgns
         return transaction_manager_->GetBalance();
     }
 
-    outcome::result<std::pair<std::string, uint64_t>> GeniusNode::MintChildTokens( uint64_t           amount,
-                                                                                   const std::string &transaction_hash,
-                                                                                   const std::string &chain_id,
-                                                                                   const std::string &token_id,
-                                                                                   std::chrono::milliseconds timeout )
-    {
-        OUTCOME_TRY( auto mainAmount, TokenAmount::ConvertFromChildToken( amount, dev_config_.TokenValueInGNUS ) );
-
-        return MintTokens( mainAmount, transaction_hash, chain_id, token_id, timeout );
-    }
 
     outcome::result<uint64_t> GeniusNode::GetChildBalance() const
     {
-        uint64_t mainRaw = const_cast<GeniusNode *>( this )->GetBalance();
-
-        return TokenAmount::ConvertToChildToken( mainRaw, dev_config_.TokenValueInGNUS );
     }
 
     outcome::result<std::pair<std::string, uint64_t>> GeniusNode::TransferChildTokens(
@@ -889,15 +876,13 @@ namespace sgns
             return {};
         }
 
-        return TokenAmount::FormatMinions( maybe_child_token.value() );
+        return maybe_child_token.value();
     }
 
     outcome::result<uint64_t> GeniusNode::ParseChildTokens( const std::string &amount_str ) const
     {
-        OUTCOME_TRY( auto &&child_token_amount, TokenAmount::ParseMinions( amount_str ) );
-
         OUTCOME_TRY( auto &&minion_amount,
-                     TokenAmount::ConvertFromChildToken( child_token_amount, dev_config_.TokenValueInGNUS ) );
+                     TokenAmount::ConvertFromChildToken( amount_str, dev_config_.TokenValueInGNUS ) );
 
         return minion_amount;
     }

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -318,7 +318,10 @@ namespace sgns
         job_globaldb_ = std::move( global_db_ret.value() );
 
         task_queue_      = std::make_shared<processing::ProcessingTaskQueueImpl>( job_globaldb_ );
-        processing_core_ = std::make_shared<processing::ProcessingCoreImpl>( job_globaldb_, 1000000, 1 );
+        processing_core_ = std::make_shared<processing::ProcessingCoreImpl>( job_globaldb_,
+                                                                             1000000,
+                                                                             1,
+                                                                             dev_config.TokenID );
         processing_core_->RegisterProcessorFactory( "mnnimage",
                                                     [] { return std::make_unique<processing::MNN_Image>(); } );
 

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -91,7 +91,7 @@ namespace sgns
                             bool                isprocessor,
                             uint16_t            base_port,
                             bool                is_full_node ) :
-        account_( std::make_shared<GeniusAccount>( static_cast<uint8_t>( dev_config.TokenID ),
+        account_( std::make_shared<GeniusAccount>( dev_config.TokenID,
                                                    dev_config.BaseWritePath,
                                                    eth_private_key ) ),
         io_( std::make_shared<boost::asio::io_context>() ),

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -194,7 +194,7 @@ namespace sgns
 
         auto tokenid = dev_config_.TokenID;
 
-        auto pubsubport = GenerateRandomPort( base_port, account_->GetAddress() + std::to_string( tokenid ) );
+        auto pubsubport = GenerateRandomPort( base_port, account_->GetAddress() +  tokenid );
 
         std::vector<std::string> addresses;
         // UPNP

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -154,7 +154,7 @@ namespace sgns
         loggerGraphsync->set_level( spdlog::level::err );
         loggerBroadcaster->set_level( spdlog::level::err );
         loggerDataStore->set_level( spdlog::level::err );
-        loggerTransactions->set_level( spdlog::level::err );
+        loggerTransactions->set_level( spdlog::level::debug );
         loggerMigration->set_level( spdlog::level::err );
         loggerMigrationStep->set_level( spdlog::level::err );
         loggerQueue->set_level( spdlog::level::err );

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -853,20 +853,6 @@ namespace sgns
         return transaction_manager_->GetBalance();
     }
 
-
-    outcome::result<uint64_t> GeniusNode::GetChildBalance() const
-    {
-    }
-
-    outcome::result<std::pair<std::string, uint64_t>> GeniusNode::TransferChildTokens(
-        uint64_t /*amount*/,
-        const std::string & /*destination*/,
-        std::chrono::milliseconds /*timeout*/ )
-    {
-        // TODO: implement transfer child tokens
-        return outcome::failure( boost::system::errc::make_error_code( boost::system::errc::function_not_supported ) );
-    }
-
     std::string GeniusNode::FormatChildTokens( uint64_t amount ) const
     {
         auto maybe_child_token = TokenAmount::ConvertToChildToken( amount, dev_config_.TokenValueInGNUS );

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -55,18 +55,18 @@ namespace sgns
          */
         enum class Error
         {
-            INSUFFICIENT_FUNDS       = 1,  ///<Insufficient funds for a transaction
-            DATABASE_WRITE_ERROR     = 2,  ///<Error writing data into the database
-            INVALID_TRANSACTION_HASH = 3,  ///<Input transaction hash is invalid
-            INVALID_CHAIN_ID         = 4,  ///<Chain ID is invalid
-            INVALID_TOKEN_ID         = 5,  ///<Token ID is invalid
-            TOKEN_ID_MISMATCH        = 6,  ///<Informed Token ID doesn't match initialized ID
-            PROCESS_COST_ERROR       = 7,  ///<The calculated Processing cost was negative
-            PROCESS_INFO_MISSING     = 8,  ///<Processing information missing on JSON file
-            INVALID_JSON             = 9,  ///<JSON cannot be parsed>
-            INVALID_BLOCK_PARAMETERS = 10, ///<JSON params for blocks incorrect or missing>
-            NO_PROCESSOR             = 11, ///<No processor for this type>
-            NO_PRICE                 = 12, ///<Couldn't get price of gnus>
+            INSUFFICIENT_FUNDS       = 1,  ///< Insufficient funds for a transaction
+            DATABASE_WRITE_ERROR     = 2,  ///< Error writing data into the database
+            INVALID_TRANSACTION_HASH = 3,  ///< Input transaction hash is invalid
+            INVALID_CHAIN_ID         = 4,  ///< Chain ID is invalid
+            INVALID_TOKEN_ID         = 5,  ///< Token ID is invalid
+            TOKEN_ID_MISMATCH        = 6,  ///< Informed Token ID doesn't match initialized ID
+            PROCESS_COST_ERROR       = 7,  ///< The calculated Processing cost was negative
+            PROCESS_INFO_MISSING     = 8,  ///< Processing information missing on JSON file
+            INVALID_JSON             = 9,  ///< JSON cannot be parsed>
+            INVALID_BLOCK_PARAMETERS = 10, ///< JSON params for blocks incorrect or missing>
+            NO_PROCESSOR             = 11, ///< No processor for this type>
+            NO_PRICE                 = 12, ///< Couldn't get price of gnus>
         };
 
 #ifdef SGNS_DEBUG
@@ -173,6 +173,52 @@ namespace sgns
         bool WaitForTransactionOutgoing( const std::string &txId, std::chrono::milliseconds timeout );
 
         bool WaitForEscrowRelease( const std::string &originalEscrowId, std::chrono::milliseconds timeout );
+
+        /**
+         * Mint in a child (fractional) token.
+         * @param amount Amount of child tokens to mint.
+         * @param transaction_hash Transaction identifier.
+         * @param chain_id Blockchain chain identifier.
+         * @param token_id Child token identifier.
+         * @param timeout Optional timeout for confirmation.
+         * @return outcome::result of (tx_hash, minted_amount) or error.
+         */
+        outcome::result<std::pair<std::string, uint64_t>> MintChildTokens(
+            uint64_t                  amount,
+            const std::string        &transaction_hash,
+            const std::string        &chain_id,
+            const std::string        &token_id,
+            std::chrono::milliseconds timeout = std::chrono::milliseconds{ 20000 } );
+        /**
+         * @brief Transfer child (fractional) tokens to another address.
+         * @param amount Amount of child tokens to transfer (in minions).
+         * @param destination Address to receive the tokens.
+         * @param timeout Maximum time to wait for transaction confirmation.
+         * @return outcome::result of a pair(tx_hash, duration_ms), or an error code.
+         */
+        outcome::result<std::pair<std::string, uint64_t>> TransferChildTokens(
+            uint64_t                  amount,
+            const std::string        &destination,
+            std::chrono::milliseconds timeout = std::chrono::milliseconds{ 20000 } );
+        /**
+         * Query balance in child (fractional) tokens.
+         * @return outcome::result of the current child-token balance or error.
+         */
+        outcome::result<uint64_t> GetChildBalance() const;
+
+        /**
+         * @brief Format a child-token amount into a human-readable string.
+         * @param amount Amount of child tokens (in minions).
+         * @return Formatted string, e.g. "1.234 GChild".
+         */
+        std::string FormatChildTokens( uint64_t amount ) const;
+
+        /**
+         * @brief Parse a formatted child-token string back into minions.
+         * @param amount_str Formatted string, e.g. "1.234 GChild".
+         * @return outcome::result<uint64_t> of the parsed minions, or error.
+         */
+        outcome::result<uint64_t> ParseChildTokens( const std::string &amount_str ) const;
 
     protected:
         friend class TransactionSyncTest;

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -27,7 +27,7 @@ typedef struct DevConfig
     char        Addr[255];
     std::string Cut;
     std::string TokenValueInGNUS;
-    int         TokenID;
+    std::string TokenID;
     char        BaseWritePath[1024];
 } DevConfig_st;
 
@@ -123,6 +123,11 @@ namespace sgns
         std::string GetAddress() const
         {
             return account_->GetAddress();
+        }
+
+        std::string GetTokenID() const
+        {
+            return dev_config_.TokenID;
         }
 
         outcome::result<std::pair<std::string, uint64_t>> TransferFunds(

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -109,6 +109,8 @@ namespace sgns
         void     AddPeer( const std::string &peer );
         void     RefreshUPNP( int pubsubport );
         uint64_t GetBalance();
+        uint64_t GetBalance( const std::string &token_id );
+        uint64_t GetBalance( const std::vector<std::string> &token_ids );
 
         [[nodiscard]] const std::vector<std::vector<uint8_t>> GetInTransactions() const
         {
@@ -257,7 +259,6 @@ namespace sgns
         static constexpr std::string_view PROCESSING_GRID_CHANNEL = "SGNUS.Jobs.2a.%02d";
         static constexpr std::string_view PROCESSING_CHANNEL      = "SGNUS.TestNet.Channel.2a.%02d";
         static constexpr std::string_view GNUS_NETWORK_PATH       = "SuperGNUSNode.TestNet.2a.%02d.%s";
-
 
         static std::string GetLoggingSystem( const std::string &base_path )
         {

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -175,23 +175,6 @@ namespace sgns
         bool WaitForEscrowRelease( const std::string &originalEscrowId, std::chrono::milliseconds timeout );
 
         /**
-         * @brief Transfer child (fractional) tokens to another address.
-         * @param amount Amount of child tokens to transfer (in minions).
-         * @param destination Address to receive the tokens.
-         * @param timeout Maximum time to wait for transaction confirmation.
-         * @return outcome::result of a pair(tx_hash, duration_ms), or an error code.
-         */
-        outcome::result<std::pair<std::string, uint64_t>> TransferChildTokens(
-            uint64_t                  amount,
-            const std::string        &destination,
-            std::chrono::milliseconds timeout = std::chrono::milliseconds{ 20000 } );
-        /**
-         * Query balance in child (fractional) tokens.
-         * @return outcome::result of the current child-token balance or error.
-         */
-        outcome::result<uint64_t> GetChildBalance() const;
-
-        /**
          * @brief Format a child-token amount into a human-readable string.
          * @param amount Amount of child tokens (in minions).
          * @return Formatted string, e.g. "1.234 GChild".

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -26,7 +26,7 @@ typedef struct DevConfig
 {
     char        Addr[255];
     std::string Cut;
-    double      TokenValueInGNUS;
+    std::string TokenValueInGNUS;
     int         TokenID;
     char        BaseWritePath[1024];
 } DevConfig_st;

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -147,17 +147,25 @@ namespace sgns
 
         /**
          * @brief       Formats a fixed-point amount into a human-readable string.
-         * @param[in]   amount Amount in Minion Tokens (1e-6 GNUS).
-         * @return      Formatted string representation in GNUS.
+         * @param[in]   amount  Amount in Minion Tokens (1e-6 GNUS).
+         * @param[in]   tokenId Optional token identifier:
+         *                         – empty: default (minion to GNUS) formatting  
+         *                         – matches DevConfig.TokenID: child-token formatting  
+         *                         – otherwise: returns Error::TOKEN_ID_MISMATCH  
+         * @return      Outcome result with the formatted string in GNUS or an error.
          */
-        static std::string FormatTokens( uint64_t amount );
+        outcome::result<std::string> FormatTokens( uint64_t amount, const std::string &tokenId = {} );
 
         /**
          * @brief       Parses a human-readable string into a fixed-point amount.
-         * @param[in]   str String representation of an amount in GNUS.
-         * @return      Outcome result with the parsed amount in Minion Tokens (1e-6 GNUS) or error.
+         * @param[in]   str      String representation of an amount in GNUS.
+         * @param[in]   tokenId  Optional token identifier:
+         *                          – empty: default (GNUS to minion) parsing  
+         *                          – matches DevConfig.TokenID: child-token parsing  
+         *                          – otherwise: returns Error::TOKEN_ID_MISMATCH  
+         * @return      Outcome result with the parsed amount in Minion Tokens (1e-6 GNUS) or an error.
          */
-        static outcome::result<uint64_t> ParseTokens( const std::string &str );
+        outcome::result<uint64_t> ParseTokens( const std::string &str, const std::string &tokenId = {} );
 
         static std::vector<uint8_t> GetImageByCID( const std::string &cid );
 
@@ -179,20 +187,6 @@ namespace sgns
         bool WaitForTransactionOutgoing( const std::string &txId, std::chrono::milliseconds timeout );
 
         bool WaitForEscrowRelease( const std::string &originalEscrowId, std::chrono::milliseconds timeout );
-
-        /**
-         * @brief Format a child-token amount into a human-readable string.
-         * @param amount Amount of child tokens (in minions).
-         * @return Formatted string, e.g. "1.234 GChild".
-         */
-        std::string FormatChildTokens( uint64_t amount ) const;
-
-        /**
-         * @brief Parse a formatted child-token string back into minions.
-         * @param amount_str Formatted string, e.g. "1.234 GChild".
-         * @return outcome::result<uint64_t> of the parsed minions, or error.
-         */
-        outcome::result<uint64_t> ParseChildTokens( const std::string &amount_str ) const;
 
     protected:
         friend class TransactionSyncTest;

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -110,7 +110,6 @@ namespace sgns
         void     RefreshUPNP( int pubsubport );
         uint64_t GetBalance();
         uint64_t GetBalance( const std::string &token_id );
-        uint64_t GetBalance( const std::vector<std::string> &token_ids );
 
         [[nodiscard]] const std::vector<std::vector<uint8_t>> GetInTransactions() const
         {

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -175,21 +175,6 @@ namespace sgns
         bool WaitForEscrowRelease( const std::string &originalEscrowId, std::chrono::milliseconds timeout );
 
         /**
-         * Mint in a child (fractional) token.
-         * @param amount Amount of child tokens to mint.
-         * @param transaction_hash Transaction identifier.
-         * @param chain_id Blockchain chain identifier.
-         * @param token_id Child token identifier.
-         * @param timeout Optional timeout for confirmation.
-         * @return outcome::result of (tx_hash, minted_amount) or error.
-         */
-        outcome::result<std::pair<std::string, uint64_t>> MintChildTokens(
-            uint64_t                  amount,
-            const std::string        &transaction_hash,
-            const std::string        &chain_id,
-            const std::string        &token_id,
-            std::chrono::milliseconds timeout = std::chrono::milliseconds{ 20000 } );
-        /**
          * @brief Transfer child (fractional) tokens to another address.
          * @param amount Amount of child tokens to transfer (in minions).
          * @param destination Address to receive the tokens.

--- a/src/account/GeniusUTXO.hpp
+++ b/src/account/GeniusUTXO.hpp
@@ -14,11 +14,12 @@ namespace sgns
     class GeniusUTXO
     {
     public:
-        GeniusUTXO( const base::Hash256 &hash, uint32_t previous_index, uint64_t amount ) :
+        GeniusUTXO( const base::Hash256 &hash, uint32_t previous_index, uint64_t amount, std::string token_id ) :
             txid_hash_( hash ),            //
             output_idx_( previous_index ), //
             amount_( amount ),             //
-            locked_( false )               //
+            locked_( false ),              //
+            tokein_id_( token_id )         //
         {
         }
 
@@ -47,11 +48,17 @@ namespace sgns
             return locked_;
         }
 
+        std::string GetTokenID() const
+        {
+            return tokein_id_;
+        }
+
     private:
         base::Hash256 txid_hash_;
         uint32_t      output_idx_;
         uint64_t      amount_;
         bool          locked_;
+        std::string   tokein_id_;
     };
 }
 

--- a/src/account/MintTransaction.cpp
+++ b/src/account/MintTransaction.cpp
@@ -58,6 +58,11 @@ namespace sgns
         return amount;
     }
 
+    std::string MintTransaction::GetTokenID() const
+    {
+        return token_id;
+    }
+
     MintTransaction MintTransaction::New( uint64_t                                        new_amount,
                                           std::string                                     chain_id,
                                           std::string                                     token_id,

--- a/src/account/MintTransaction.hpp
+++ b/src/account/MintTransaction.hpp
@@ -31,6 +31,8 @@ namespace sgns
 
         uint64_t GetAmount() const;
 
+        std::string GetTokenID() const;
+
         std::string GetTransactionSpecificPath() override
         {
             return GetType();

--- a/src/account/TokenAmount.cpp
+++ b/src/account/TokenAmount.cpp
@@ -109,7 +109,7 @@ namespace sgns
         return outcome::success( raw_minions );
     }
 
-    outcome::result<uint64_t> TokenAmount::ConvertToChildToken( uint64_t in, std::string ratio )
+    outcome::result<std::string> TokenAmount::ConvertToChildToken( uint64_t in, std::string ratio )
     {
         OUTCOME_TRY( auto ratio_fp, ScaledInteger::New( ratio, PRECISION ) );
 
@@ -117,10 +117,10 @@ namespace sgns
 
         OUTCOME_TRY( auto child_fp, minion_fp->Divide( *ratio_fp ) );
 
-        return outcome::success( child_fp.Value() );
+        return outcome::success( child_fp.ToString() );
     }
 
-    outcome::result<uint64_t> TokenAmount::ConvertFromChildToken( uint64_t in, std::string ratio )
+    outcome::result<uint64_t> TokenAmount::ConvertFromChildToken( std::string in, std::string ratio )
     {
         OUTCOME_TRY( auto ratio_fp, ScaledInteger::New( ratio, PRECISION ) );
 

--- a/src/account/TokenAmount.cpp
+++ b/src/account/TokenAmount.cpp
@@ -124,7 +124,7 @@ namespace sgns
     {
         OUTCOME_TRY( auto ratio_fp, ScaledInteger::New( ratio, PRECISION ) );
 
-        OUTCOME_TRY( auto child_fp, ScaledInteger::New( in, PRECISION ) );
+        OUTCOME_TRY( auto child_fp, ScaledInteger::New( in, PRECISION, ScaledInteger::ParseMode::Truncate ) );
 
         OUTCOME_TRY( auto minion_fp, child_fp->Multiply( *ratio_fp ) );
 

--- a/src/account/TokenAmount.cpp
+++ b/src/account/TokenAmount.cpp
@@ -109,4 +109,26 @@ namespace sgns
         return outcome::success( raw_minions );
     }
 
+    outcome::result<uint64_t> TokenAmount::ConvertToChildToken( uint64_t in, std::string ratio )
+    {
+        OUTCOME_TRY( auto ratio_fp, ScaledInteger::New( ratio, PRECISION ) );
+
+        OUTCOME_TRY( auto minion_fp, ScaledInteger::New( in, PRECISION ) );
+
+        OUTCOME_TRY( auto child_fp, minion_fp->Divide( *ratio_fp ) );
+
+        return outcome::success( child_fp.Value() );
+    }
+
+    outcome::result<uint64_t> TokenAmount::ConvertFromChildToken( uint64_t in, std::string ratio )
+    {
+        OUTCOME_TRY( auto ratio_fp, ScaledInteger::New( ratio, PRECISION ) );
+
+        OUTCOME_TRY( auto child_fp, ScaledInteger::New( in, PRECISION ) );
+
+        OUTCOME_TRY( auto minion_fp, child_fp->Multiply( *ratio_fp ) );
+
+        return outcome::success( minion_fp.Value() );
+    }
+
 } // namespace sgns

--- a/src/account/TokenAmount.cpp
+++ b/src/account/TokenAmount.cpp
@@ -18,23 +18,15 @@ namespace sgns
 
     outcome::result<std::shared_ptr<TokenAmount>> TokenAmount::New( double value )
     {
-        auto res = ScaledInteger::FromDouble( value, PRECISION );
-        if ( !res )
-        {
-            return outcome::failure( res.error() );
-        }
-        auto ptr = std::shared_ptr<TokenAmount>( new TokenAmount( res.value() ) );
+        OUTCOME_TRY( auto &&from_dbl_value, ScaledInteger::FromDouble( value, PRECISION ) );
+        auto ptr = std::shared_ptr<TokenAmount>( new TokenAmount( from_dbl_value ) );
         return outcome::success( ptr );
     }
 
     outcome::result<std::shared_ptr<TokenAmount>> TokenAmount::New( const std::string &str )
     {
-        auto res = ScaledInteger::FromString( str, PRECISION );
-        if ( !res )
-        {
-            return outcome::failure( res.error() );
-        }
-        auto ptr = std::shared_ptr<TokenAmount>( new TokenAmount( res.value() ) );
+        OUTCOME_TRY( auto &&from_str_value, ScaledInteger::FromString( str, PRECISION ) );
+        auto ptr = std::shared_ptr<TokenAmount>( new TokenAmount( from_str_value ) );
         return outcome::success( ptr );
     }
 
@@ -42,22 +34,14 @@ namespace sgns
 
     outcome::result<TokenAmount> TokenAmount::Multiply( const TokenAmount &other ) const
     {
-        auto res = ScaledInteger::Multiply( minions_, other.minions_, PRECISION );
-        if ( !res )
-        {
-            return outcome::failure( res.error() );
-        }
-        return outcome::success( TokenAmount( res.value() ) );
+        OUTCOME_TRY( auto &&multiply_res, ScaledInteger::Multiply( minions_, other.minions_, PRECISION ) );
+        return outcome::success( TokenAmount( multiply_res ) );
     }
 
     outcome::result<TokenAmount> TokenAmount::Divide( const TokenAmount &other ) const
     {
-        auto res = ScaledInteger::Divide( minions_, other.minions_, PRECISION );
-        if ( !res )
-        {
-            return outcome::failure( res.error() );
-        }
-        return outcome::success( TokenAmount( res.value() ) );
+        OUTCOME_TRY( auto &&divide_res, ScaledInteger::Divide( minions_, other.minions_, PRECISION ) );
+        return outcome::success( TokenAmount( divide_res ) );
     }
 
     uint64_t TokenAmount::Value() const
@@ -79,8 +63,8 @@ namespace sgns
     {
         uint128_t product = static_cast<uint128_t>( total_bytes ) * static_cast<uint128_t>( PRICE_PER_FLOP ) *
                             static_cast<uint128_t>( FLOPS_PER_BYTE );
-        std::shared_ptr<sgns::ScaledInteger> cost_fp;
-        uint128_t                            divisor = 1;
+        std::shared_ptr<ScaledInteger> cost_fp;
+        uint128_t                      divisor = 1;
 
         for ( uint64_t prec = PRICE_PER_FLOP_FRACTIONAL_DIGITS; prec >= PRECISION; prec-- )
         {
@@ -118,13 +102,8 @@ namespace sgns
             return outcome::failure( std::errc::value_too_large );
         }
 
-        auto minions_res = cost_fp->ConvertPrecision( PRECISION );
-        if ( !minions_res )
-        {
-            return outcome::failure( minions_res.error() );
-        }
-
-        uint64_t raw_minions = minions_res.value().Value();
+        OUTCOME_TRY( auto &&minions_res, cost_fp->ConvertPrecision( PRECISION ) );
+        uint64_t raw_minions = minions_res.Value();
         raw_minions          = std::max( raw_minions, MIN_MINION_UNITS );
 
         return outcome::success( raw_minions );

--- a/src/account/TokenAmount.hpp
+++ b/src/account/TokenAmount.hpp
@@ -113,6 +113,9 @@ namespace sgns
          */
         static outcome::result<uint64_t> CalculateCostMinions( uint64_t total_bytes, double price_usd_per_genius );
 
+        static outcome::result<uint64_t> ConvertToChildToken( uint64_t in, std::string ratio );
+        static outcome::result<uint64_t> ConvertFromChildToken( uint64_t in, std::string ratio );
+
     private:
         /// Internal representation in minion units (GNUS * 10^6)
         uint64_t minions_;
@@ -123,7 +126,6 @@ namespace sgns
          * @param minion_units Scaled token value.
          */
         TokenAmount( uint64_t minion_units );
-
     };
 
 } // namespace sgns

--- a/src/account/TokenAmount.hpp
+++ b/src/account/TokenAmount.hpp
@@ -113,8 +113,8 @@ namespace sgns
          */
         static outcome::result<uint64_t> CalculateCostMinions( uint64_t total_bytes, double price_usd_per_genius );
 
-        static outcome::result<uint64_t> ConvertToChildToken( uint64_t in, std::string ratio );
-        static outcome::result<uint64_t> ConvertFromChildToken( uint64_t in, std::string ratio );
+        static outcome::result<std::string> ConvertToChildToken( uint64_t in, std::string ratio );
+        static outcome::result<uint64_t>    ConvertFromChildToken( std::string in, std::string ratio );
 
     private:
         /// Internal representation in minion units (GNUS * 10^6)

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -339,9 +339,9 @@ namespace sgns
         for ( auto &subtask : taskresult.subtask_results() )
         {
             std::cout << "Subtask Result " << subtask.subtaskid() << "from " << subtask.node_address() << std::endl;
-            m_logger->debug( "Paying out {} ", peers_amount );
+            m_logger->debug( "Paying out {} in {}", peers_amount, subtask.token_id() );
             subtask_ids.push_back( subtask.subtaskid() );
-            payout_peers.push_back( { peers_amount, subtask.node_address(), escrowTokenId } );
+            payout_peers.push_back( { peers_amount, subtask.node_address(), subtask.token_id() } );
             remainder -= peers_amount;
         }
         //TODO: see what do with token_id here

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -781,7 +781,7 @@ namespace sgns
             if ( dest_infos[i].dest_address == account_m->GetAddress() )
             {
                 auto       hash = ( base::Hash256::fromReadableString( transfer_tx->dag_st.data_hash() ) ).value();
-                GeniusUTXO new_utxo( hash, i, dest_infos[i].encrypted_amount );
+                GeniusUTXO new_utxo( hash, i, dest_infos[i].encrypted_amount, dest_infos[i].token_id );
                 account_m->PutUTXO( new_utxo );
             }
             if ( notify_destinations )
@@ -810,7 +810,7 @@ namespace sgns
         if ( mint_tx->GetSrcAddress() == account_m->GetAddress() )
         {
             auto       hash = ( base::Hash256::fromReadableString( mint_tx->dag_st.data_hash() ) ).value();
-            GeniusUTXO new_utxo( hash, 0, mint_tx->GetAmount() );
+            GeniusUTXO new_utxo( hash, 0, mint_tx->GetAmount(), mint_tx->GetTokenID() );
             account_m->PutUTXO( new_utxo );
             m_logger->info( "Created tokens, balance " + account_m->GetBalance<std::string>() );
         }
@@ -837,7 +837,10 @@ namespace sgns
                 {
                     if ( dest_infos.outputs_[1].dest_address == account_m->GetAddress() )
                     {
-                        GeniusUTXO new_utxo( hash, 1, dest_infos.outputs_[1].encrypted_amount );
+                        GeniusUTXO new_utxo( hash,
+                                             1,
+                                             dest_infos.outputs_[1].encrypted_amount,
+                                             dest_infos.outputs_[1].token_id );
                         account_m->PutUTXO( new_utxo );
                     }
                 }

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -266,8 +266,7 @@ namespace sgns
     outcome::result<std::pair<std::string, EscrowDataPair>> TransactionManager::HoldEscrow( uint64_t           amount,
                                                                                             const std::string &dev_addr,
                                                                                             uint64_t peers_cut,
-                                                                                            const std::string &job_id,
-                                                                                            std::string token_id )
+                                                                                            const std::string &job_id )
     {
         auto hash_data = hasher_m->blake2b_256( std::vector<uint8_t>{ job_id.begin(), job_id.end() } );
 
@@ -275,7 +274,6 @@ namespace sgns
                      UTXOTxParameters::create( account_m->utxos,
                                                account_m->GetAddress(),
                                                amount,
-                                               token_id,
                                                "0x" + hash_data.toReadableString() ) );
 
         account_m->utxos        = UTXOTxParameters::UpdateUTXOList( account_m->utxos, params );

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -205,9 +205,15 @@ namespace sgns
         return *account_m;
     }
 
-    outcome::result<std::string> TransactionManager::TransferFunds( uint64_t amount, const std::string &destination )
+    outcome::result<std::string> TransactionManager::TransferFunds( uint64_t           amount,
+                                                                    const std::string &destination,
+                                                                    std::string        token_id )
     {
-        auto maybe_params = UTXOTxParameters::create( account_m->utxos, account_m->GetAddress(), amount, destination );
+        auto maybe_params = UTXOTxParameters::create( account_m->utxos,
+                                                      account_m->GetAddress(),
+                                                      amount,
+                                                      destination,
+                                                      account_m->GetToken() );
 
         if ( !maybe_params )
         {
@@ -262,7 +268,8 @@ namespace sgns
     outcome::result<std::pair<std::string, EscrowDataPair>> TransactionManager::HoldEscrow( uint64_t           amount,
                                                                                             const std::string &dev_addr,
                                                                                             uint64_t peers_cut,
-                                                                                            const std::string &job_id )
+                                                                                            const std::string &job_id,
+                                                                                            std::string token_id )
     {
         auto hash_data = hasher_m->blake2b_256( std::vector<uint8_t>{ job_id.begin(), job_id.end() } );
 
@@ -270,6 +277,7 @@ namespace sgns
                      UTXOTxParameters::create( account_m->utxos,
                                                account_m->GetAddress(),
                                                amount,
+                                               account_m->GetToken(),
                                                "0x" + hash_data.toReadableString() ) );
 
         account_m->utxos        = UTXOTxParameters::UpdateUTXOList( account_m->utxos, params );

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -343,6 +343,7 @@ namespace sgns
             payout_peers.push_back( { peers_amount, subtask.node_address() } );
             remainder -= peers_amount;
         }
+        //TODO: see what do with token_id here
         m_logger->debug( "Sending to dev {}", remainder );
         payout_peers.push_back( { remainder, escrow_tx->GetDevAddress() } );
         InputUTXOInfo escrow_utxo_input;

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -1,6 +1,6 @@
 /**
  * @file       TransactionManager.hpp
- * @brief      
+ * @brief
  * @date       2024-03-13
  * @author     Henrique A. Klein (hklein@gnus.ai)
  */
@@ -70,8 +70,7 @@ namespace sgns
         outcome::result<std::pair<std::string, EscrowDataPair>> HoldEscrow( uint64_t           amount,
                                                                             const std::string &dev_addr,
                                                                             uint64_t           peers_cut,
-                                                                            const std::string &job_id,
-                                                                            std::string        token_id = "" );
+                                                                            const std::string &job_id );
         outcome::result<std::string>                            PayEscrow( const std::string                       &escrow_path,
                                                                            const SGProcessing::TaskResult          &taskresult,
                                                                            std::shared_ptr<crdt::AtomicTransaction> crdt_transaction );

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -62,15 +62,18 @@ namespace sgns
         std::vector<std::vector<uint8_t>> GetOutTransactions() const;
         std::vector<std::vector<uint8_t>> GetInTransactions() const;
 
-        outcome::result<std::string> TransferFunds( uint64_t amount, const std::string &destination );
-        outcome::result<std::string> MintFunds( uint64_t    amount,
-                                                std::string transaction_hash,
-                                                std::string chainid,
-                                                std::string tokenid );
+        outcome::result<std::string>                            TransferFunds( uint64_t           amount,
+                                                                               const std::string &destination,
+                                                                               std::string        token_id = "" );
+        outcome::result<std::string>                            MintFunds( uint64_t    amount,
+                                                                           std::string transaction_hash,
+                                                                           std::string chainid,
+                                                                           std::string tokenid );
         outcome::result<std::pair<std::string, EscrowDataPair>> HoldEscrow( uint64_t           amount,
                                                                             const std::string &dev_addr,
                                                                             uint64_t           peers_cut,
-                                                                            const std::string &job_id );
+                                                                            const std::string &job_id,
+                                                                            std::string        token_id = "" );
         outcome::result<std::string>                            PayEscrow( const std::string                       &escrow_path,
                                                                            const SGProcessing::TaskResult          &taskresult,
                                                                            std::shared_ptr<crdt::AtomicTransaction> crdt_transaction );

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -62,13 +62,11 @@ namespace sgns
         std::vector<std::vector<uint8_t>> GetOutTransactions() const;
         std::vector<std::vector<uint8_t>> GetInTransactions() const;
 
-        outcome::result<std::string>                            TransferFunds( uint64_t           amount,
-                                                                               const std::string &destination,
-                                                                               std::string        token_id = "" );
-        outcome::result<std::string>                            MintFunds( uint64_t    amount,
-                                                                           std::string transaction_hash,
-                                                                           std::string chainid,
-                                                                           std::string tokenid );
+        outcome::result<std::string> TransferFunds( uint64_t amount, const std::string &destination );
+        outcome::result<std::string> MintFunds( uint64_t    amount,
+                                                std::string transaction_hash,
+                                                std::string chainid,
+                                                std::string tokenid );
         outcome::result<std::pair<std::string, EscrowDataPair>> HoldEscrow( uint64_t           amount,
                                                                             const std::string &dev_addr,
                                                                             uint64_t           peers_cut,
@@ -85,9 +83,9 @@ namespace sgns
         bool WaitForTransactionOutgoing( const std::string &txId, std::chrono::milliseconds timeout ) const;
         bool WaitForEscrowRelease( const std::string &originalEscrowId, std::chrono::milliseconds timeout ) const;
 
-        static std::string       GetTransactionPath( IGeniusTransactions &element );
+        static std::string GetTransactionPath( IGeniusTransactions &element );
 
-        static std::string       GetTransactionProofPath( IGeniusTransactions &element );
+        static std::string GetTransactionProofPath( IGeniusTransactions &element );
         static outcome::result<std::shared_ptr<IGeniusTransactions>> FetchTransaction(
             const std::shared_ptr<crdt::GlobalDB> &db,
             std::string_view                       transaction_key );
@@ -109,13 +107,12 @@ namespace sgns
         SGTransaction::DAGStruct FillDAGStruct( std::string transaction_hash = "" ) const;
         outcome::result<void>    SendTransaction();
 
-        static std::string       GetTransactionBasePath( const std::string &address );
-        static std::string       GetBlockChainBase();
+        static std::string GetTransactionBasePath( const std::string &address );
+        static std::string GetBlockChainBase();
         static outcome::result<std::shared_ptr<IGeniusTransactions>> DeSerializeTransaction( std::string tx_data );
         static outcome::result<std::string>                          GetExpectedProofKey( const std::string                          &tx_key,
                                                                                           const std::shared_ptr<IGeniusTransactions> &tx );
         static outcome::result<std::string>                          GetExpectedTxKey( const std::string &proof_key );
-
 
         outcome::result<bool> CheckProof( const std::shared_ptr<IGeniusTransactions> &tx );
         outcome::result<void> ParseTransaction( const std::shared_ptr<IGeniusTransactions> &tx );

--- a/src/account/TransferTransaction.cpp
+++ b/src/account/TransferTransaction.cpp
@@ -13,12 +13,10 @@ namespace sgns
 {
     TransferTransaction::TransferTransaction( std::vector<OutputDestInfo> destinations,
                                               std::vector<InputUTXOInfo>  inputs,
-                                              SGTransaction::DAGStruct    dag,
-                                              std::string                 token_id  ) :
+                                              SGTransaction::DAGStruct    dag ) :
         IGeniusTransactions( "transfer", SetDAGWithType( std::move( dag ), "transfer" ) ), //
         input_tx_( std::move( inputs ) ),                                                  //
-        outputs_( std::move( destinations ) ),                                             //
-        token_id_( std::move( token_id ) )
+        outputs_( std::move( destinations ) )                                              //
     {
     }
 
@@ -27,9 +25,8 @@ namespace sgns
                                                   SGTransaction::DAGStruct                        dag,
                                                   std::shared_ptr<ethereum::EthereumKeyGenerator> eth_key )
     {
-        std::string token_id = "GNUS";
-        TransferTransaction instance( std::move( destinations ), std::move( inputs ), std::move( dag ), token_id  );
-        
+        TransferTransaction instance( std::move( destinations ), std::move( inputs ), std::move( dag ) );
+
         instance.FillHash();
         instance.MakeSignature( std::move( eth_key ) );
         return instance;
@@ -39,7 +36,6 @@ namespace sgns
     {
         SGTransaction::TransferTx tx_struct;
         tx_struct.mutable_dag_struct()->CopyFrom( this->dag_st );
-        tx_struct.set_token_id( token_id_ );
         SGTransaction::UTXOTxParams *utxo_proto_params = tx_struct.mutable_utxo_params();
 
         for ( const auto &input : input_tx_ )
@@ -89,9 +85,10 @@ namespace sgns
             OutputDestInfo curr{ output_proto.encrypted_amount(), output_proto.dest_addr() };
             outputs.push_back( curr );
         }
-        std::string token_id = tx_struct.token_id(); 
+        std::string token_id = tx_struct.token_id();
 
-        return std::make_shared<TransferTransaction>( TransferTransaction( outputs, inputs, tx_struct.dag_struct(), token_id ));
+        return std::make_shared<TransferTransaction>(
+            TransferTransaction( outputs, inputs, tx_struct.dag_struct() ) );
     }
 
     std::vector<OutputDestInfo> TransferTransaction::GetDstInfos() const
@@ -104,8 +101,4 @@ namespace sgns
         return input_tx_;
     }
 
-    std::string TransferTransaction::GetTokenId() const
-    {
-        return token_id_;
-    }
 }

--- a/src/account/TransferTransaction.cpp
+++ b/src/account/TransferTransaction.cpp
@@ -85,7 +85,7 @@ namespace sgns
             OutputDestInfo curr{ output_proto.encrypted_amount(), output_proto.dest_addr() };
             outputs.push_back( curr );
         }
-        std::string token_id = tx_struct.token_id();
+        std::string token_id = std::to_string( tx_struct.token_id() );
 
         return std::make_shared<TransferTransaction>(
             TransferTransaction( outputs, inputs, tx_struct.dag_struct() ) );

--- a/src/account/TransferTransaction.cpp
+++ b/src/account/TransferTransaction.cpp
@@ -13,10 +13,12 @@ namespace sgns
 {
     TransferTransaction::TransferTransaction( std::vector<OutputDestInfo> destinations,
                                               std::vector<InputUTXOInfo>  inputs,
-                                              SGTransaction::DAGStruct    dag ) :
+                                              SGTransaction::DAGStruct    dag,
+                                              std::string                 token_id  ) :
         IGeniusTransactions( "transfer", SetDAGWithType( std::move( dag ), "transfer" ) ), //
         input_tx_( std::move( inputs ) ),                                                  //
-        outputs_( std::move( destinations ) )                                              //
+        outputs_( std::move( destinations ) ),                                             //
+        token_id_( std::move( token_id ) )
     {
     }
 
@@ -25,7 +27,9 @@ namespace sgns
                                                   SGTransaction::DAGStruct                        dag,
                                                   std::shared_ptr<ethereum::EthereumKeyGenerator> eth_key )
     {
-        TransferTransaction instance( std::move( destinations ), std::move( inputs ), std::move( dag ) );
+        std::string token_id = "GNUS";
+        TransferTransaction instance( std::move( destinations ), std::move( inputs ), std::move( dag ), token_id  );
+        
         instance.FillHash();
         instance.MakeSignature( std::move( eth_key ) );
         return instance;
@@ -35,7 +39,7 @@ namespace sgns
     {
         SGTransaction::TransferTx tx_struct;
         tx_struct.mutable_dag_struct()->CopyFrom( this->dag_st );
-        tx_struct.set_token_id( 0 );
+        tx_struct.set_token_id( token_id_ );
         SGTransaction::UTXOTxParams *utxo_proto_params = tx_struct.mutable_utxo_params();
 
         for ( const auto &input : input_tx_ )
@@ -85,8 +89,9 @@ namespace sgns
             OutputDestInfo curr{ output_proto.encrypted_amount(), output_proto.dest_addr() };
             outputs.push_back( curr );
         }
+        std::string token_id = tx_struct.token_id(); 
 
-        return std::make_shared<TransferTransaction>( TransferTransaction( outputs, inputs, tx_struct.dag_struct() ) );
+        return std::make_shared<TransferTransaction>( TransferTransaction( outputs, inputs, tx_struct.dag_struct(), token_id ));
     }
 
     std::vector<OutputDestInfo> TransferTransaction::GetDstInfos() const
@@ -99,4 +104,8 @@ namespace sgns
         return input_tx_;
     }
 
+    std::string TransferTransaction::GetTokenId() const
+    {
+        return token_id_;
+    }
 }

--- a/src/account/TransferTransaction.cpp
+++ b/src/account/TransferTransaction.cpp
@@ -50,6 +50,7 @@ namespace sgns
             SGTransaction::TransferOutput *output_proto = utxo_proto_params->add_outputs();
             output_proto->set_encrypted_amount( output.encrypted_amount );
             output_proto->set_dest_addr( output.dest_address );
+            output_proto->set_token_id( output.token_id );
         }
         size_t               size = tx_struct.ByteSizeLong();
         std::vector<uint8_t> serialized_proto( size );
@@ -82,13 +83,12 @@ namespace sgns
         {
             const SGTransaction::TransferOutput &output_proto = utxo_proto_params->outputs( i );
 
-            OutputDestInfo curr{ output_proto.encrypted_amount(), output_proto.dest_addr() };
+            OutputDestInfo curr{ output_proto.encrypted_amount(), output_proto.dest_addr(), output_proto.token_id() };
             outputs.push_back( curr );
         }
-        std::string token_id = std::to_string( tx_struct.token_id() );
+        std::string token_id = tx_struct.token_id();
 
-        return std::make_shared<TransferTransaction>(
-            TransferTransaction( outputs, inputs, tx_struct.dag_struct() ) );
+        return std::make_shared<TransferTransaction>( TransferTransaction( outputs, inputs, tx_struct.dag_struct() ) );
     }
 
     std::vector<OutputDestInfo> TransferTransaction::GetDstInfos() const

--- a/src/account/TransferTransaction.cpp
+++ b/src/account/TransferTransaction.cpp
@@ -86,7 +86,6 @@ namespace sgns
             OutputDestInfo curr{ output_proto.encrypted_amount(), output_proto.dest_addr(), output_proto.token_id() };
             outputs.push_back( curr );
         }
-        std::string token_id = tx_struct.token_id();
 
         return std::make_shared<TransferTransaction>( TransferTransaction( outputs, inputs, tx_struct.dag_struct() ) );
     }

--- a/src/account/TransferTransaction.hpp
+++ b/src/account/TransferTransaction.hpp
@@ -17,9 +17,9 @@ namespace sgns
     class TransferTransaction : public IGeniusTransactions
     {
     public:
-        static TransferTransaction New( std::vector<OutputDestInfo> destinations,
-                                        std::vector<InputUTXOInfo>  inputs,
-                                        SGTransaction::DAGStruct    dag,
+        static TransferTransaction New( std::vector<OutputDestInfo>                     destinations,
+                                        std::vector<InputUTXOInfo>                      inputs,
+                                        SGTransaction::DAGStruct                        dag,
                                         std::shared_ptr<ethereum::EthereumKeyGenerator> eth_key );
         /**
          * @brief      Default Transfer Transaction destructor
@@ -41,7 +41,6 @@ namespace sgns
 
         std::vector<OutputDestInfo> GetDstInfos() const;
         std::vector<InputUTXOInfo>  GetInputInfos() const;
-        std::string GetTokenId() const;
 
         std::string GetTransactionSpecificPath() override
         {
@@ -57,12 +56,10 @@ namespace sgns
          */
         TransferTransaction( std::vector<OutputDestInfo> destinations,
                              std::vector<InputUTXOInfo>  inputs,
-                             SGTransaction::DAGStruct    dag,
-                             std::string                 token_id );
+                             SGTransaction::DAGStruct    dag );
 
         std::vector<InputUTXOInfo>  input_tx_;
         std::vector<OutputDestInfo> outputs_;
-        std::string token_id_;
 
         /**
          * @brief       Registers the deserializer for the transfer transaction type.

--- a/src/account/TransferTransaction.hpp
+++ b/src/account/TransferTransaction.hpp
@@ -41,6 +41,7 @@ namespace sgns
 
         std::vector<OutputDestInfo> GetDstInfos() const;
         std::vector<InputUTXOInfo>  GetInputInfos() const;
+        std::string GetTokenId() const;
 
         std::string GetTransactionSpecificPath() override
         {
@@ -56,10 +57,12 @@ namespace sgns
          */
         TransferTransaction( std::vector<OutputDestInfo> destinations,
                              std::vector<InputUTXOInfo>  inputs,
-                             SGTransaction::DAGStruct    dag );
+                             SGTransaction::DAGStruct    dag,
+                             std::string                 token_id );
 
         std::vector<InputUTXOInfo>  input_tx_;
         std::vector<OutputDestInfo> outputs_;
+        std::string token_id_;
 
         /**
          * @brief       Registers the deserializer for the transfer transaction type.

--- a/src/account/UTXOTxParameters.cpp
+++ b/src/account/UTXOTxParameters.cpp
@@ -73,33 +73,49 @@ sgns::UTXOTxParameters::UTXOTxParameters( const std::vector<GeniusUTXO> &utxo_po
     }
 
     // Abort if insufficient funds
-    if ( ( selected_amount < amount ) || ( selected_utxos.size() == 0 ) )
+    if ( ( selected_amount < amount ) || ( selected_utxos.empty() ) )
     {
         inputs_.clear();
         outputs_.clear();
         return;
     }
 
-    outputs_.reserve( selected_utxos.size() + 1 );
-    uint64_t used_amount = 0;
-
-    // Replicate each UTXO except the last one: send full amount to dest
-    for ( size_t i = 0; i < selected_utxos.size() - 1; i++ )
+    // Aggregate destination amounts by TokenID
+    std::unordered_map<std::string, uint64_t> send_totals;
+    uint64_t                                  used_amount = 0;
+    for ( const auto &utxo : selected_utxos )
     {
-        const auto &utxo     = selected_utxos[i];
+        const auto &token    = utxo.GetTokenID();
         uint64_t    utxo_amt = utxo.GetAmount();
-        outputs_.push_back( { utxo_amt, dest_address, utxo.GetTokenID() } );
-        used_amount += utxo_amt;
+
+        if ( used_amount + utxo_amt <= amount )
+        {
+            send_totals[token] += utxo_amt;
+            used_amount        += utxo_amt;
+        }
+        else
+        {
+            uint64_t needed     = amount - used_amount;
+            send_totals[token] += needed;
+            used_amount        += needed;
+            break;
+        }
     }
 
-    // Handle the last UTXO: send only what's needed, then change
-    uint64_t    needed    = amount - used_amount;
-    const auto &last_utxo = selected_utxos.back();
+    // Reserve space: one output per token plus possible change
+    outputs_.reserve( send_totals.size() + 1 );
 
-    outputs_.push_back( { needed, dest_address, last_utxo.GetTokenID() } );
-    uint64_t change = last_utxo.GetAmount() - needed;
+    // Create one output per TokenID for the destination
+    for ( const auto &entry : send_totals )
+    {
+        outputs_.push_back( { entry.second, dest_address, entry.first } );
+    }
+
+    // Single change output (always from the last UTXO's token)
+    uint64_t change = selected_amount - amount;
     if ( change > 0 )
     {
+        const auto &last_utxo = selected_utxos.back();
         outputs_.push_back( { change, src_address, last_utxo.GetTokenID() } );
     }
 }

--- a/src/account/UTXOTxParameters.cpp
+++ b/src/account/UTXOTxParameters.cpp
@@ -47,3 +47,59 @@ sgns::UTXOTxParameters::UTXOTxParameters( const std::vector<GeniusUTXO>     &utx
         outputs_.push_back( { change, src_address, change_token } );
     }
 }
+
+sgns::UTXOTxParameters::UTXOTxParameters( const std::vector<GeniusUTXO> &utxo_pool,
+                                          const std::string             &src_address,
+                                          uint64_t                       amount,
+                                          const std::string              dest_address,
+                                          std::string                    signature )
+{
+    // Select UTXOs until we cover the requested amount
+    std::vector<GeniusUTXO> selected_utxos;
+    uint64_t                selected_amount = 0;
+    for ( const auto &utxo : utxo_pool )
+    {
+        if ( selected_amount >= amount )
+        {
+            break;
+        }
+        if ( utxo.GetLock() )
+        {
+            continue;
+        }
+        inputs_.push_back( { utxo.GetTxID(), utxo.GetOutputIdx(), signature } );
+        selected_utxos.push_back( utxo );
+        selected_amount += utxo.GetAmount();
+    }
+
+    // Abort if insufficient funds
+    if ( ( selected_amount < amount ) || ( selected_utxos.size() == 0 ) )
+    {
+        inputs_.clear();
+        outputs_.clear();
+        return;
+    }
+
+    outputs_.reserve( selected_utxos.size() + 1 );
+    uint64_t used_amount = 0;
+
+    // Replicate each UTXO except the last one: send full amount to dest
+    for ( size_t i = 0; i < selected_utxos.size() - 1; i++ )
+    {
+        const auto &utxo     = selected_utxos[i];
+        uint64_t    utxo_amt = utxo.GetAmount();
+        outputs_.push_back( { utxo_amt, dest_address, utxo.GetTokenID() } );
+        used_amount += utxo_amt;
+    }
+
+    // Handle the last UTXO: send only what's needed, then change
+    uint64_t    needed    = amount - used_amount;
+    const auto &last_utxo = selected_utxos.back();
+
+    outputs_.push_back( { needed, dest_address, last_utxo.GetTokenID() } );
+    uint64_t change = last_utxo.GetAmount() - needed;
+    if ( change > 0 )
+    {
+        outputs_.push_back( { change, src_address, last_utxo.GetTokenID() } );
+    }
+}

--- a/src/account/UTXOTxParameters.cpp
+++ b/src/account/UTXOTxParameters.cpp
@@ -42,6 +42,6 @@ sgns::UTXOTxParameters::UTXOTxParameters( const std::vector<GeniusUTXO>     &utx
     if ( used_amount > total_amount )
     {
         uint64_t change      = used_amount - total_amount;
-        outputs_.push_back( { change, src_address } );
+        outputs_.push_back( { change, src_address, "" } );
     }
 }

--- a/src/account/UTXOTxParameters.cpp
+++ b/src/account/UTXOTxParameters.cpp
@@ -1,15 +1,17 @@
 #include "UTXOTxParameters.hpp"
 #include <boost/multiprecision/fwd.hpp>
 #include <cmath>
+
 sgns::UTXOTxParameters::UTXOTxParameters( const std::vector<GeniusUTXO>     &utxo_pool,
                                           const std::string                 &src_address,
                                           const std::vector<OutputDestInfo> &destinations,
                                           std::string                        signature )
 {
-    uint64_t total_amount = 0;
-    for ( const auto &dest_info : destinations )
+    uint64_t    total_amount = 0;
+    std::string change_token;
+    for ( const auto &d : destinations )
     {
-        total_amount += dest_info.encrypted_amount;
+        total_amount += d.encrypted_amount;
     }
 
     uint64_t used_amount = 0;
@@ -24,9 +26,9 @@ sgns::UTXOTxParameters::UTXOTxParameters( const std::vector<GeniusUTXO>     &utx
             continue;
         }
         InputUTXOInfo curr_input{ utxo.GetTxID(), utxo.GetOutputIdx(), signature };
-
         used_amount += utxo.GetAmount();
         inputs_.push_back( curr_input );
+        change_token = utxo.GetTokenID();
     }
 
     if ( used_amount < total_amount )
@@ -41,8 +43,7 @@ sgns::UTXOTxParameters::UTXOTxParameters( const std::vector<GeniusUTXO>     &utx
 
     if ( used_amount > total_amount )
     {
-        uint64_t change      = used_amount - total_amount;
-        //TODO: see what do with token_id on change
-        outputs_.push_back( { change, src_address, "" } );
+        uint64_t change = used_amount - total_amount;
+        outputs_.push_back( { change, src_address, change_token } );
     }
 }

--- a/src/account/UTXOTxParameters.cpp
+++ b/src/account/UTXOTxParameters.cpp
@@ -42,6 +42,7 @@ sgns::UTXOTxParameters::UTXOTxParameters( const std::vector<GeniusUTXO>     &utx
     if ( used_amount > total_amount )
     {
         uint64_t change      = used_amount - total_amount;
+        //TODO: see what do with token_id on change
         outputs_.push_back( { change, src_address, "" } );
     }
 }

--- a/src/account/UTXOTxParameters.hpp
+++ b/src/account/UTXOTxParameters.hpp
@@ -1,6 +1,6 @@
 /**
  * @file       UTXOTxParameters.hpp
- * @brief      
+ * @brief
  * @date       2024-04-29
  * @author     Henrique A. Klein (hklein@gnus.ai)
  */
@@ -47,14 +47,12 @@ namespace sgns
                                                          const std::string             &src_address,
                                                          uint64_t                       amount,
                                                          std::string                    dest_address,
-                                                         std::string                    token_id,
                                                          std::string                    signature = "" )
         {
             UTXOTxParameters instance( utxo_pool,
                                        src_address,
                                        amount,
                                        std::move( dest_address ),
-                                       std::move( token_id ),
                                        std::move( signature ) );
 
             if ( !instance.inputs_.empty() )
@@ -103,14 +101,7 @@ namespace sgns
                           const std::string             &src_address,
                           uint64_t                       amount,
                           std::string                    dest_address,
-                          std::string                    token_id,
-                          std::string                    signature ) :
-            UTXOTxParameters( utxo_pool,
-                              src_address,
-                              { OutputDestInfo{ amount, std::move( dest_address ), std::move( token_id ) } },
-                              std::move( signature ) )
-        {
-        }
+                          std::string                    signature );
 
         UTXOTxParameters( const std::vector<GeniusUTXO>     &utxo_pool,
                           const std::string                 &src_address,

--- a/src/account/UTXOTxParameters.hpp
+++ b/src/account/UTXOTxParameters.hpp
@@ -30,6 +30,7 @@ namespace sgns
     {
         uint64_t    encrypted_amount; ///< El Gamal encrypted amount
         std::string dest_address;     ///< Destination node address
+        std::string token_id;         ///< Token identifier
     };
 
     struct UTXOTxParameters
@@ -46,12 +47,14 @@ namespace sgns
                                                          const std::string             &src_address,
                                                          uint64_t                       amount,
                                                          std::string                    dest_address,
+                                                         std::string                    token_id,
                                                          std::string                    signature = "" )
         {
             UTXOTxParameters instance( utxo_pool,
                                        src_address,
                                        amount,
                                        std::move( dest_address ),
+                                       std::move( token_id ),
                                        std::move( signature ) );
 
             if ( !instance.inputs_.empty() )
@@ -100,10 +103,11 @@ namespace sgns
                           const std::string             &src_address,
                           uint64_t                       amount,
                           std::string                    dest_address,
+                          std::string                    token_id,
                           std::string                    signature ) :
             UTXOTxParameters( utxo_pool,
                               src_address,
-                              { OutputDestInfo{ amount, std::move( dest_address ) } },
+                              { OutputDestInfo{ amount, std::move( dest_address ), std::move( token_id ) } },
                               std::move( signature ) )
         {
         }

--- a/src/account/proto/SGTransaction.proto
+++ b/src/account/proto/SGTransaction.proto
@@ -29,6 +29,7 @@ message TransferOutput
 {
     uint64 encrypted_amount = 1; // 
     bytes dest_addr = 2; // 
+    bytes token_id = 3; //
 }
 message UTXOTxParams
 {

--- a/src/account/proto/SGTransaction.proto
+++ b/src/account/proto/SGTransaction.proto
@@ -38,7 +38,7 @@ message UTXOTxParams
 message TransferTx
 {
     DAGStruct dag_struct = 1;// 
-    uint64 token_id = 2; // 
+    bytes token_id = 2; // 
     UTXOTxParams utxo_params = 3; //
 
 }

--- a/src/base/ScaledInteger.cpp
+++ b/src/base/ScaledInteger.cpp
@@ -31,10 +31,28 @@ namespace sgns
         return outcome::success( ptr );
     }
 
-    outcome::result<std::shared_ptr<ScaledInteger>> ScaledInteger::New( const std::string &str_value, uint64_t precision )
+    outcome::result<std::shared_ptr<ScaledInteger>> ScaledInteger::New( const std::string &str_value,
+                                                                        uint64_t           precision )
     {
         OUTCOME_TRY( auto &&from_str_value, FromString( str_value, precision ) );
         auto ptr = std::shared_ptr<ScaledInteger>( new ScaledInteger( from_str_value, precision ) );
+        return outcome::success( ptr );
+    }
+
+    outcome::result<std::shared_ptr<ScaledInteger>> ScaledInteger::New( const std::string &str_value )
+    {
+        size_t   dot_pos = str_value.find( '.' );
+        uint64_t precision_calc;
+        if ( dot_pos == std::string::npos )
+        {
+            precision_calc = 0;
+        }
+        else
+        {
+            precision_calc = str_value.size() - dot_pos - 1;
+        }
+        OUTCOME_TRY( auto &&raw_value, FromString( str_value, precision_calc ) );
+        auto ptr = std::shared_ptr<ScaledInteger>( new ScaledInteger( raw_value, precision_calc ) );
         return outcome::success( ptr );
     }
 

--- a/src/base/ScaledInteger.cpp
+++ b/src/base/ScaledInteger.cpp
@@ -219,6 +219,30 @@ namespace sgns
         return precision_;
     }
 
+    std::string ScaledInteger::ToString( bool fixedDecimals ) const
+    {
+        std::string s = ToString( value_, precision_ );
+
+        if ( !fixedDecimals )
+        {
+            auto dotPos = s.find( '.' );
+            if ( dotPos != std::string::npos )
+            {
+                auto lastNonZero = s.find_last_not_of( '0' );
+                if ( lastNonZero != std::string::npos )
+                {
+                    s.erase( lastNonZero + 1 );
+                }
+                if ( !s.empty() && s.back() == '.' )
+                {
+                    s.pop_back();
+                }
+            }
+        }
+
+        return s;
+    }
+
     outcome::result<ScaledInteger> ScaledInteger::Add( const ScaledInteger &other ) const
     {
         if ( precision_ != other.precision_ )

--- a/src/base/ScaledInteger.hpp
+++ b/src/base/ScaledInteger.hpp
@@ -2,8 +2,8 @@
  * @file        ScaledInteger.hpp
  * @author      Luiz Guilherme Rizzatto Zucchi (luizgrz@gmail.com)
  * @brief       Utilities for decimal arithmetic using scaled integers.
- * @version     1.0
- * @date        2025-01-29
+ * @version     1.1
+ * @date        2025-06-10
  * @copyright   Copyright (c) 2025
  */
 
@@ -27,6 +27,16 @@ namespace sgns
     {
     public:
         /**
+         * @enum ParseMode
+         * @brief Controls handling of extra fractional digits when parsing.
+         */
+        enum class ParseMode
+        {
+            Strict,   ///< Fail if input has more fractional digits than precision.
+            Truncate, ///< Drop any extra fractional digits.
+        };
+
+        /**
          * @brief Create a ScaledInteger from a raw integer and precision.
          * @param[in] raw_value  Integer representation scaled by 10^precision.
          * @param[in] precision  Number of decimal places (scale factor).
@@ -46,13 +56,17 @@ namespace sgns
          * @brief Create a ScaledInteger from a string and precision.
          * @param[in] str        String representation of the decimal value.
          * @param[in] precision  Number of decimal places (scale factor).
+         * @param[in] mode       Mode for handling extra fractional digits.
          * @return Outcome containing shared_ptr to ScaledInteger or error.
          */
-        static outcome::result<std::shared_ptr<ScaledInteger>> New( const std::string &str, uint64_t precision );
+        static outcome::result<std::shared_ptr<ScaledInteger>> New( const std::string &str,
+                                                                    uint64_t           precision,
+                                                                    ParseMode          mode = ParseMode::Strict );
 
         /**
          * @brief Create a ScaledInteger from a decimal string by inferring precision.
          * @param[in] str  String representation of the decimal value (e.g., "123.45").
+         *               In Strict mode, will fail if more than inferred precision.
          * @return Outcome containing shared_ptr to ScaledInteger or error.
          */
         static outcome::result<std::shared_ptr<ScaledInteger>> New( const std::string &str );
@@ -65,12 +79,15 @@ namespace sgns
         static constexpr uint64_t ScaleFactor( uint64_t precision );
 
         /**
-         * @brief Convert a string to a scaled integer representation.
+         * @brief Convert a numeric string to a raw scaled integer.
          * @param[in] str        Numeric string with integer and fractional parts.
          * @param[in] precision  Number of decimal places.
+         * @param[in] mode       Mode for handling extra fractional digits.
          * @return Outcome containing raw scaled integer or error.
          */
-        static outcome::result<uint64_t> FromString( const std::string &str, uint64_t precision );
+        static outcome::result<uint64_t> FromString( const std::string &str,
+                                                     uint64_t           precision,
+                                                     ParseMode          mode = ParseMode::Strict );
 
         /**
          * @brief Convert a scaled integer to a string representation.
@@ -130,7 +147,7 @@ namespace sgns
         /**
          * @brief  Return this value as a string.
          * @param  fixedDecimals
-         *         - true: always show all fractional digits (pad with zeros up to precision())
+         *         - true: always show all fractional digits (pad with zeros up to precision)
          *         - false: trim trailing '0's in the fractional part (and drop the '.' if no fraction remains)
          * @return formatted string
          */

--- a/src/base/ScaledInteger.hpp
+++ b/src/base/ScaledInteger.hpp
@@ -51,6 +51,13 @@ namespace sgns
         static outcome::result<std::shared_ptr<ScaledInteger>> New( const std::string &str, uint64_t precision );
 
         /**
+         * @brief Create a ScaledInteger from a decimal string by inferring precision.
+         * @param[in] str  String representation of the decimal value (e.g., "123.45").
+         * @return Outcome containing shared_ptr to ScaledInteger or error.
+         */
+        static outcome::result<std::shared_ptr<ScaledInteger>> New( const std::string &str );
+
+        /**
          * @brief Compute 10^precision as the scale factor.
          * @param[in] precision  Number of decimal places.
          * @return Scale factor (10^precision).

--- a/src/base/ScaledInteger.hpp
+++ b/src/base/ScaledInteger.hpp
@@ -128,6 +128,15 @@ namespace sgns
         uint64_t Precision() const noexcept;
 
         /**
+         * @brief  Return this value as a string.
+         * @param  fixedDecimals
+         *         - true: always show all fractional digits (pad with zeros up to precision())
+         *         - false: trim trailing '0's in the fractional part (and drop the '.' if no fraction remains)
+         * @return formatted string
+         */
+        std::string ToString( bool fixedDecimals = true ) const;
+
+        /**
          * @brief Add another ScaledInteger with matching precision.
          * @param[in] other      ScaledInteger to add.
          * @return Outcome containing sum ScaledInteger or error.

--- a/src/processing/impl/processing_core_impl.cpp
+++ b/src/processing/impl/processing_core_impl.cpp
@@ -68,6 +68,7 @@ namespace sgns::processing
                                                                   *buffers->first );
             std::string hashString( tempresult.begin(), tempresult.end() );
             result.set_result_hash( hashString );
+            result.set_token_id(m_tokenId);
             --m_processingSubTaskCount;
         }
         else
@@ -91,6 +92,7 @@ namespace sgns::processing
                                                                   *buffers->first );
             std::string hashString( tempresult.begin(), tempresult.end() );
             result.set_result_hash( hashString );
+            result.set_token_id(m_tokenId);
             --m_processingSubTaskCount;
         }
         return result;

--- a/src/processing/impl/processing_core_impl.hpp
+++ b/src/processing/impl/processing_core_impl.hpp
@@ -32,12 +32,12 @@ namespace sgns::processing
             std::shared_ptr<sgns::crdt::GlobalDB> db,
             size_t subTaskProcessingTime,
             size_t maximalProcessingSubTaskCount,
-            std::string tokenId = "")
+            std::string tokenId)
             : m_db(std::move(db))
             //, m_subTaskProcessingTime(subTaskProcessingTime)
+            , m_tokenId(std::move(tokenId))
             , m_processor(nullptr)
             , m_maximalProcessingSubTaskCount(maximalProcessingSubTaskCount)
-            , m_tokenId(std::move(tokenId))
             , m_processingSubTaskCount(0)
         {
         }

--- a/src/processing/impl/processing_core_impl.hpp
+++ b/src/processing/impl/processing_core_impl.hpp
@@ -31,11 +31,13 @@ namespace sgns::processing
         ProcessingCoreImpl(
             std::shared_ptr<sgns::crdt::GlobalDB> db,
             size_t subTaskProcessingTime,
-            size_t maximalProcessingSubTaskCount)
+            size_t maximalProcessingSubTaskCount,
+            std::string tokenId = "")
             : m_db(std::move(db))
             //, m_subTaskProcessingTime(subTaskProcessingTime)
             , m_processor(nullptr)
             , m_maximalProcessingSubTaskCount(maximalProcessingSubTaskCount)
+            , m_tokenId(std::move(tokenId))
             , m_processingSubTaskCount(0)
         {
         }
@@ -106,6 +108,7 @@ namespace sgns::processing
 
     private:
         std::shared_ptr<sgns::crdt::GlobalDB> m_db;
+        std::string                           m_tokenId;
         std::unique_ptr<ProcessingProcessor> m_processor;
         std::unordered_map<std::string, std::function<std::unique_ptr<ProcessingProcessor>()>> m_processorFactories;
         //size_t m_subTaskProcessingTime;

--- a/src/processing/proto/SGProcessing.proto
+++ b/src/processing/proto/SGProcessing.proto
@@ -94,6 +94,7 @@ message SubTaskResult
     string ipfs_results_data_id = 3; // UUID of the results data on ipfs
     string subtaskid = 4; // linked subtask id
     string node_address = 5; // The processor node ID/address
+    bytes token_id = 6;  
 }
 
 message SubTaskState

--- a/test/src/account/CMakeLists.txt
+++ b/test/src/account/CMakeLists.txt
@@ -19,3 +19,25 @@ else()
         "-Wl,--no-whole-archive"
     )
 endif()
+
+addtest(account_balance_test
+account_balance_test.cpp
+)
+
+target_include_directories(account_balance_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
+
+target_link_libraries(account_balance_test
+    sgns_account
+)
+
+if(MSVC)
+    target_link_options(account_balance_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:sgns_account>)
+elseif(APPLE)
+    target_link_options(account_balance_test PUBLIC -force_load "$<TARGET_FILE:sgns_account>")
+else()
+    target_link_options(account_balance_test PUBLIC
+        "-Wl,--whole-archive"
+        "$<TARGET_FILE:sgns_account>"
+        "-Wl,--no-whole-archive"
+    )
+endif()

--- a/test/src/account/account_balance_test.cpp
+++ b/test/src/account/account_balance_test.cpp
@@ -62,30 +62,6 @@ TEST( GeniusAccount, BalanceByTokenNonexistent )
     EXPECT_EQ( account->GetBalance( "UNKNOWN" ), 0ull );
 }
 
-TEST( GeniusAccount, BalanceByTokenSet )
-{
-    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
-    Hash256 h;
-    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
-    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
-    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
-    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 3, 40, "TOKC" ) ) );
-    std::vector<std::string> tokens = { "TOKA", "TOKC" };
-    EXPECT_EQ( account->GetBalance( tokens ), 110ull );
-}
-
-TEST( GeniusAccount, BalanceByTokenSetEmpty )
-{
-    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
-    Hash256 h;
-    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
-    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
-    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
-    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 3, 40, "TOKC" ) ) );
-    std::vector<std::string> empty;
-    EXPECT_EQ( account->GetBalance( empty ), 0ull );
-}
-
 TEST( GeniusAccount, StringTemplateBalance )
 {
     auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );

--- a/test/src/account/account_balance_test.cpp
+++ b/test/src/account/account_balance_test.cpp
@@ -1,0 +1,166 @@
+#include <gtest/gtest.h>
+
+#include "base/blob.hpp" // for sgns::base::Hash256
+#include "account/GeniusAccount.hpp"
+#include "account/GeniusUTXO.hpp"
+#include "account/UTXOTxParameters.hpp"
+
+using namespace sgns;
+using namespace sgns::base;
+
+// Test constants
+static const std::string     TOKEN_NAME = "TEST_TOKEN";
+static const std::string     DATA_DIR   = ".";
+static constexpr const char *PRIV_KEY   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+TEST( GeniusAccount, InitialUTXOCount )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    // Insert four unique UTXOs
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 3, 40, "TOKC" ) ) );
+    // Duplicate should be ignored
+    EXPECT_FALSE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_EQ( account->utxos.size(), 4u );
+}
+
+TEST( GeniusAccount, TotalBalance )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 3, 40, "TOKC" ) ) );
+    EXPECT_EQ( account->GetBalance<uint64_t>(), 140ull );
+}
+
+TEST( GeniusAccount, BalanceByToken )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 3, 40, "TOKC" ) ) );
+    EXPECT_EQ( account->GetBalance( "TOKA" ), 70ull );
+    EXPECT_EQ( account->GetBalance( "TOKB" ), 30ull );
+    EXPECT_EQ( account->GetBalance( "TOKC" ), 40ull );
+}
+
+TEST( GeniusAccount, BalanceByTokenNonexistent )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 3, 40, "TOKC" ) ) );
+    EXPECT_EQ( account->GetBalance( "UNKNOWN" ), 0ull );
+}
+
+TEST( GeniusAccount, BalanceByTokenSet )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 3, 40, "TOKC" ) ) );
+    std::vector<std::string> tokens = { "TOKA", "TOKC" };
+    EXPECT_EQ( account->GetBalance( tokens ), 110ull );
+}
+
+TEST( GeniusAccount, BalanceByTokenSetEmpty )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 3, 40, "TOKC" ) ) );
+    std::vector<std::string> empty;
+    EXPECT_EQ( account->GetBalance( empty ), 0ull );
+}
+
+TEST( GeniusAccount, StringTemplateBalance )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 50, "TOKB" ) ) );
+    std::string s = account->GetBalance<std::string>();
+    EXPECT_EQ( s, std::to_string( account->GetBalance<uint64_t>() ) );
+}
+
+TEST( GeniusAccount, RefreshNoUTXOsLeavesAll )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    size_t before = account->utxos.size();
+    account->RefreshUTXOs( {} );
+    EXPECT_EQ( account->utxos.size(), before );
+}
+
+TEST( GeniusAccount, RefreshPartialUTXOsRemovesOnlySpecified )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 2, 20, "TOKA" ) ) );
+    InputUTXOInfo info;
+    info.txid_hash_  = h;
+    info.output_idx_ = 1; // remove idx 1
+    account->RefreshUTXOs( { info } );
+    EXPECT_EQ( account->GetBalance( "TOKB" ), 0ull );
+    EXPECT_EQ( account->GetBalance( "TOKA" ), 70ull );
+}
+
+TEST( GeniusAccount, RefreshAllUTXOsRemovesAll )
+{
+    auto    account = std::make_unique<GeniusAccount>( TOKEN_NAME, DATA_DIR, PRIV_KEY );
+    Hash256 h;
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 0, 50, "TOKA" ) ) );
+    EXPECT_TRUE( account->PutUTXO( GeniusUTXO( h, 1, 30, "TOKB" ) ) );
+    std::vector<InputUTXOInfo> infos;
+    for ( const auto &utxo : account->utxos )
+    {
+        InputUTXOInfo i;
+        i.txid_hash_  = utxo.GetTxID();
+        i.output_idx_ = utxo.GetOutputIdx();
+        infos.push_back( i );
+    }
+    account->RefreshUTXOs( infos );
+    EXPECT_TRUE( account->utxos.empty() );
+    EXPECT_EQ( account->GetBalance<uint64_t>(), 0ull );
+}
+
+TEST( GeniusUTXO, PropertyAccessors )
+{
+    Hash256     h;
+    uint32_t    idx = 5;
+    uint64_t    amt = 12345;
+    std::string tok = "TOKX";
+    GeniusUTXO  utxo( h, idx, amt, tok );
+    EXPECT_EQ( utxo.GetTxID(), h );
+    EXPECT_EQ( utxo.GetOutputIdx(), idx );
+    EXPECT_EQ( utxo.GetAmount(), amt );
+    EXPECT_EQ( utxo.GetTokenID(), tok );
+    EXPECT_FALSE( utxo.GetLock() );
+}
+
+TEST( InputUTXOInfo, FieldAssignment )
+{
+    InputUTXOInfo info;
+    Hash256       h;
+    info.txid_hash_  = h;
+    info.output_idx_ = 2;
+    EXPECT_EQ( info.txid_hash_, h );
+    EXPECT_EQ( info.output_idx_, 2u );
+}

--- a/test/src/account_creation/account_creation_test.cpp
+++ b/test/src/account_creation/account_creation_test.cpp
@@ -43,8 +43,8 @@ protected:
 TEST_F(AccountCreationTest, AccountCreationAddress )
 {
 
-    sgns::GeniusAccount account(0, ".", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
-    sgns::GeniusAccount account2(0, ".", "deedbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+    sgns::GeniusAccount account("0", ".", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+    sgns::GeniusAccount account2("0", ".", "deedbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
     std::string address_main = account.GetAddress();
     std::string address_main2 = account2.GetAddress();
     EXPECT_EQ(address_main, "c865650410bdc1328cf99dc011c14cb52dc0aeb43b5f49dbf64a478fe2f6eafd2056ed0155770ba0a2832c1adb65c75df043c62e772d167437e4532d1b4e788f") << " Address is not expected" << address_main;

--- a/test/src/base/scaled_integer_test.cpp
+++ b/test/src/base/scaled_integer_test.cpp
@@ -7,79 +7,132 @@
 #include "base/ScaledInteger.hpp"
 
 // ======================== FixedPointFromStringTests ========================
-
 /**
- * @brief Struct to hold test parameters for FixedPointParamTest.
+ * @brief Struct to hold test parameters for conversion with specified precision.
  */
-struct FromStrParam_s
+struct FixedPrecisionParam_s
 {
     std::string                       input;     ///< Input string representing a fixed-point number.
     uint64_t                          precision; ///< Precision level for conversion.
-    std::variant<uint64_t, std::errc> expected;  ///< Expected output, either a valid result or an error code.
+    std::variant<uint64_t, std::errc> expected;  ///< Expected result or error code.
 };
 
 /**
- * @brief Parameterized test fixture for testing `fromString` function.
+ * @brief Parameterized test fixture for testing `FromString` with specified precision.
  */
-class FixedPointParamTest : public ::testing::TestWithParam<FromStrParam_s>
+class FixedPrecisionTest : public ::testing::TestWithParam<FixedPrecisionParam_s>
 {
 };
 
 /**
- * @test Tests the conversion of string to fixed-point representation.
+ * @test Verifies string-to-fixed-point conversion when precision is provided.
  */
-TEST_P( FixedPointParamTest, FromString )
+TEST_P( FixedPrecisionTest, FromStringWithSpecifiedPrecision )
 {
-    auto test_case = GetParam();
-    auto result    = sgns::ScaledInteger::FromString( test_case.input, test_case.precision );
+    const auto &tc     = GetParam();
+    auto        result = sgns::ScaledInteger::FromString( tc.input, tc.precision );
 
-    if ( std::holds_alternative<uint64_t>( test_case.expected ) )
+    if ( std::holds_alternative<uint64_t>( tc.expected ) )
     {
-        uint64_t expected_val = std::get<uint64_t>( test_case.expected );
+        uint64_t expected_val = std::get<uint64_t>( tc.expected );
         ASSERT_TRUE( result.has_value() );
         EXPECT_EQ( result.value(), expected_val );
     }
     else
     {
-        std::errc expected_err = std::get<std::errc>( test_case.expected );
+        std::errc expected_err = std::get<std::errc>( tc.expected );
         ASSERT_FALSE( result.has_value() );
         EXPECT_EQ( result.error(), std::make_error_code( expected_err ) );
     }
 }
 
-/**
- * @test Test suite for `fromString` function.
- */
-INSTANTIATE_TEST_SUITE_P( FixedPointFromStringTests,
-                          FixedPointParamTest,
+INSTANTIATE_TEST_SUITE_P( FixedPrecisionFromStringTests,
+                          FixedPrecisionTest,
                           ::testing::Values(
                               // Valid cases
-                              FromStrParam_s{ "123.456", 9ULL, 123456000000ULL },
-                              FromStrParam_s{ "000123.00456000", 9ULL, 123004560000ULL },
-                              FromStrParam_s{ "123", 9ULL, 123000000000ULL },
-                              FromStrParam_s{ "123.45", 9ULL, 123450000000ULL },
-                              FromStrParam_s{ "1.123456789", 9ULL, 1123456789ULL },
-                              FromStrParam_s{ "0.000000001", 9ULL, 1ULL },
-                              FromStrParam_s{ "999999999.999999999", 9ULL, 999999999999999999ULL },
-                              FromStrParam_s{ "123.4", 1ULL, 1234ULL },
-                              FromStrParam_s{ "123", 0ULL, 123ULL },
-                              FromStrParam_s{ "0", 0ULL, 0ULL },
-                              FromStrParam_s{ "1.1", 1ULL, 11ULL },
-                              FromStrParam_s{ "1.123", 3ULL, 1123ULL },
-                              // Error Cases
-                              FromStrParam_s{ "abc", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "1.1234567890", 9ULL, std::errc::value_too_large },
-                              FromStrParam_s{ "-123.456", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "123..456", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "123.45.67", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "1.123456789", 8ULL, std::errc::value_too_large },
-                              FromStrParam_s{ " 123.456", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "A123.456", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "123.456 ", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "123.456A", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ ".", 9ULL, std::errc::invalid_argument },
-                              FromStrParam_s{ "0.0000000001", 9ULL, std::errc::value_too_large } ) );
+                              FixedPrecisionParam_s{ "123.456", 9ULL, 123456000000ULL },
+                              FixedPrecisionParam_s{ "000123.00456000", 9ULL, 123004560000ULL },
+                              FixedPrecisionParam_s{ "123", 9ULL, 123000000000ULL },
+                              FixedPrecisionParam_s{ "123.45", 9ULL, 123450000000ULL },
+                              FixedPrecisionParam_s{ "1.123456789", 9ULL, 1123456789ULL },
+                              FixedPrecisionParam_s{ "0.000000001", 9ULL, 1ULL },
+                              FixedPrecisionParam_s{ "999999999.999999999", 9ULL, 999999999999999999ULL },
+                              FixedPrecisionParam_s{ "123.4", 1ULL, 1234ULL },
+                              FixedPrecisionParam_s{ "123", 0ULL, 123ULL },
+                              FixedPrecisionParam_s{ "0", 0ULL, 0ULL },
+                              FixedPrecisionParam_s{ "1.1", 1ULL, 11ULL },
+                              FixedPrecisionParam_s{ "1.123", 3ULL, 1123ULL },
+                              // Error cases
+                              FixedPrecisionParam_s{ "abc", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "1.1234567890", 9ULL, std::errc::value_too_large },
+                              FixedPrecisionParam_s{ "-123.456", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "123..456", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "123.45.67", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "1.123456789", 8ULL, std::errc::value_too_large },
+                              FixedPrecisionParam_s{ " 123.456", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "A123.456", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "123.456 ", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "123.456A", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ ".", 9ULL, std::errc::invalid_argument },
+                              FixedPrecisionParam_s{ "0.0000000001", 9ULL, std::errc::value_too_large } ) );
+
+/**
+ * @brief Struct to hold test parameters for conversion with inferred precision.
+ */
+struct InferredPrecisionParam_s
+{
+    std::string                             input;              ///< Decimal string input.
+    uint64_t                                expected_value;     ///< Expected scaled integer value.
+    uint64_t                                expected_precision; ///< Expected precision inferred from input.
+    std::variant<std::monostate, std::errc> expected;           ///< Success (monostate) or error code.
+};
+
+/**
+ * @brief Parameterized test fixture for testing `New` which infers precision.
+ */
+class InferredPrecisionTest : public ::testing::TestWithParam<InferredPrecisionParam_s>
+{
+};
+
+/**
+ * @test Verifies string-to-fixed-point conversion where precision is inferred from the input.
+ */
+TEST_P( InferredPrecisionTest, NewFromStringInfersPrecision )
+{
+    const auto &tc  = GetParam();
+    auto        res = sgns::ScaledInteger::New( tc.input );
+
+    if ( std::holds_alternative<std::errc>( tc.expected ) )
+    {
+        EXPECT_FALSE( res.has_value() );
+        EXPECT_EQ( res.error(), std::make_error_code( std::get<std::errc>( tc.expected ) ) );
+    }
+    else
+    {
+        ASSERT_TRUE( res.has_value() );
+        auto ptr = res.value();
+        EXPECT_EQ( ptr->Value(), tc.expected_value );
+        EXPECT_EQ( ptr->Precision(), tc.expected_precision );
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    InferredPrecisionFromStringTests,
+    InferredPrecisionTest,
+    ::testing::Values(
+        // Valid cases
+        InferredPrecisionParam_s{ "42", 42ULL, 0ULL, std::monostate{} },
+        InferredPrecisionParam_s{ "123.456", 123456ULL, 3ULL, std::monostate{} },
+        InferredPrecisionParam_s{ "123.", 123ULL, 0ULL, std::monostate{} },
+        InferredPrecisionParam_s{ "123.0", 1230ULL, 1ULL, std::monostate{} },
+        InferredPrecisionParam_s{ "000123.00456000", 12300456000ULL, 8ULL, std::monostate{} },
+        // Error cases
+        InferredPrecisionParam_s{ "", 0ULL, 0ULL, std::errc::invalid_argument },
+        InferredPrecisionParam_s{ "abc", 0ULL, 0ULL, std::errc::invalid_argument },
+        InferredPrecisionParam_s{ "1.2.3", 0ULL, 0ULL, std::errc::invalid_argument },
+        InferredPrecisionParam_s{ "-1.23", 0ULL, 0ULL, std::errc::invalid_argument },
+        InferredPrecisionParam_s{ "18446744073709551616", 0ULL, 0ULL, std::errc::invalid_argument } ) );
 
 /**
  * @brief Struct to hold test parameters for FixedPointToStringParamTest.

--- a/test/src/base/scaled_integer_test.cpp
+++ b/test/src/base/scaled_integer_test.cpp
@@ -114,10 +114,12 @@ INSTANTIATE_TEST_SUITE_P(
     FromStringParseModeTests,
     FromStringParseMode,
     ::testing::Values(
+        ParseModeParam_s{ "0.000", 3ULL, sgns::ScaledInteger::ParseMode::Truncate, 0ULL },
         ParseModeParam_s{ "1.2345", 3ULL, sgns::ScaledInteger::ParseMode::Truncate, 1234ULL },
         ParseModeParam_s{ "1.234", 3ULL, sgns::ScaledInteger::ParseMode::Truncate, 1234ULL },
         ParseModeParam_s{ "123.45678", 4ULL, sgns::ScaledInteger::ParseMode::Truncate, 1234567ULL },
         ParseModeParam_s{ "123.4567", 4ULL, sgns::ScaledInteger::ParseMode::Truncate, 1234567ULL },
+        ParseModeParam_s{ "0.000", 3ULL, sgns::ScaledInteger::ParseMode::Strict, 0ULL },
         ParseModeParam_s{ "1.23", 2ULL, sgns::ScaledInteger::ParseMode::Strict, 123ULL },
         ParseModeParam_s{ "0.0042", 4ULL, sgns::ScaledInteger::ParseMode::Strict, 42ULL },
         ParseModeParam_s{ "1.2345", 3ULL, sgns::ScaledInteger::ParseMode::Strict, std::errc::value_too_large },

--- a/test/src/multiaccount/multi_account_sync.cpp
+++ b/test/src/multiaccount/multi_account_sync.cpp
@@ -86,8 +86,8 @@ protected:
 sgns::GeniusNode *MultiAccountTest::node_main  = nullptr;
 sgns::GeniusNode *MultiAccountTest::node_proc1 = nullptr;
 
-DevConfig_st MultiAccountTest::DEV_CONFIG  = { "0xcafe", "0.65", 1.0, 0, "./node1" };
-DevConfig_st MultiAccountTest::DEV_CONFIG2 = { "0xcafe", "0.65", 1.0, 1, "./node2" };
+DevConfig_st MultiAccountTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", 0, "./node1" };
+DevConfig_st MultiAccountTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", 1, "./node2" };
 
 std::string MultiAccountTest::binary_path = "";
 

--- a/test/src/multiaccount/multi_account_sync.cpp
+++ b/test/src/multiaccount/multi_account_sync.cpp
@@ -86,8 +86,8 @@ protected:
 sgns::GeniusNode *MultiAccountTest::node_main  = nullptr;
 sgns::GeniusNode *MultiAccountTest::node_proc1 = nullptr;
 
-DevConfig_st MultiAccountTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", 0, "./node1" };
-DevConfig_st MultiAccountTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", 1, "./node2" };
+DevConfig_st MultiAccountTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", "0", "./node1" };
+DevConfig_st MultiAccountTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", "1", "./node2" };
 
 std::string MultiAccountTest::binary_path = "";
 

--- a/test/src/processing_multi/processing_multi_test.cpp
+++ b/test/src/processing_multi/processing_multi_test.cpp
@@ -115,9 +115,9 @@ sgns::GeniusNode *ProcessingMultiTest::node_main  = nullptr;
 sgns::GeniusNode *ProcessingMultiTest::node_proc1 = nullptr;
 sgns::GeniusNode *ProcessingMultiTest::node_proc2 = nullptr;
 
-DevConfig_st ProcessingMultiTest::DEV_CONFIG  = { "0xcafe", "0.65", 1.0, 0, "./node1" };
-DevConfig_st ProcessingMultiTest::DEV_CONFIG2 = { "0xcafe", "0.65", 1.0, 0, "./node2" };
-DevConfig_st ProcessingMultiTest::DEV_CONFIG3 = { "0xcafe", "0.65", 1.0, 0, "./node3" };
+DevConfig_st ProcessingMultiTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", 0, "./node1" };
+DevConfig_st ProcessingMultiTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", 0, "./node2" };
+DevConfig_st ProcessingMultiTest::DEV_CONFIG3 = { "0xcafe", "0.65", "1.0", 0, "./node3" };
 
 std::string ProcessingMultiTest::binary_path = "";
 

--- a/test/src/processing_multi/processing_multi_test.cpp
+++ b/test/src/processing_multi/processing_multi_test.cpp
@@ -115,9 +115,9 @@ sgns::GeniusNode *ProcessingMultiTest::node_main  = nullptr;
 sgns::GeniusNode *ProcessingMultiTest::node_proc1 = nullptr;
 sgns::GeniusNode *ProcessingMultiTest::node_proc2 = nullptr;
 
-DevConfig_st ProcessingMultiTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", 0, "./node1" };
-DevConfig_st ProcessingMultiTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", 0, "./node2" };
-DevConfig_st ProcessingMultiTest::DEV_CONFIG3 = { "0xcafe", "0.65", "1.0", 0, "./node3" };
+DevConfig_st ProcessingMultiTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", "0", "./node1" };
+DevConfig_st ProcessingMultiTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", "0", "./node2" };
+DevConfig_st ProcessingMultiTest::DEV_CONFIG3 = { "0xcafe", "0.65", "1.0", "0", "./node3" };
 
 std::string ProcessingMultiTest::binary_path = "";
 

--- a/test/src/processing_nodes/CMakeLists.txt
+++ b/test/src/processing_nodes/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 addtest(processing_nodes_test
     processing_nodes_test.cpp
-    )
+)
 
 target_include_directories(processing_nodes_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
@@ -16,6 +16,30 @@ elseif(APPLE)
 
 else()
     target_link_options(processing_nodes_test PUBLIC
+        "-Wl,--whole-archive"
+        "$<TARGET_FILE:sgns_account>"
+        "-Wl,--no-whole-archive"
+    )
+endif()
+
+addtest(child_tokens_test
+    child_tokens_test.cpp
+)
+
+target_include_directories(child_tokens_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
+
+target_link_libraries(child_tokens_test
+    mp_utils
+    sgns_account
+)
+if(WIN32)
+    target_link_options(child_tokens_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:sgns_account>)
+
+elseif(APPLE)
+    target_link_options(child_tokens_test PUBLIC -force_load "$<TARGET_FILE:sgns_account>")
+
+else()
+    target_link_options(child_tokens_test PUBLIC
         "-Wl,--whole-archive"
         "$<TARGET_FILE:sgns_account>"
         "-Wl,--no-whole-archive"

--- a/test/src/processing_nodes/child_tokens_test.cpp
+++ b/test/src/processing_nodes/child_tokens_test.cpp
@@ -198,13 +198,12 @@ TEST_P( GeniusNodeMintMainTest, MintMainBalance )
     EXPECT_EQ( parsedFinalChild.value() - parsedInitialChild.value(), parsedExpectedDelta.value() );
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    MintMainVariations,
-    GeniusNodeMintMainTest,
-    ::testing::Values( MintMainCase_s{ .tokenValue = "1", .mintMain = 1000000, .expectedChild = "1" },
-                       MintMainCase_s{ .tokenValue = "0.5", .mintMain = 1000000, .expectedChild = "2.0" },
-                       MintMainCase_s{ .tokenValue = "2", .mintMain = 1000000, .expectedChild = "0.5" },
-                       MintMainCase_s{ .tokenValue = "0.5", .mintMain = 2000000, .expectedChild = "4.0" } ) );
+INSTANTIATE_TEST_SUITE_P( MintMainVariations,
+                          GeniusNodeMintMainTest,
+                          ::testing::Values( MintMainCase_s{ "1", 1000000, "1" },
+                                             MintMainCase_s{ "0.5", 1000000, "2.0" },
+                                             MintMainCase_s{ "2", 1000000, "0.5" },
+                                             MintMainCase_s{ "0.5", 2000000, "4.0" } ) );
 
 // ------------------ Suite 2: Mint Child Tokens ------------------
 
@@ -263,12 +262,11 @@ TEST_P( GeniusNodeMintChildTest, MintChildBalance )
     EXPECT_EQ( parsedFinal.value() - parsedInitial.value(), parsedExpectedDelta.value() );
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    MintChildVariations,
-    GeniusNodeMintChildTest,
-    ::testing::Values( MintChildCase_s{ .tokenValue = "1.0", .mintChild = "1.0", .expectedMain = 1000000 },
-                       MintChildCase_s{ .tokenValue = "0.5", .mintChild = "1.0", .expectedMain = 500000 },
-                       MintChildCase_s{ .tokenValue = "2.0", .mintChild = "1.0", .expectedMain = 2000000 } ) );
+INSTANTIATE_TEST_SUITE_P( MintChildVariations,
+                          GeniusNodeMintChildTest,
+                          ::testing::Values( MintChildCase_s{ "1.0", "1.0", 1000000 },
+                                             MintChildCase_s{ "0.5", "1.0", 500000 },
+                                             MintChildCase_s{ "2.0", "1.0", 2000000 } ) );
 
 /// Suite 3: Transfer Main and Child Tokens with Base Node
 
@@ -349,14 +347,8 @@ TEST_P( GeniusNodeTransferMainTest, TransferMainBalance )
 
 INSTANTIATE_TEST_SUITE_P( TransferMainVariations,
                           GeniusNodeTransferMainTest,
-                          ::testing::Values( TransferMainCase_s{ .tokenValue    = "1.0",
-                                                                 .transferValue = 400000,
-                                                                 .deltaMain     = "-0.4",
-                                                                 .deltaChild    = "0.6" },
-                                             TransferMainCase_s{ .tokenValue    = "0.5",
-                                                                 .transferValue = 500000,
-                                                                 .deltaMain     = "-0.5",
-                                                                 .deltaChild    = "1.0" } ) );
+                          ::testing::Values( TransferMainCase_s{ "1.0", 400000, "-0.4", "0.6" },
+                                             TransferMainCase_s{ "0.5", 500000, "-0.5", "1.0" } ) );
 
 // ------------------ Suite 4: Transfer Child via Main Methods ------------------
 

--- a/test/src/processing_nodes/child_tokens_test.cpp
+++ b/test/src/processing_nodes/child_tokens_test.cpp
@@ -4,7 +4,7 @@
 #include <thread>
 #include <cstring>
 #include <ostream>
-
+#include <atomic>
 #include "account/GeniusNode.hpp"
 #include "testutil/wait_condition.hpp"
 
@@ -20,12 +20,11 @@ namespace
      */
     std::unique_ptr<sgns::GeniusNode> CreateNode( const std::string &tokenValue, std::string &outPath )
     {
-        std::string binaryPath = boost::dll::program_location().parent_path().string();
-        std::string testName   = ::testing::UnitTest::GetInstance()->current_test_info()->name();
-        outPath                = binaryPath + "/" + testName;
-
-        boost::filesystem::remove_all( outPath );
-        boost::filesystem::create_directories( outPath );
+        static std::atomic<int> node_counter{ 0 };
+        int                     id         = node_counter.fetch_add( 1 );
+        std::string             binaryPath = boost::dll::program_location().parent_path().string();
+        std::string             testName   = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+        outPath                            = binaryPath + "/" + testName + "_" + std::to_string( id );
 
         DevConfig_st devConfig = { "0xcafe", "0.65", tokenValue, 0, "" };
         std::strncpy( devConfig.BaseWritePath, outPath.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
@@ -33,10 +32,109 @@ namespace
 
         const char *key  = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
         auto        node = std::make_unique<sgns::GeniusNode>( devConfig, key, false, false );
-        std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 1000 ) );
         return node;
     }
 } // namespace
+
+/// Suite: Simple Three-Node Transfers
+
+TEST( SimpleThreeNodeTransferTest, Node51AndNode52ToNode50 )
+{
+    const std::string binary_path = boost::dll::program_location().parent_path().string();
+
+    DevConfig_st cfg50 = { "0xcafe", "0.65", "1.0", 0, {} };
+    DevConfig_st cfg51 = { "0xcafe", "0.65", "0.5", 0, {} };
+    DevConfig_st cfg52 = { "0xcafe", "0.65", "2.0", 0, {} };
+
+    std::strncpy( cfg50.BaseWritePath, ( binary_path + "/node50/" ).c_str(), sizeof( cfg50.BaseWritePath ) - 1 );
+    std::strncpy( cfg51.BaseWritePath, ( binary_path + "/node51/" ).c_str(), sizeof( cfg51.BaseWritePath ) - 1 );
+    std::strncpy( cfg52.BaseWritePath, ( binary_path + "/node52/" ).c_str(), sizeof( cfg52.BaseWritePath ) - 1 );
+
+    cfg50.BaseWritePath[sizeof( cfg50.BaseWritePath ) - 1] = '\0';
+    cfg51.BaseWritePath[sizeof( cfg51.BaseWritePath ) - 1] = '\0';
+    cfg52.BaseWritePath[sizeof( cfg52.BaseWritePath ) - 1] = '\0';
+
+    auto node50 = std::make_unique<sgns::GeniusNode>(
+        cfg50,
+        "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        false,
+        false );
+    auto node51 = std::make_unique<sgns::GeniusNode>(
+        cfg51,
+        "eeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        false,
+        false );
+    auto node52 = std::make_unique<sgns::GeniusNode>(
+        cfg52,
+        "feadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        false,
+        false );
+
+    node51->GetPubSub()->AddPeers( { node50->GetPubSub()->GetLocalAddress() } );
+    node52->GetPubSub()->AddPeers( { node50->GetPubSub()->GetLocalAddress() } );
+    node50->GetPubSub()->AddPeers( { node51->GetPubSub()->GetLocalAddress(), node52->GetPubSub()->GetLocalAddress() } );
+
+    auto init50 = node50->GetBalance();
+    auto init51 = node51->GetBalance();
+    auto init52 = node52->GetBalance();
+
+    // ---------- Ensure enought balance ----------
+    uint64_t mintAmount51 = 1000000;
+    auto     mintRes51    = node51->MintTokens( 10000000,
+                                         "",
+                                         "",
+                                         "",
+                                         std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+    ASSERT_TRUE( mintRes51.has_value() ) << "Mint failed on node51";
+
+    uint64_t mintAmount52 = 1000000;
+    auto     mintRes52    = node52->MintTokens( 10000000,
+                                         "",
+                                         "",
+                                         "",
+                                         std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+    ASSERT_TRUE( mintRes52.has_value() ) << "Mint failed on node52";
+
+    // ---------- Node51 to Node50 ----------
+    std::string childTransfer51 = "1.0";
+    auto        parsed51        = node51->ParseChildTokens( childTransfer51 );
+    ASSERT_TRUE( parsed51.has_value() ) << "Failed to parse child transfer string (node51)";
+
+    auto transferRes51 = node51->TransferFunds( parsed51.value(),
+                                                node50->GetAddress(),
+                                                std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+    ASSERT_TRUE( transferRes51.has_value() ) << "Transfer from node51 failed";
+    auto [tx51, dur51] = transferRes51.value();
+
+    ASSERT_TRUE(
+        node50->WaitForTransactionIncoming( tx51, std::chrono::milliseconds( INCOMING_TIMEOUT_MILLISECONDS ) ) )
+        << "Node50 did not receive transaction from node51";
+
+    // ---------- Node52 to Node50 ----------
+    std::string childTransfer52 = "1.0";
+    auto        parsed52        = node52->ParseChildTokens( childTransfer52 );
+    ASSERT_TRUE( parsed52.has_value() ) << "Failed to parse child transfer string (node52)";
+
+    auto transferRes52 = node52->TransferFunds( parsed52.value(),
+                                                node50->GetAddress(),
+                                                std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+    ASSERT_TRUE( transferRes52.has_value() ) << "Transfer from node52 failed";
+    auto [tx52, dur52] = transferRes52.value();
+
+    ASSERT_TRUE(
+        node50->WaitForTransactionIncoming( tx52, std::chrono::milliseconds( INCOMING_TIMEOUT_MILLISECONDS ) ) )
+        << "Node50 did not receive transaction from node52";
+
+    // ---------- Final balance checks ----------
+    auto final50 = node50->GetBalance();
+    auto final51 = node51->GetBalance();
+    auto final52 = node52->GetBalance();
+
+    EXPECT_EQ( final50 - init50, 2000000 + 500000 );
+    EXPECT_EQ( final51 - init51, 10000000 - 500000 );
+    EXPECT_EQ( final52 - init52, 10000000 - 2000000 );
+}
 
 // ------------------ Suite 1: Mint Main Tokens ------------------
 
@@ -58,7 +156,7 @@ class GeniusNodeMintMainTest : public ::testing::TestWithParam<MintMainCase_s>
 {
 };
 
-TEST_P( GeniusNodeMintMainTest, MintMainBalance )
+TEST_P( GeniusNodeMintMainTest, DISABLED_MintMainBalance )
 {
     auto        p = GetParam();
     std::string basePath;
@@ -69,12 +167,8 @@ TEST_P( GeniusNodeMintMainTest, MintMainBalance )
     auto        parsedInitialChild = node->ParseChildTokens( initialChildStr );
     ASSERT_TRUE( parsedInitialChild.has_value() );
 
-    auto res = node->MintTokens( p.mintMain, "", "", "" );
+    auto res = node->MintTokens( p.mintMain, "", "", "", std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
     ASSERT_TRUE( res.has_value() );
-
-    assertWaitForCondition( [&]() { return node->GetBalance() - initialMain == p.mintMain; },
-                            std::chrono::milliseconds( 20000 ),
-                            "Main mint timeout for " + p.tokenValue );
 
     uint64_t    finalMain        = node->GetBalance();
     std::string finalChildStr    = node->FormatChildTokens( finalMain );
@@ -86,8 +180,6 @@ TEST_P( GeniusNodeMintMainTest, MintMainBalance )
 
     EXPECT_EQ( finalMain - initialMain, p.mintMain );
     EXPECT_EQ( parsedFinalChild.value() - parsedInitialChild.value(), parsedExpectedDelta.value() );
-
-    boost::filesystem::remove_all( basePath );
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -116,9 +208,14 @@ inline std::ostream &operator<<( std::ostream &os, MintChildCase_s const &c )
 
 class GeniusNodeMintChildTest : public ::testing::TestWithParam<MintChildCase_s>
 {
+protected:
+    static void SetUpTestSuite()
+    {
+        // CleanTestSuiteDirectories( "GeniusNodeMintChildTest" );
+    }
 };
 
-TEST_P( GeniusNodeMintChildTest, MintChildBalance )
+TEST_P( GeniusNodeMintChildTest, DISABLED_MintChildBalance )
 {
     auto        p = GetParam();
     std::string basePath;
@@ -132,20 +229,12 @@ TEST_P( GeniusNodeMintChildTest, MintChildBalance )
     auto parsedMint = node->ParseChildTokens( p.mintChild );
     ASSERT_TRUE( parsedMint.has_value() );
 
-    auto res = node->MintTokens( parsedMint.value(), "", "", "" );
+    auto res = node->MintTokens( parsedMint.value(),
+                                 "",
+                                 "",
+                                 "",
+                                 std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
     ASSERT_TRUE( res.has_value() );
-
-    assertWaitForCondition(
-        [&]()
-        {
-            std::string currentChildStr = node->FormatChildTokens( node->GetBalance() );
-            auto        currentParsed   = node->ParseChildTokens( currentChildStr );
-            auto        expectedDelta   = node->ParseChildTokens( p.mintChild );
-            return currentParsed && expectedDelta &&
-                   ( currentParsed.value() - parsedInitial.value() == expectedDelta.value() );
-        },
-        std::chrono::milliseconds( 20000 ),
-        "Child mint timeout for " + p.tokenValue );
 
     uint64_t    finalMain     = node->GetBalance();
     std::string finalChildStr = node->FormatChildTokens( finalMain );
@@ -157,8 +246,6 @@ TEST_P( GeniusNodeMintChildTest, MintChildBalance )
 
     EXPECT_EQ( finalMain - initialMain, p.expectedMain );
     EXPECT_EQ( parsedFinal.value() - parsedInitial.value(), parsedExpectedDelta.value() );
-
-    boost::filesystem::remove_all( basePath );
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -168,88 +255,163 @@ INSTANTIATE_TEST_SUITE_P(
                        MintChildCase_s{ .tokenValue = "0.5", .mintChild = "1.0", .expectedMain = 500000 },
                        MintChildCase_s{ .tokenValue = "2.0", .mintChild = "1.0", .expectedMain = 2000000 } ) );
 
-// ------------------ Suite 3: Transfer Main Tokens ------------------
-/// @brief Parameters for transfer-main tests
-struct TransferMainCase_s
+/// Suite 3: Transfer Main and Child Tokens with Base Node
+
+/// Parameters for transfer-main tests
+typedef struct
 {
-    std::string tokenValue;   ///< TokenValueInGNUS
-    uint64_t    mintMain;     ///< Mint on nodeA
-    uint64_t    transferMain; ///< Transfer from A to B
-    uint64_t    expA_main;    ///< Expected delta A main
-    uint64_t    expA_child;   ///< Expected delta A child
-    uint64_t    expB_main;    ///< Expected delta B main
-    uint64_t    expB_child;   ///< Expected delta B child
-};
+    std::string tokenValue;     ///< TokenValueInGNUS (used to mint child tokens)
+    uint64_t    mintValue;      ///< Amount to mint on child node
+    uint64_t    transferMain;   ///< Amount to transfer from child to base
+    std::string expBase_child;  ///< Expected delta on base child tokens
+    std::string expChild_child; ///< Expected delta on child child tokens
+} TransferMainCase_s;
 
 inline std::ostream &operator<<( std::ostream &os, TransferMainCase_s const &c )
 {
-    return os << "TransferMainCase_s{tokenValue='" << c.tokenValue << "', mintMain=" << c.mintMain
-              << ", transferMain=" << c.transferMain << ", expA_main=" << c.expA_main << ", expA_child=" << c.expA_child
-              << ", expB_main=" << c.expB_main << ", expB_child=" << c.expB_child << "}";
+    return os << "TransferMainCase_s{tokenValue='" << c.tokenValue << "', mintValue=" << c.mintValue
+              << ", transferMain=" << c.transferMain << ", expBase_child='" << c.expBase_child << "', expChild_child='"
+              << c.expChild_child << "'}";
 }
 
 class GeniusNodeTransferMainTest : public ::testing::TestWithParam<TransferMainCase_s>
 {
+protected:
+    // Shared binary path & counter
+    static inline std::string      binary_path;
+    static inline std::atomic<int> dir_counter{ 30 };
+
+    // Base node lives for entire suite
+    static inline sgns::GeniusNode *base_node = nullptr;
+    // All created nodes (base + children)
+    static inline std::vector<sgns::GeniusNode *> all_nodes;
+
+    // Child node for each test
+    sgns::GeniusNode *child_node = nullptr;
+    DevConfig_st      dev_cfg_child{};
+
+    // Called once before any tests in this suite
+    static void SetUpTestSuite()
+    {
+        // Initialize binary path
+        binary_path = boost::dll::program_location().parent_path().string();
+
+        // Configure base node
+        DevConfig_st cfg_base  = { "0xcafe", "0.65", "1.0", 0, {} };
+        std::string  base_path = binary_path + "/node00/";
+        std::strncpy( cfg_base.BaseWritePath, base_path.c_str(), sizeof( cfg_base.BaseWritePath ) - 1 );
+
+        // Instantiate base node
+        base_node = new sgns::GeniusNode( cfg_base,
+                                          "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                                          false,
+                                          false );
+        all_nodes.push_back( base_node );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 1000 ) );
+    }
+
+    static void TearDownTestSuite()
+    {
+        for ( auto node : all_nodes )
+        {
+            delete node;
+        }
+        all_nodes.clear();
+    }
+
+    void SetUp() override
+    {
+        int         id         = dir_counter.fetch_add( 1 );
+        std::string child_path = binary_path + "/node" + std::to_string( id ) + "/";
+
+        dev_cfg_child = { "0xcafe", "0.65", "1.0", 0, {} };
+        std::strncpy( dev_cfg_child.BaseWritePath, child_path.c_str(), sizeof( dev_cfg_child.BaseWritePath ) - 1 );
+
+        child_node = new sgns::GeniusNode( dev_cfg_child,
+                                           "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                                           false,
+                                           false );
+        all_nodes.push_back( child_node );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 1000 ) );
+
+        auto base_addr  = base_node->GetPubSub()->GetLocalAddress();
+        auto child_addr = child_node->GetPubSub()->GetLocalAddress();
+        base_node->GetPubSub()->AddPeers( { child_addr } );
+        child_node->GetPubSub()->AddPeers( { base_addr } );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 1000 ) );
+    }
+
+    // No per-test cleanup; nodes live until TearDownTestSuite
+    void TearDown() override {}
 };
 
 TEST_P( GeniusNodeTransferMainTest, DISABLED_TransferMainBalance )
 {
-    auto        c = GetParam();
-    std::string baseA, baseB;
-    auto        nodeA = CreateNode( c.tokenValue, baseA );
-    auto        nodeB = CreateNode( c.tokenValue, baseB );
+    const auto c = GetParam();
 
-    uint64_t initA_main  = nodeA->GetBalance();
-    uint64_t initA_child = nodeA->GetChildBalance().value();
-    uint64_t initB_main  = nodeB->GetBalance();
-    uint64_t initB_child = nodeB->GetChildBalance().value();
+    // Record initial balances
+    auto initBase_main  = base_node->GetBalance();
+    auto parsedInitBase = base_node->ParseChildTokens( base_node->FormatChildTokens( initBase_main ) );
+    ASSERT_TRUE( parsedInitBase.has_value() );
 
-    auto r = nodeA->MintTokens( c.mintMain, "", "", "" );
-    ASSERT_TRUE( r.has_value() ) << "MintTokens failed for " << c;
+    auto initChild_main  = child_node->GetBalance();
+    auto parsedInitChild = child_node->ParseChildTokens( child_node->FormatChildTokens( initChild_main ) );
+    ASSERT_TRUE( parsedInitChild.has_value() );
 
-    auto t = nodeA->TransferFunds( c.transferMain, nodeB->GetAddress(), std::chrono::milliseconds( 20000 ) );
-    ASSERT_TRUE( t.has_value() ) << "TransferFunds failed for " << c;
+    // Mint on child and transfer to base
+    ASSERT_TRUE(
+        child_node->MintTokens( c.mintValue, "", "", "", std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) )
+            .has_value() );
+    auto [txId, _] = child_node
+                         ->TransferFunds( c.transferMain,
+                                          base_node->GetAddress(),
+                                          std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) )
+                         .value();
+    ASSERT_TRUE(
+        base_node->WaitForTransactionIncoming( txId, std::chrono::milliseconds( INCOMING_TIMEOUT_MILLISECONDS ) ) );
 
-    assertWaitForCondition( [&]() { return nodeA->GetBalance() - initA_main == c.expA_main; },
-                            std::chrono::milliseconds( 20000 ),
-                            "A main timeout for " + c.tokenValue );
-    assertWaitForCondition( [&]() { return nodeB->GetBalance() - initB_main == c.expB_main; },
-                            std::chrono::milliseconds( 20000 ),
-                            "B main timeout for " + c.tokenValue );
+    // Verify final balances and child deltas
+    auto finalBase_main  = base_node->GetBalance();
+    auto parsedFinalBase = base_node->ParseChildTokens( base_node->FormatChildTokens( finalBase_main ) );
+    ASSERT_TRUE( parsedFinalBase.has_value() );
 
-    EXPECT_EQ( nodeA->GetBalance() - initA_main, c.expA_main ) << c;
-    EXPECT_EQ( nodeA->GetChildBalance().value() - initA_child, c.expA_child ) << c;
-    EXPECT_EQ( nodeB->GetBalance() - initB_main, c.expB_main ) << c;
-    EXPECT_EQ( nodeB->GetChildBalance().value() - initB_child, c.expB_child ) << c;
+    auto finalChild_main  = child_node->GetBalance();
+    auto parsedFinalChild = child_node->ParseChildTokens( child_node->FormatChildTokens( finalChild_main ) );
+    ASSERT_TRUE( parsedFinalChild.has_value() );
 
-    boost::filesystem::remove_all( baseA );
-    boost::filesystem::remove_all( baseB );
+    auto expBase_val  = base_node->ParseChildTokens( c.expBase_child );
+    auto expChild_val = child_node->ParseChildTokens( c.expChild_child );
+    ASSERT_TRUE( expBase_val.has_value() && expChild_val.has_value() );
+
+    // Child balance decreased by transfer; base balance increased by transfer
+    EXPECT_EQ( finalChild_main - initChild_main, c.mintValue - c.transferMain );
+    EXPECT_EQ( finalBase_main - initBase_main, c.transferMain );
+    // Child and base child-token deltas
+    EXPECT_EQ( parsedFinalChild.value() - parsedInitChild.value(), expChild_val.value() );
+    EXPECT_EQ( parsedFinalBase.value() - parsedInitBase.value(), expBase_val.value() );
 }
 
-INSTANTIATE_TEST_SUITE_P( DISABLED_TransferMainVariations,
+INSTANTIATE_TEST_SUITE_P( TransferMainVariations,
                           GeniusNodeTransferMainTest,
-                          ::testing::Values( TransferMainCase_s{ "1.0", 1000, 400, 600, 0, 400, 0 },
-                                             TransferMainCase_s{ "0.5", 2000, 500, 1500, 0, 500, 0 } ) );
+                          ::testing::Values( TransferMainCase_s{ "1.0", 1000000, 400000, "0.4", "0.6" },
+                                             TransferMainCase_s{ "1.0", 1000000, 400000, "0.4", "0.6" },
+                                             TransferMainCase_s{ "0.5", 2000000, 500000, "0.25", "0.75" } ) );
 
-// ------------------ Suite 4: Transfer Child Tokens ------------------
-/// @brief Parameters for transfer-child tests
+// ------------------ Suite 4: Transfer Child via Main Methods ------------------
+
+/// @brief Parameters for transfer-child tests (converted via main units)
 struct TransferChildCase_s
 {
     std::string tokenValue;
-    uint64_t    mintChild;
-    uint64_t    transferChild;
-    uint64_t    expA_main;
-    uint64_t    expA_child;
-    uint64_t    expB_main;
-    uint64_t    expB_child;
+    std::string transferChild; ///< Amount to transfer in child tokens (as string)
+    std::string expA_child;    ///< Expected delta A child (as string)
+    std::string expB_child;    ///< Expected delta B child (as string)
 };
 
 inline std::ostream &operator<<( std::ostream &os, TransferChildCase_s const &c )
 {
-    return os << "TransferChildCase_s{tokenValue='" << c.tokenValue << "', mintChild=" << c.mintChild
-              << ", transferChild=" << c.transferChild << ", expA_main=" << c.expA_main
-              << ", expA_child=" << c.expA_child << ", expB_main=" << c.expB_main << ", expB_child=" << c.expB_child
-              << "}";
+    return os << "TransferChildCase_s{tokenValue='" << c.tokenValue << "', transferChild='" << c.transferChild
+              << "', expA_child='" << c.expA_child << "', expB_child='" << c.expB_child << "'}";
 }
 
 class GeniusNodeTransferChildTest : public ::testing::TestWithParam<TransferChildCase_s>
@@ -263,35 +425,39 @@ TEST_P( GeniusNodeTransferChildTest, DISABLED_TransferChildBalance )
     auto        nodeA = CreateNode( c.tokenValue, baseA );
     auto        nodeB = CreateNode( c.tokenValue, baseB );
 
-    uint64_t initA_main  = nodeA->GetBalance();
-    uint64_t initA_child = nodeA->GetChildBalance().value();
-    uint64_t initB_main  = nodeB->GetBalance();
-    uint64_t initB_child = nodeB->GetChildBalance().value();
+    uint64_t initA_main     = nodeA->GetBalance();
+    auto     initA_childStr = nodeA->FormatChildTokens( initA_main );
+    auto     parsedInitA    = nodeA->ParseChildTokens( initA_childStr );
+    ASSERT_TRUE( parsedInitA.has_value() );
+    uint64_t initB_main     = nodeB->GetBalance();
+    auto     initB_childStr = nodeB->FormatChildTokens( initB_main );
+    auto     parsedInitB    = nodeB->ParseChildTokens( initB_childStr );
+    ASSERT_TRUE( parsedInitB.has_value() );
 
-    // auto r = nodeA->MintChildTokens( c.mintChild, "", "", "" );
-    // ASSERT_TRUE( r.has_value() ) << "MintChildTokens failed for " << c;
+    auto parsedChild = nodeA->ParseChildTokens( c.transferChild );
+    ASSERT_TRUE( parsedChild.has_value() );
+    std::string mainStr      = nodeA->FormatTokens( parsedChild.value() );
+    auto        transferMain = std::stoull( mainStr );
 
-    auto t = nodeA->TransferChildTokens( c.transferChild, nodeB->GetAddress(), std::chrono::milliseconds( 20000 ) );
-    ASSERT_TRUE( t.has_value() ) << "TransferChildTokens failed for " << c;
+    auto t = nodeA->TransferFunds( transferMain,
+                                   nodeB->GetAddress(),
+                                   std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+    ASSERT_TRUE( t.has_value() );
 
-    assertWaitForCondition( [&]() { return nodeA->GetChildBalance().value() - initA_child == c.expA_child; },
-                            std::chrono::milliseconds( 20000 ),
-                            "A child timeout for " + c.tokenValue );
-    assertWaitForCondition( [&]() { return nodeB->GetChildBalance().value() - initB_child == c.expB_child; },
-                            std::chrono::milliseconds( 20000 ),
-                            "B child timeout for " + c.tokenValue );
+    auto finalA = nodeA->ParseChildTokens( nodeA->FormatChildTokens( nodeA->GetBalance() ) );
+    auto finalB = nodeB->ParseChildTokens( nodeB->FormatChildTokens( nodeB->GetBalance() ) );
+    ASSERT_TRUE( finalA.has_value() && finalB.has_value() );
 
-    EXPECT_EQ( nodeA->GetChildBalance().value() - initA_child, c.expA_child ) << c;
-    EXPECT_EQ( nodeA->GetBalance() - initA_main, c.expA_main ) << c;
-    EXPECT_EQ( nodeB->GetChildBalance().value() - initB_child, c.expB_child ) << c;
-    EXPECT_EQ( nodeB->GetBalance() - initB_main, c.expB_main ) << c;
+    auto expA_childVal = nodeA->ParseChildTokens( c.expA_child );
+    ASSERT_TRUE( expA_childVal.has_value() );
+    auto expB_childVal = nodeB->ParseChildTokens( c.expB_child );
+    ASSERT_TRUE( expB_childVal.has_value() );
 
-    boost::filesystem::remove_all( baseA );
-    boost::filesystem::remove_all( baseB );
+    EXPECT_EQ( finalA.value() - parsedInitA.value(), expA_childVal.value() );
+    EXPECT_EQ( finalB.value() - parsedInitB.value(), expB_childVal.value() );
 }
 
 INSTANTIATE_TEST_SUITE_P( DISABLED_TransferChildVariations,
                           GeniusNodeTransferChildTest,
-                          ::testing::Values( TransferChildCase_s{ "1.0", 500, 200, 300, 300, 200, 200 },
-                                             TransferChildCase_s{ "0.5", 1000, 250, 375, 750, 125, 250 },
-                                             TransferChildCase_s{ "1.5", 300, 100, 150, 200, 100, 100 } ) );
+                          ::testing::Values( TransferChildCase_s{ "1.0", "0.2", "-0.2", "0.2" },
+                                             TransferChildCase_s{ "0.5", "0.25", "-0.25", "0.25" } ) );

--- a/test/src/processing_nodes/child_tokens_test.cpp
+++ b/test/src/processing_nodes/child_tokens_test.cpp
@@ -93,9 +93,10 @@ TEST_P( GeniusNodeMintMainTest, MintMainBalance )
 INSTANTIATE_TEST_SUITE_P(
     MintMainVariations,
     GeniusNodeMintMainTest,
-    ::testing::Values( MintMainCase_s{ .tokenValue = "1.0", .mintMain = 1000, .expectedChild = "1000" },
-                       MintMainCase_s{ .tokenValue = "0.5", .mintMain = 1000, .expectedChild = "2000" },
-                       MintMainCase_s{ .tokenValue = "1.25", .mintMain = 1000, .expectedChild = "800" } ) );
+    ::testing::Values( MintMainCase_s{ .tokenValue = "1", .mintMain = 1000000, .expectedChild = "1" },
+                       MintMainCase_s{ .tokenValue = "0.5", .mintMain = 1000000, .expectedChild = "2.0" },
+                       MintMainCase_s{ .tokenValue = "2", .mintMain = 1000000, .expectedChild = "0.5" },
+                       MintMainCase_s{ .tokenValue = "0.5", .mintMain = 2000000, .expectedChild = "4.0" } ) );
 
 // ------------------ Suite 2: Mint Child Tokens ------------------
 
@@ -163,9 +164,9 @@ TEST_P( GeniusNodeMintChildTest, MintChildBalance )
 INSTANTIATE_TEST_SUITE_P(
     MintChildVariations,
     GeniusNodeMintChildTest,
-    ::testing::Values( MintChildCase_s{ .tokenValue = "1.0", .mintChild = "500", .expectedMain = 500 },
-                       MintChildCase_s{ .tokenValue = "0.5", .mintChild = "1000", .expectedMain = 500 },
-                       MintChildCase_s{ .tokenValue = "1.5", .mintChild = "2000", .expectedMain = 3000 } ) );
+    ::testing::Values( MintChildCase_s{ .tokenValue = "1.0", .mintChild = "1.0", .expectedMain = 1000000 },
+                       MintChildCase_s{ .tokenValue = "0.5", .mintChild = "1.0", .expectedMain = 500000 },
+                       MintChildCase_s{ .tokenValue = "2.0", .mintChild = "1.0", .expectedMain = 2000000 } ) );
 
 // ------------------ Suite 3: Transfer Main Tokens ------------------
 /// @brief Parameters for transfer-main tests
@@ -267,8 +268,8 @@ TEST_P( GeniusNodeTransferChildTest, DISABLED_TransferChildBalance )
     uint64_t initB_main  = nodeB->GetBalance();
     uint64_t initB_child = nodeB->GetChildBalance().value();
 
-    auto r = nodeA->MintChildTokens( c.mintChild, "", "", "" );
-    ASSERT_TRUE( r.has_value() ) << "MintChildTokens failed for " << c;
+    // auto r = nodeA->MintChildTokens( c.mintChild, "", "", "" );
+    // ASSERT_TRUE( r.has_value() ) << "MintChildTokens failed for " << c;
 
     auto t = nodeA->TransferChildTokens( c.transferChild, nodeB->GetAddress(), std::chrono::milliseconds( 20000 ) );
     ASSERT_TRUE( t.has_value() ) << "TransferChildTokens failed for " << c;

--- a/test/src/processing_nodes/child_tokens_test.cpp
+++ b/test/src/processing_nodes/child_tokens_test.cpp
@@ -10,60 +10,42 @@
 
 using namespace sgns::test;
 
-/**
- * @brief Common fixture for GeniusNode tests.
- */
-template <typename ParamType>
-class GeniusNodeCommonTest : public ::testing::TestWithParam<ParamType>
+namespace
 {
-protected:
-    DevConfig_st                      devConfig;
-    std::string                       baseA, baseB;
-    std::unique_ptr<sgns::GeniusNode> nodeA, nodeB;
-
-    void SetUp() override
+    /**
+     * @brief Helper to create a GeniusNode with its own directory and cleanup.
+     * @param tokenValue TokenValueInGNUS to initialize DevConfig.
+     * @param outPath Receives the created base path for cleanup.
+     * @return unique_ptr to the initialized GeniusNode.
+     */
+    std::unique_ptr<sgns::GeniusNode> CreateNode( const std::string &tokenValue, std::string &outPath )
     {
-        auto        p          = this->GetParam();
         std::string binaryPath = boost::dll::program_location().parent_path().string();
         std::string testName   = ::testing::UnitTest::GetInstance()->current_test_info()->name();
-        baseA                  = binaryPath + "/" + testName + "_A";
-        baseB                  = binaryPath + "/" + testName + "_B";
+        outPath                = binaryPath + "/" + testName;
 
-        boost::filesystem::remove_all( baseA );
-        boost::filesystem::remove_all( baseB );
-        boost::filesystem::create_directories( baseA );
-        boost::filesystem::create_directories( baseB );
+        boost::filesystem::remove_all( outPath );
+        boost::filesystem::create_directories( outPath );
 
-        devConfig = { "0xcafe", "0.65", p.tokenValue, 0, "" };
-        std::strncpy( devConfig.BaseWritePath, baseA.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
+        DevConfig_st devConfig = { "0xcafe", "0.65", tokenValue, 0, "" };
+        std::strncpy( devConfig.BaseWritePath, outPath.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
         devConfig.BaseWritePath[sizeof( devConfig.BaseWritePath ) - 1] = '\0';
 
-        const char *key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
-        nodeA           = std::make_unique<sgns::GeniusNode>( devConfig, key, false, false );
-
-        std::strncpy( devConfig.BaseWritePath, baseB.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
-        devConfig.BaseWritePath[sizeof( devConfig.BaseWritePath ) - 1] = '\0';
-        nodeB = std::make_unique<sgns::GeniusNode>( devConfig, key, false, false );
-
+        const char *key  = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        auto        node = std::make_unique<sgns::GeniusNode>( devConfig, key, false, false );
         std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
+        return node;
     }
-
-    void TearDown() override
-    {
-        nodeA.reset();
-        nodeB.reset();
-        boost::filesystem::remove_all( baseA );
-        boost::filesystem::remove_all( baseB );
-    }
-};
+} // namespace
 
 // ------------------ Suite 1: Mint Main Tokens ------------------
+/// @brief Parameters for mint-main tests
 struct MintMainCase_s
 {
-    std::string tokenValue;
-    uint64_t    mintMain;
-    uint64_t    expectedMain;
-    uint64_t    expectedChild;
+    std::string tokenValue;    ///< TokenValueInGNUS
+    uint64_t    mintMain;      ///< Amount to mint in main tokens
+    uint64_t    expectedMain;  ///< Expected delta of main balance
+    uint64_t    expectedChild; ///< Expected delta of child balance
 };
 
 inline std::ostream &operator<<( std::ostream &os, MintMainCase_s const &c )
@@ -72,37 +54,48 @@ inline std::ostream &operator<<( std::ostream &os, MintMainCase_s const &c )
               << ", expectedMain=" << c.expectedMain << ", expectedChild=" << c.expectedChild << "}";
 }
 
-class GeniusNodeMintMainTest : public GeniusNodeCommonTest<MintMainCase_s>
+class GeniusNodeMintMainTest : public ::testing::TestWithParam<MintMainCase_s>
 {
 };
 
 TEST_P( GeniusNodeMintMainTest, MintMainBalance )
 {
-    auto p   = this->GetParam();
-    auto res = this->nodeA->MintTokens( p.mintMain, "", "", "" );
+    auto        p = GetParam();
+    std::string basePath;
+    auto        node = CreateNode( p.tokenValue, basePath );
+
+    uint64_t initialMain  = node->GetBalance();
+    uint64_t initialChild = node->GetChildBalance().value();
+
+    auto res = node->MintTokens( p.mintMain, "", "", "" );
     ASSERT_TRUE( res.has_value() ) << "MintTokens failed for " << p;
-    assertWaitForCondition( [&]() { return this->nodeA->GetBalance() == p.expectedMain; },
+
+    assertWaitForCondition( [&]() { return node->GetBalance() - initialMain == p.expectedMain; },
                             std::chrono::milliseconds( 20000 ),
                             "Main mint timeout for " + p.tokenValue );
-    EXPECT_EQ( this->nodeA->GetBalance(), p.expectedMain ) << p;
-    EXPECT_EQ( this->nodeA->GetChildBalance().value(), p.expectedChild ) << p;
+
+    uint64_t finalMain  = node->GetBalance();
+    uint64_t finalChild = node->GetChildBalance().value();
+    EXPECT_EQ( finalMain - initialMain, p.expectedMain ) << p;
+    EXPECT_EQ( finalChild - initialChild, p.expectedChild ) << p;
+
+    boost::filesystem::remove_all( basePath );
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    MintMainVariations,
-    GeniusNodeMintMainTest,
-    ::testing::Values(
-        MintMainCase_s{ .tokenValue = "1.0", .mintMain = 1000, .expectedMain = 1000, .expectedChild = 1000 },
-        MintMainCase_s{ .tokenValue = "0.5", .mintMain = 1000, .expectedMain = 1000, .expectedChild = 2000 },
-        MintMainCase_s{ .tokenValue = "1.25", .mintMain = 1000, .expectedMain = 1000, .expectedChild = 800 } ) );
+INSTANTIATE_TEST_SUITE_P( MintMainVariations,
+                          GeniusNodeMintMainTest,
+                          ::testing::Values( MintMainCase_s{ "1.0", 1000, 1000, 1000 },
+                                             MintMainCase_s{ "0.5", 1000, 1000, 2000 },
+                                             MintMainCase_s{ "1.25", 1000, 1000, 800 } ) );
 
 // ------------------ Suite 2: Mint Child Tokens ------------------
+/// @brief Parameters for mint-child tests
 struct MintChildCase_s
 {
-    std::string tokenValue;
-    uint64_t    mintChild;
-    uint64_t    expectedChild;
-    uint64_t    expectedMain;
+    std::string tokenValue;    ///< TokenValueInGNUS
+    uint64_t    mintChild;     ///< Amount to mint in child tokens
+    uint64_t    expectedChild; ///< Expected delta of child balance
+    uint64_t    expectedMain;  ///< Expected delta of main balance
 };
 
 inline std::ostream &operator<<( std::ostream &os, MintChildCase_s const &c )
@@ -111,40 +104,49 @@ inline std::ostream &operator<<( std::ostream &os, MintChildCase_s const &c )
               << ", expectedChild=" << c.expectedChild << ", expectedMain=" << c.expectedMain << "}";
 }
 
-class GeniusNodeMintChildTest : public GeniusNodeCommonTest<MintChildCase_s>
+class GeniusNodeMintChildTest : public ::testing::TestWithParam<MintChildCase_s>
 {
 };
 
-TEST_P( GeniusNodeMintChildTest, DISABLED_MintChildBalance )
+TEST_P( GeniusNodeMintChildTest, MintChildBalance )
 {
-    auto p   = this->GetParam();
-    auto res = this->nodeA->MintChildTokens( p.mintChild, "", "", "" );
+    auto        p = GetParam();
+    std::string basePath;
+    auto        node = CreateNode( p.tokenValue, basePath );
+
+    uint64_t initialMain  = node->GetBalance();
+    uint64_t initialChild = node->GetChildBalance().value();
+
+    auto res = node->MintChildTokens( p.mintChild, "", "", "" );
     ASSERT_TRUE( res.has_value() ) << "MintChildTokens failed for " << p;
-    assertWaitForCondition( [&]() { return this->nodeA->GetChildBalance().value() == p.expectedChild; },
+
+    assertWaitForCondition( [&]() { return node->GetChildBalance().value() - initialChild == p.expectedChild; },
                             std::chrono::milliseconds( 20000 ),
                             "Child mint timeout for " + p.tokenValue );
-    EXPECT_EQ( this->nodeA->GetChildBalance().value(), p.expectedChild ) << p;
-    EXPECT_EQ( this->nodeA->GetBalance(), p.expectedMain ) << p;
+
+    EXPECT_EQ( node->GetChildBalance().value() - initialChild, p.expectedChild ) << p;
+    EXPECT_EQ( node->GetBalance() - initialMain, p.expectedMain ) << p;
+
+    boost::filesystem::remove_all( basePath );
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    DISABLED_MintChildVariations,
-    GeniusNodeMintChildTest,
-    ::testing::Values(
-        MintChildCase_s{ .tokenValue = "1.0", .mintChild = 500, .expectedChild = 500, .expectedMain = 500 },
-        MintChildCase_s{ .tokenValue = "0.5", .mintChild = 1000, .expectedChild = 1000, .expectedMain = 500 },
-        MintChildCase_s{ .tokenValue = "1.5", .mintChild = 2000, .expectedChild = 2000, .expectedMain = 3000 } ) );
+INSTANTIATE_TEST_SUITE_P( MintChildVariations,
+                          GeniusNodeMintChildTest,
+                          ::testing::Values( MintChildCase_s{ "1.0", 500, 500, 500 },
+                                             MintChildCase_s{ "0.5", 1000, 1000, 500 },
+                                             MintChildCase_s{ "1.5", 2000, 2000, 3000 } ) );
 
 // ------------------ Suite 3: Transfer Main Tokens ------------------
+/// @brief Parameters for transfer-main tests
 struct TransferMainCase_s
 {
-    std::string tokenValue;
-    uint64_t    mintMain;
-    uint64_t    transferMain;
-    uint64_t    expA_main;
-    uint64_t    expA_child;
-    uint64_t    expB_main;
-    uint64_t    expB_child;
+    std::string tokenValue;   ///< TokenValueInGNUS
+    uint64_t    mintMain;     ///< Mint on nodeA
+    uint64_t    transferMain; ///< Transfer from A to B
+    uint64_t    expA_main;    ///< Expected delta A main
+    uint64_t    expA_child;   ///< Expected delta A child
+    uint64_t    expB_main;    ///< Expected delta B main
+    uint64_t    expB_child;   ///< Expected delta B child
 };
 
 inline std::ostream &operator<<( std::ostream &os, TransferMainCase_s const &c )
@@ -154,49 +156,51 @@ inline std::ostream &operator<<( std::ostream &os, TransferMainCase_s const &c )
               << ", expB_main=" << c.expB_main << ", expB_child=" << c.expB_child << "}";
 }
 
-class GeniusNodeTransferMainTest : public GeniusNodeCommonTest<TransferMainCase_s>
+class GeniusNodeTransferMainTest : public ::testing::TestWithParam<TransferMainCase_s>
 {
 };
 
 TEST_P( GeniusNodeTransferMainTest, DISABLED_TransferMainBalance )
 {
-    auto c = this->GetParam();
-    auto r = this->nodeA->MintTokens( c.mintMain, "", "", "" );
+    auto        c = GetParam();
+    std::string baseA, baseB;
+    auto        nodeA = CreateNode( c.tokenValue, baseA );
+    auto        nodeB = CreateNode( c.tokenValue, baseB );
+
+    uint64_t initA_main  = nodeA->GetBalance();
+    uint64_t initA_child = nodeA->GetChildBalance().value();
+    uint64_t initB_main  = nodeB->GetBalance();
+    uint64_t initB_child = nodeB->GetChildBalance().value();
+
+    auto r = nodeA->MintTokens( c.mintMain, "", "", "" );
     ASSERT_TRUE( r.has_value() ) << "MintTokens failed for " << c;
-    assertWaitForCondition( [&]() { return this->nodeA->GetBalance() == c.mintMain; },
-                            std::chrono::milliseconds( 20000 ) );
-    auto t = this->nodeA->TransferFunds( c.transferMain,
-                                         this->nodeB->GetAddress(),
-                                         std::chrono::milliseconds( 20000 ) );
+
+    auto t = nodeA->TransferFunds( c.transferMain, nodeB->GetAddress(), std::chrono::milliseconds( 20000 ) );
     ASSERT_TRUE( t.has_value() ) << "TransferFunds failed for " << c;
-    assertWaitForCondition( [&]() { return this->nodeA->GetBalance() == c.expA_main; },
-                            std::chrono::milliseconds( 20000 ) );
-    EXPECT_EQ( this->nodeA->GetBalance(), c.expA_main ) << c;
-    EXPECT_EQ( this->nodeA->GetChildBalance().value(), c.expA_child ) << c;
-    assertWaitForCondition( [&]() { return this->nodeB->GetBalance() == c.expB_main; },
-                            std::chrono::milliseconds( 20000 ) );
-    EXPECT_EQ( this->nodeB->GetBalance(), c.expB_main ) << c;
-    EXPECT_EQ( this->nodeB->GetChildBalance().value(), c.expB_child ) << c;
+
+    assertWaitForCondition( [&]() { return nodeA->GetBalance() - initA_main == c.expA_main; },
+                            std::chrono::milliseconds( 20000 ),
+                            "A main timeout for " + c.tokenValue );
+    assertWaitForCondition( [&]() { return nodeB->GetBalance() - initB_main == c.expB_main; },
+                            std::chrono::milliseconds( 20000 ),
+                            "B main timeout for " + c.tokenValue );
+
+    EXPECT_EQ( nodeA->GetBalance() - initA_main, c.expA_main ) << c;
+    EXPECT_EQ( nodeA->GetChildBalance().value() - initA_child, c.expA_child ) << c;
+    EXPECT_EQ( nodeB->GetBalance() - initB_main, c.expB_main ) << c;
+    EXPECT_EQ( nodeB->GetChildBalance().value() - initB_child, c.expB_child ) << c;
+
+    boost::filesystem::remove_all( baseA );
+    boost::filesystem::remove_all( baseB );
 }
 
 INSTANTIATE_TEST_SUITE_P( DISABLED_TransferMainVariations,
                           GeniusNodeTransferMainTest,
-                          ::testing::Values( TransferMainCase_s{ .tokenValue   = "1.0",
-                                                                 .mintMain     = 1000,
-                                                                 .transferMain = 400,
-                                                                 .expA_main    = 600,
-                                                                 .expA_child   = 0,
-                                                                 .expB_main    = 400,
-                                                                 .expB_child   = 0 },
-                                             TransferMainCase_s{ .tokenValue   = "0.5",
-                                                                 .mintMain     = 2000,
-                                                                 .transferMain = 500,
-                                                                 .expA_main    = 1500,
-                                                                 .expA_child   = 0,
-                                                                 .expB_main    = 500,
-                                                                 .expB_child   = 0 } ) );
+                          ::testing::Values( TransferMainCase_s{ "1.0", 1000, 400, 600, 0, 400, 0 },
+                                             TransferMainCase_s{ "0.5", 2000, 500, 1500, 0, 500, 0 } ) );
 
 // ------------------ Suite 4: Transfer Child Tokens ------------------
+/// @brief Parameters for transfer-child tests
 struct TransferChildCase_s
 {
     std::string tokenValue;
@@ -216,52 +220,46 @@ inline std::ostream &operator<<( std::ostream &os, TransferChildCase_s const &c 
               << "}";
 }
 
-class GeniusNodeTransferChildTest : public GeniusNodeCommonTest<TransferChildCase_s>
+class GeniusNodeTransferChildTest : public ::testing::TestWithParam<TransferChildCase_s>
 {
 };
 
 TEST_P( GeniusNodeTransferChildTest, DISABLED_TransferChildBalance )
 {
-    auto c = this->GetParam();
-    auto r = this->nodeA->MintChildTokens( c.mintChild, "", "", "" );
+    auto        c = GetParam();
+    std::string baseA, baseB;
+    auto        nodeA = CreateNode( c.tokenValue, baseA );
+    auto        nodeB = CreateNode( c.tokenValue, baseB );
+
+    uint64_t initA_main  = nodeA->GetBalance();
+    uint64_t initA_child = nodeA->GetChildBalance().value();
+    uint64_t initB_main  = nodeB->GetBalance();
+    uint64_t initB_child = nodeB->GetChildBalance().value();
+
+    auto r = nodeA->MintChildTokens( c.mintChild, "", "", "" );
     ASSERT_TRUE( r.has_value() ) << "MintChildTokens failed for " << c;
-    assertWaitForCondition( [&]()
-                            { return this->nodeA->GetChildBalance().value() == ( c.mintChild - c.transferChild ); },
-                            std::chrono::milliseconds( 20000 ) );
-    auto t = this->nodeA->TransferChildTokens( c.transferChild,
-                                               this->nodeB->GetAddress(),
-                                               std::chrono::milliseconds( 20000 ) );
+
+    auto t = nodeA->TransferChildTokens( c.transferChild, nodeB->GetAddress(), std::chrono::milliseconds( 20000 ) );
     ASSERT_TRUE( t.has_value() ) << "TransferChildTokens failed for " << c;
-    assertWaitForCondition( [&]() { return this->nodeA->GetChildBalance().value() == c.expA_child; },
-                            std::chrono::milliseconds( 20000 ) );
-    EXPECT_EQ( this->nodeA->GetChildBalance().value(), c.expA_child ) << c;
-    EXPECT_EQ( this->nodeA->GetBalance(), c.expA_main ) << c;
-    assertWaitForCondition( [&]() { return this->nodeB->GetChildBalance().value() == c.expB_child; },
-                            std::chrono::milliseconds( 20000 ) );
-    EXPECT_EQ( this->nodeB->GetChildBalance().value(), c.expB_child ) << c;
-    EXPECT_EQ( this->nodeB->GetBalance(), c.expB_main ) << c;
+
+    assertWaitForCondition( [&]() { return nodeA->GetChildBalance().value() - initA_child == c.expA_child; },
+                            std::chrono::milliseconds( 20000 ),
+                            "A child timeout for " + c.tokenValue );
+    assertWaitForCondition( [&]() { return nodeB->GetChildBalance().value() - initB_child == c.expB_child; },
+                            std::chrono::milliseconds( 20000 ),
+                            "B child timeout for " + c.tokenValue );
+
+    EXPECT_EQ( nodeA->GetChildBalance().value() - initA_child, c.expA_child ) << c;
+    EXPECT_EQ( nodeA->GetBalance() - initA_main, c.expA_main ) << c;
+    EXPECT_EQ( nodeB->GetChildBalance().value() - initB_child, c.expB_child ) << c;
+    EXPECT_EQ( nodeB->GetBalance() - initB_main, c.expB_main ) << c;
+
+    boost::filesystem::remove_all( baseA );
+    boost::filesystem::remove_all( baseB );
 }
 
 INSTANTIATE_TEST_SUITE_P( DISABLED_TransferChildVariations,
                           GeniusNodeTransferChildTest,
-                          ::testing::Values( TransferChildCase_s{ .tokenValue    = "1.0",
-                                                                  .mintChild     = 500,
-                                                                  .transferChild = 200,
-                                                                  .expA_main     = 300,
-                                                                  .expA_child    = 300,
-                                                                  .expB_main     = 200,
-                                                                  .expB_child    = 200 },
-                                             TransferChildCase_s{ .tokenValue    = "0.5",
-                                                                  .mintChild     = 1000,
-                                                                  .transferChild = 250,
-                                                                  .expA_main     = 375,
-                                                                  .expA_child    = 750,
-                                                                  .expB_main     = 125,
-                                                                  .expB_child    = 250 },
-                                             TransferChildCase_s{ .tokenValue    = "1.5",
-                                                                  .mintChild     = 300,
-                                                                  .transferChild = 100,
-                                                                  .expA_main     = 150,
-                                                                  .expA_child    = 200,
-                                                                  .expB_main     = 100,
-                                                                  .expB_child    = 100 } ) );
+                          ::testing::Values( TransferChildCase_s{ "1.0", 500, 200, 300, 300, 200, 200 },
+                                             TransferChildCase_s{ "0.5", 1000, 250, 375, 750, 125, 250 },
+                                             TransferChildCase_s{ "1.5", 300, 100, 150, 200, 100, 100 } ) );

--- a/test/src/processing_nodes/child_tokens_test.cpp
+++ b/test/src/processing_nodes/child_tokens_test.cpp
@@ -1,0 +1,267 @@
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+#include <boost/dll.hpp>
+#include <thread>
+#include <cstring>
+#include <ostream>
+
+#include "account/GeniusNode.hpp"
+#include "testutil/wait_condition.hpp"
+
+using namespace sgns::test;
+
+/**
+ * @brief Common fixture for GeniusNode tests.
+ */
+template <typename ParamType>
+class GeniusNodeCommonTest : public ::testing::TestWithParam<ParamType>
+{
+protected:
+    DevConfig_st                      devConfig;
+    std::string                       baseA, baseB;
+    std::unique_ptr<sgns::GeniusNode> nodeA, nodeB;
+
+    void SetUp() override
+    {
+        auto        p          = this->GetParam();
+        std::string binaryPath = boost::dll::program_location().parent_path().string();
+        std::string testName   = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+        baseA                  = binaryPath + "/" + testName + "_A";
+        baseB                  = binaryPath + "/" + testName + "_B";
+
+        boost::filesystem::remove_all( baseA );
+        boost::filesystem::remove_all( baseB );
+        boost::filesystem::create_directories( baseA );
+        boost::filesystem::create_directories( baseB );
+
+        devConfig = { "0xcafe", "0.65", p.tokenValue, 0, "" };
+        std::strncpy( devConfig.BaseWritePath, baseA.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
+        devConfig.BaseWritePath[sizeof( devConfig.BaseWritePath ) - 1] = '\0';
+
+        const char *key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        nodeA           = std::make_unique<sgns::GeniusNode>( devConfig, key, false, false );
+
+        std::strncpy( devConfig.BaseWritePath, baseB.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
+        devConfig.BaseWritePath[sizeof( devConfig.BaseWritePath ) - 1] = '\0';
+        nodeB = std::make_unique<sgns::GeniusNode>( devConfig, key, false, false );
+
+        std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
+    }
+
+    void TearDown() override
+    {
+        nodeA.reset();
+        nodeB.reset();
+        boost::filesystem::remove_all( baseA );
+        boost::filesystem::remove_all( baseB );
+    }
+};
+
+// ------------------ Suite 1: Mint Main Tokens ------------------
+struct MintMainCase_s
+{
+    std::string tokenValue;
+    uint64_t    mintMain;
+    uint64_t    expectedMain;
+    uint64_t    expectedChild;
+};
+
+inline std::ostream &operator<<( std::ostream &os, MintMainCase_s const &c )
+{
+    return os << "MintMainCase_s{tokenValue='" << c.tokenValue << "', mintMain=" << c.mintMain
+              << ", expectedMain=" << c.expectedMain << ", expectedChild=" << c.expectedChild << "}";
+}
+
+class GeniusNodeMintMainTest : public GeniusNodeCommonTest<MintMainCase_s>
+{
+};
+
+TEST_P( GeniusNodeMintMainTest, MintMainBalance )
+{
+    auto p   = this->GetParam();
+    auto res = this->nodeA->MintTokens( p.mintMain, "", "", "" );
+    ASSERT_TRUE( res.has_value() ) << "MintTokens failed for " << p;
+    assertWaitForCondition( [&]() { return this->nodeA->GetBalance() == p.expectedMain; },
+                            std::chrono::milliseconds( 20000 ),
+                            "Main mint timeout for " + p.tokenValue );
+    EXPECT_EQ( this->nodeA->GetBalance(), p.expectedMain ) << p;
+    EXPECT_EQ( this->nodeA->GetChildBalance().value(), p.expectedChild ) << p;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MintMainVariations,
+    GeniusNodeMintMainTest,
+    ::testing::Values(
+        MintMainCase_s{ .tokenValue = "1.0", .mintMain = 1000, .expectedMain = 1000, .expectedChild = 1000 },
+        MintMainCase_s{ .tokenValue = "0.5", .mintMain = 1000, .expectedMain = 1000, .expectedChild = 2000 },
+        MintMainCase_s{ .tokenValue = "1.25", .mintMain = 1000, .expectedMain = 1000, .expectedChild = 800 } ) );
+
+// ------------------ Suite 2: Mint Child Tokens ------------------
+struct MintChildCase_s
+{
+    std::string tokenValue;
+    uint64_t    mintChild;
+    uint64_t    expectedChild;
+    uint64_t    expectedMain;
+};
+
+inline std::ostream &operator<<( std::ostream &os, MintChildCase_s const &c )
+{
+    return os << "MintChildCase_s{tokenValue='" << c.tokenValue << "', mintChild=" << c.mintChild
+              << ", expectedChild=" << c.expectedChild << ", expectedMain=" << c.expectedMain << "}";
+}
+
+class GeniusNodeMintChildTest : public GeniusNodeCommonTest<MintChildCase_s>
+{
+};
+
+TEST_P( GeniusNodeMintChildTest, DISABLED_MintChildBalance )
+{
+    auto p   = this->GetParam();
+    auto res = this->nodeA->MintChildTokens( p.mintChild, "", "", "" );
+    ASSERT_TRUE( res.has_value() ) << "MintChildTokens failed for " << p;
+    assertWaitForCondition( [&]() { return this->nodeA->GetChildBalance().value() == p.expectedChild; },
+                            std::chrono::milliseconds( 20000 ),
+                            "Child mint timeout for " + p.tokenValue );
+    EXPECT_EQ( this->nodeA->GetChildBalance().value(), p.expectedChild ) << p;
+    EXPECT_EQ( this->nodeA->GetBalance(), p.expectedMain ) << p;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DISABLED_MintChildVariations,
+    GeniusNodeMintChildTest,
+    ::testing::Values(
+        MintChildCase_s{ .tokenValue = "1.0", .mintChild = 500, .expectedChild = 500, .expectedMain = 500 },
+        MintChildCase_s{ .tokenValue = "0.5", .mintChild = 1000, .expectedChild = 1000, .expectedMain = 500 },
+        MintChildCase_s{ .tokenValue = "1.5", .mintChild = 2000, .expectedChild = 2000, .expectedMain = 3000 } ) );
+
+// ------------------ Suite 3: Transfer Main Tokens ------------------
+struct TransferMainCase_s
+{
+    std::string tokenValue;
+    uint64_t    mintMain;
+    uint64_t    transferMain;
+    uint64_t    expA_main;
+    uint64_t    expA_child;
+    uint64_t    expB_main;
+    uint64_t    expB_child;
+};
+
+inline std::ostream &operator<<( std::ostream &os, TransferMainCase_s const &c )
+{
+    return os << "TransferMainCase_s{tokenValue='" << c.tokenValue << "', mintMain=" << c.mintMain
+              << ", transferMain=" << c.transferMain << ", expA_main=" << c.expA_main << ", expA_child=" << c.expA_child
+              << ", expB_main=" << c.expB_main << ", expB_child=" << c.expB_child << "}";
+}
+
+class GeniusNodeTransferMainTest : public GeniusNodeCommonTest<TransferMainCase_s>
+{
+};
+
+TEST_P( GeniusNodeTransferMainTest, DISABLED_TransferMainBalance )
+{
+    auto c = this->GetParam();
+    auto r = this->nodeA->MintTokens( c.mintMain, "", "", "" );
+    ASSERT_TRUE( r.has_value() ) << "MintTokens failed for " << c;
+    assertWaitForCondition( [&]() { return this->nodeA->GetBalance() == c.mintMain; },
+                            std::chrono::milliseconds( 20000 ) );
+    auto t = this->nodeA->TransferFunds( c.transferMain,
+                                         this->nodeB->GetAddress(),
+                                         std::chrono::milliseconds( 20000 ) );
+    ASSERT_TRUE( t.has_value() ) << "TransferFunds failed for " << c;
+    assertWaitForCondition( [&]() { return this->nodeA->GetBalance() == c.expA_main; },
+                            std::chrono::milliseconds( 20000 ) );
+    EXPECT_EQ( this->nodeA->GetBalance(), c.expA_main ) << c;
+    EXPECT_EQ( this->nodeA->GetChildBalance().value(), c.expA_child ) << c;
+    assertWaitForCondition( [&]() { return this->nodeB->GetBalance() == c.expB_main; },
+                            std::chrono::milliseconds( 20000 ) );
+    EXPECT_EQ( this->nodeB->GetBalance(), c.expB_main ) << c;
+    EXPECT_EQ( this->nodeB->GetChildBalance().value(), c.expB_child ) << c;
+}
+
+INSTANTIATE_TEST_SUITE_P( DISABLED_TransferMainVariations,
+                          GeniusNodeTransferMainTest,
+                          ::testing::Values( TransferMainCase_s{ .tokenValue   = "1.0",
+                                                                 .mintMain     = 1000,
+                                                                 .transferMain = 400,
+                                                                 .expA_main    = 600,
+                                                                 .expA_child   = 0,
+                                                                 .expB_main    = 400,
+                                                                 .expB_child   = 0 },
+                                             TransferMainCase_s{ .tokenValue   = "0.5",
+                                                                 .mintMain     = 2000,
+                                                                 .transferMain = 500,
+                                                                 .expA_main    = 1500,
+                                                                 .expA_child   = 0,
+                                                                 .expB_main    = 500,
+                                                                 .expB_child   = 0 } ) );
+
+// ------------------ Suite 4: Transfer Child Tokens ------------------
+struct TransferChildCase_s
+{
+    std::string tokenValue;
+    uint64_t    mintChild;
+    uint64_t    transferChild;
+    uint64_t    expA_main;
+    uint64_t    expA_child;
+    uint64_t    expB_main;
+    uint64_t    expB_child;
+};
+
+inline std::ostream &operator<<( std::ostream &os, TransferChildCase_s const &c )
+{
+    return os << "TransferChildCase_s{tokenValue='" << c.tokenValue << "', mintChild=" << c.mintChild
+              << ", transferChild=" << c.transferChild << ", expA_main=" << c.expA_main
+              << ", expA_child=" << c.expA_child << ", expB_main=" << c.expB_main << ", expB_child=" << c.expB_child
+              << "}";
+}
+
+class GeniusNodeTransferChildTest : public GeniusNodeCommonTest<TransferChildCase_s>
+{
+};
+
+TEST_P( GeniusNodeTransferChildTest, DISABLED_TransferChildBalance )
+{
+    auto c = this->GetParam();
+    auto r = this->nodeA->MintChildTokens( c.mintChild, "", "", "" );
+    ASSERT_TRUE( r.has_value() ) << "MintChildTokens failed for " << c;
+    assertWaitForCondition( [&]()
+                            { return this->nodeA->GetChildBalance().value() == ( c.mintChild - c.transferChild ); },
+                            std::chrono::milliseconds( 20000 ) );
+    auto t = this->nodeA->TransferChildTokens( c.transferChild,
+                                               this->nodeB->GetAddress(),
+                                               std::chrono::milliseconds( 20000 ) );
+    ASSERT_TRUE( t.has_value() ) << "TransferChildTokens failed for " << c;
+    assertWaitForCondition( [&]() { return this->nodeA->GetChildBalance().value() == c.expA_child; },
+                            std::chrono::milliseconds( 20000 ) );
+    EXPECT_EQ( this->nodeA->GetChildBalance().value(), c.expA_child ) << c;
+    EXPECT_EQ( this->nodeA->GetBalance(), c.expA_main ) << c;
+    assertWaitForCondition( [&]() { return this->nodeB->GetChildBalance().value() == c.expB_child; },
+                            std::chrono::milliseconds( 20000 ) );
+    EXPECT_EQ( this->nodeB->GetChildBalance().value(), c.expB_child ) << c;
+    EXPECT_EQ( this->nodeB->GetBalance(), c.expB_main ) << c;
+}
+
+INSTANTIATE_TEST_SUITE_P( DISABLED_TransferChildVariations,
+                          GeniusNodeTransferChildTest,
+                          ::testing::Values( TransferChildCase_s{ .tokenValue    = "1.0",
+                                                                  .mintChild     = 500,
+                                                                  .transferChild = 200,
+                                                                  .expA_main     = 300,
+                                                                  .expA_child    = 300,
+                                                                  .expB_main     = 200,
+                                                                  .expB_child    = 200 },
+                                             TransferChildCase_s{ .tokenValue    = "0.5",
+                                                                  .mintChild     = 1000,
+                                                                  .transferChild = 250,
+                                                                  .expA_main     = 375,
+                                                                  .expA_child    = 750,
+                                                                  .expB_main     = 125,
+                                                                  .expB_child    = 250 },
+                                             TransferChildCase_s{ .tokenValue    = "1.5",
+                                                                  .mintChild     = 300,
+                                                                  .transferChild = 100,
+                                                                  .expA_main     = 150,
+                                                                  .expA_child    = 200,
+                                                                  .expB_main     = 100,
+                                                                  .expB_child    = 100 } ) );

--- a/test/src/processing_nodes/child_tokens_test.cpp
+++ b/test/src/processing_nodes/child_tokens_test.cpp
@@ -27,9 +27,9 @@ namespace
         std::string binaryPath = boost::dll::program_location().parent_path().string();
         const char *filePath   = ::testing::UnitTest::GetInstance()->current_test_info()->file();
         std::string fileStem   = std::filesystem::path( filePath ).stem().string();
-        auto        outPath    = binaryPath + "/" + fileStem + "/node" + std::to_string( id ) + "/";
+        auto        outPath    = binaryPath + /*"/" + fileStem +*/ "/node_" + std::to_string( id ) + "/";
 
-        DevConfig_st devConfig = { "0xcafe", "0.65", tokenValue, 0, "" };
+        DevConfig_st devConfig = { "0xcafe", "0.65", tokenValue, "0", "" };
         std::strncpy( devConfig.BaseWritePath, outPath.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
         devConfig.BaseWritePath[sizeof( devConfig.BaseWritePath ) - 1] = '\0';
 

--- a/test/src/processing_nodes/processing_nodes_test.cpp
+++ b/test/src/processing_nodes/processing_nodes_test.cpp
@@ -116,9 +116,9 @@ sgns::GeniusNode *ProcessingNodesTest::node_main  = nullptr;
 sgns::GeniusNode *ProcessingNodesTest::node_proc1 = nullptr;
 sgns::GeniusNode *ProcessingNodesTest::node_proc2 = nullptr;
 
-DevConfig_st ProcessingNodesTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", 0, "./node1" };
-DevConfig_st ProcessingNodesTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", 0, "./node2" };
-DevConfig_st ProcessingNodesTest::DEV_CONFIG3 = { "0xcafe", "0.65", "1.0", 0, "./node3" };
+DevConfig_st ProcessingNodesTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", "0", "./node1" };
+DevConfig_st ProcessingNodesTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", "0", "./node2" };
+DevConfig_st ProcessingNodesTest::DEV_CONFIG3 = { "0xcafe", "0.65", "1.0", "0", "./node3" };
 
 std::string ProcessingNodesTest::binary_path = "";
 

--- a/test/src/processing_nodes/processing_nodes_test.cpp
+++ b/test/src/processing_nodes/processing_nodes_test.cpp
@@ -116,9 +116,9 @@ sgns::GeniusNode *ProcessingNodesTest::node_main  = nullptr;
 sgns::GeniusNode *ProcessingNodesTest::node_proc1 = nullptr;
 sgns::GeniusNode *ProcessingNodesTest::node_proc2 = nullptr;
 
-DevConfig_st ProcessingNodesTest::DEV_CONFIG  = { "0xcafe", "0.65", 1.0, 0, "./node1" };
-DevConfig_st ProcessingNodesTest::DEV_CONFIG2 = { "0xcafe", "0.65", 1.0, 0, "./node2" };
-DevConfig_st ProcessingNodesTest::DEV_CONFIG3 = { "0xcafe", "0.65", 1.0, 0, "./node3" };
+DevConfig_st ProcessingNodesTest::DEV_CONFIG  = { "0xcafe", "0.65", "1.0", 0, "./node1" };
+DevConfig_st ProcessingNodesTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", 0, "./node2" };
+DevConfig_st ProcessingNodesTest::DEV_CONFIG3 = { "0xcafe", "0.65", "1.0", 0, "./node3" };
 
 std::string ProcessingNodesTest::binary_path = "";
 

--- a/test/src/transaction_sync/migration_sync_test.cpp
+++ b/test/src/transaction_sync/migration_sync_test.cpp
@@ -30,7 +30,7 @@ protected:
         "0xcafe", // Addr
         "0.65",   // Cut
         "1.0",    // TokenValueInGNUS
-        0,        // TokenID
+        "0",      // TokenID
         ""        // BaseWritePath
     };
 

--- a/test/src/transaction_sync/migration_sync_test.cpp
+++ b/test/src/transaction_sync/migration_sync_test.cpp
@@ -29,7 +29,7 @@ protected:
     static inline DevConfig_st DEV_CONFIG = {
         "0xcafe", // Addr
         "0.65",   // Cut
-        1.0,      // TokenValueInGNUS
+        "1.0",    // TokenValueInGNUS
         0,        // TokenID
         ""        // BaseWritePath
     };

--- a/test/src/transaction_sync/transaction_sync_test.cpp
+++ b/test/src/transaction_sync/transaction_sync_test.cpp
@@ -38,9 +38,9 @@ namespace sgns
         static inline sgns::GeniusNode *node_proc2 = nullptr;
         static inline sgns::GeniusNode *full_node  = nullptr;
 
-        static inline DevConfig_st DEV_CONFIG  = { "0xcafe", "0.65", 1.0, 0, "./node10" };
-        static inline DevConfig_st DEV_CONFIG2 = { "0xcafe", "0.65", 1.0, 0, "./node20" };
-        static inline DevConfig_st DEV_CONFIG3 = { "0xcafe", "0.65", 1.0, 0, "./node_full" };
+        static inline DevConfig_st DEV_CONFIG  = { "0xcafe", "0.65", "1.0", "0", "./node10" };
+        static inline DevConfig_st DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", "0", "./node20" };
+        static inline DevConfig_st DEV_CONFIG3 = { "0xcafe", "0.65", "1.0", "0", "./node_full" };
 
         static inline std::string binary_path = "";
 

--- a/test/src/transaction_sync/transaction_sync_test.cpp
+++ b/test/src/transaction_sync/transaction_sync_test.cpp
@@ -95,7 +95,8 @@ namespace sgns
             auto maybe_params = sgns::UTXOTxParameters::create( account->utxos,
                                                                 account->GetAddress(),
                                                                 amount,
-                                                                destination );
+                                                                destination,
+                                                                "GNUS Token" );
 
             if ( !maybe_params )
             {


### PR DESCRIPTION
## Overview
Add child-token support by propagating a new `token_id` field through core data structures, transaction flows and examples.

### Added
- `token_id` in `TransferOutput`, `GeniusUTXO`, transaction builders and manager methods  
- Escrow transactions now include `token_id`  
- Example updates and new unit tests for token handling  

### Changed
- Constructors and methods updated to use `std::string tokenId` instead of numeric token  
- Account helper and API calls adjusted for string tokens  
- Protobuf builders regenerated to include `token_id`
- UTXOTxParameters now creates uxtos keeping the original token id

### Removed
- Legacy numeric-token constructors and overloads  
- Redundant `std::to_string` calls on token strings
