### PR TITLE
Full Node support

### DIFF
--- a/example/account_handling/AccountHelper.cpp
+++ b/example/account_handling/AccountHelper.cpp
@@ -134,22 +134,6 @@ namespace sgns
         //Also Find providers
         pubsub_->StartFindingPeers( key );
 
-        // UNCOMMENT THESE NEXT 2 LINES TO CAUSE pubsub_->GetDHT()->Start(); to crash
-        //task_queue_      = std::make_shared<processing::ProcessingTaskQueueImpl>( globaldb_ );
-        //processing_core_ = std::make_shared<processing::ProcessingCoreImpl>( globaldb_, 1000000, 2 );
-
-        //processing_core_->RegisterProcessorFactory( "posenet",
-        //                                            []() { return std::make_unique<processing::MNN_PoseNet>(); } );
-        //processing_service_ = std::make_shared<processing::ProcessingServiceImpl>(
-        //    pubsub_,                                                             //
-        //    MAX_NODES_COUNT,                                                     //
-        //    std::make_shared<processing::SubTaskEnqueuerImpl>( task_queue_ ),    //
-        //    std::make_shared<processing::ProcessSubTaskStateStorage>(),          //
-        //    std::make_shared<processing::SubTaskResultStorageImpl>( globaldb_ ), //
-        //    processing_core_ );
-        //processing_service_->SetChannelListRequestTimeout( boost::posix_time::milliseconds( 10000 ) );
-        //processing_service_->StartProcessing( std::string( PROCESSING_GRID_CHANNEL ) );
-
         io_thread = std::thread( [this]() { io_->run(); } );
     }
 

--- a/example/crdt_globaldb/globaldb_app.cpp
+++ b/example/crdt_globaldb/globaldb_app.cpp
@@ -254,7 +254,7 @@ int main( int argc, char **argv )
                     }
                     Buffer valueBuffer;
                     valueBuffer.put( value );
-                    auto setKeyResult = globalDB->Put( HierarchicalKey( key ), valueBuffer, {} );
+                    auto setKeyResult = globalDB->Put( HierarchicalKey( key ), valueBuffer, {"test"} );
                     if ( setKeyResult.has_failure() )
                     {
                         std::cout << "Unable to put key-value to CRDT datastore: " << key << " " << value << std::endl;

--- a/example/crdt_globaldb/globaldb_app.cpp
+++ b/example/crdt_globaldb/globaldb_app.cpp
@@ -254,7 +254,7 @@ int main( int argc, char **argv )
                     }
                     Buffer valueBuffer;
                     valueBuffer.put( value );
-                    auto setKeyResult = globalDB->Put( HierarchicalKey( key ), valueBuffer );
+                    auto setKeyResult = globalDB->Put( HierarchicalKey( key ), valueBuffer, {} );
                     if ( setKeyResult.has_failure() )
                     {
                         std::cout << "Unable to put key-value to CRDT datastore: " << key << " " << value << std::endl;

--- a/example/node_test/NodeExample.cpp
+++ b/example/node_test/NodeExample.cpp
@@ -147,7 +147,16 @@ void MintTokens( const std::vector<std::string> &args, sgns::GeniusNode &genius_
         std::cerr << "Invalid mint command format.\n";
         return;
     }
-    genius_node.MintTokens( std::stoull( args[1] ), "", "", sgns::TokenID::FromBytes({0x00}) );
+    genius_node.MintTokens( std::stoull( args[1] ), "", "", sgns::TokenID::FromBytes( { 0x00 } ) );
+}
+void TransferTokens( const std::vector<std::string> &args, sgns::GeniusNode &genius_node )
+{
+    if ( args.size() != 3 )
+    {
+        std::cerr << "Invalid mint command format.\n";
+        return;
+    }
+    genius_node.TransferFunds( std::stoull( args[1] ), args[2], sgns::TokenID::FromBytes( { 0x00 } ) );
 }
 
 void GetCoinPrice( const std::vector<std::string> &args, sgns::GeniusNode &genius_node )
@@ -255,6 +264,10 @@ void process_events( sgns::GeniusNode &genius_node )
             else if ( arguments[0] == "mint" )
             {
                 MintTokens( arguments, genius_node );
+            }
+            else if ( arguments[0] == "transfer" )
+            {
+                TransferTokens( arguments, genius_node );
             }
             else if ( arguments[0] == "info" )
             {

--- a/example/processing_dapp/processing_dapp.cpp
+++ b/example/processing_dapp/processing_dapp.cpp
@@ -259,7 +259,7 @@ int main( int argc, char *argv[] )
 
     std::thread iothread( [io]() { io->run(); } );
 
-    auto taskQueue = std::make_shared<ProcessingTaskQueueImpl>( globalDB );
+    auto taskQueue = std::make_shared<ProcessingTaskQueueImpl>( globalDB, "" );
 
     TaskSplitter taskSplitter( options->nSubTasks, options->nChunks, options->addValidationSubtask );
 

--- a/example/processing_dapp/processing_dapp.cpp
+++ b/example/processing_dapp/processing_dapp.cpp
@@ -259,7 +259,7 @@ int main( int argc, char *argv[] )
 
     std::thread iothread( [io]() { io->run(); } );
 
-    auto taskQueue = std::make_shared<ProcessingTaskQueueImpl>( globalDB, "" );
+    auto taskQueue = std::make_shared<ProcessingTaskQueueImpl>( globalDB, "test" );
 
     TaskSplitter taskSplitter( options->nSubTasks, options->nChunks, options->addValidationSubtask );
 

--- a/example/processing_dapp/processing_dapp_processor.cpp
+++ b/example/processing_dapp/processing_dapp_processor.cpp
@@ -339,7 +339,7 @@ int main( int argc, char *argv[] )
 
     std::thread iothread( [io]() { io->run(); } );
 
-    auto taskQueue = std::make_shared<ProcessingTaskQueueImpl>( globalDB, "" );
+    auto taskQueue = std::make_shared<ProcessingTaskQueueImpl>( globalDB, "test" );
 
     auto processingCore                     = std::make_shared<ProcessingCoreImpl>( globalDB,
                                                                 options->subTaskProcessingTime,
@@ -353,7 +353,7 @@ int main( int argc, char *argv[] )
                                              maximalNodesCount,
                                              enqueuer,
                                              std::make_shared<SubTaskStateStorageImpl>(),
-                                             std::make_shared<SubTaskResultStorageImpl>( globalDB, "" ),
+                                             std::make_shared<SubTaskResultStorageImpl>( globalDB, "test" ),
                                              processingCore );
 
     processingService.SetChannelListRequestTimeout(

--- a/example/processing_dapp/processing_dapp_processor.cpp
+++ b/example/processing_dapp/processing_dapp_processor.cpp
@@ -339,7 +339,7 @@ int main( int argc, char *argv[] )
 
     std::thread iothread( [io]() { io->run(); } );
 
-    auto taskQueue = std::make_shared<ProcessingTaskQueueImpl>( globalDB );
+    auto taskQueue = std::make_shared<ProcessingTaskQueueImpl>( globalDB, "" );
 
     auto processingCore                     = std::make_shared<ProcessingCoreImpl>( globalDB,
                                                                 options->subTaskProcessingTime,
@@ -353,7 +353,7 @@ int main( int argc, char *argv[] )
                                              maximalNodesCount,
                                              enqueuer,
                                              std::make_shared<SubTaskStateStorageImpl>(),
-                                             std::make_shared<SubTaskResultStorageImpl>( globalDB ),
+                                             std::make_shared<SubTaskResultStorageImpl>( globalDB, "" ),
                                              processingCore );
 
     processingService.SetChannelListRequestTimeout(

--- a/example/processing_mnn/processing_mnn.cpp
+++ b/example/processing_mnn/processing_mnn.cpp
@@ -285,7 +285,7 @@ int main( int argc, char *argv[] )
     globalDB->Start();
 
     //Split tasks into subtasks
-    auto taskQueue = std::make_shared<sgns::processing::ProcessingTaskQueueImpl>( globalDB, "" );
+    auto taskQueue = std::make_shared<sgns::processing::ProcessingTaskQueueImpl>( globalDB, "test" );
 
     size_t       nSubTasks = chunkOptions.size();
     size_t       nChunks   = 0;

--- a/example/processing_mnn/processing_mnn.cpp
+++ b/example/processing_mnn/processing_mnn.cpp
@@ -285,7 +285,7 @@ int main( int argc, char *argv[] )
     globalDB->Start();
 
     //Split tasks into subtasks
-    auto taskQueue = std::make_shared<sgns::processing::ProcessingTaskQueueImpl>( globalDB );
+    auto taskQueue = std::make_shared<sgns::processing::ProcessingTaskQueueImpl>( globalDB, "" );
 
     size_t       nSubTasks = chunkOptions.size();
     size_t       nChunks   = 0;

--- a/example/processing_mnn/processing_mnn_p.cpp
+++ b/example/processing_mnn/processing_mnn_p.cpp
@@ -115,7 +115,7 @@ int main( int argc, char *argv[] )
     globalDB2->Start();
 
     //Processing Service Values
-    auto taskQueue2 = std::make_shared<sgns::processing::ProcessingTaskQueueImpl>( globalDB2 );
+    auto taskQueue2 = std::make_shared<sgns::processing::ProcessingTaskQueueImpl>( globalDB2, "" );
     auto enqueuer2  = std::make_shared<SubTaskEnqueuerImpl>( taskQueue2 );
 
     //Processing Core
@@ -133,7 +133,7 @@ int main( int argc, char *argv[] )
                                              maximalNodesCount,
                                              enqueuer2,
                                              std::make_shared<SubTaskStateStorageImpl>(),
-                                             std::make_shared<SubTaskResultStorageImpl>( globalDB2 ),
+                                             std::make_shared<SubTaskResultStorageImpl>( globalDB2, "" ),
                                              processingCore2 );
 
     processingService.SetChannelListRequestTimeout( boost::posix_time::milliseconds( 10000 ) );

--- a/example/processing_mnn/processing_mnn_p.cpp
+++ b/example/processing_mnn/processing_mnn_p.cpp
@@ -115,7 +115,7 @@ int main( int argc, char *argv[] )
     globalDB2->Start();
 
     //Processing Service Values
-    auto taskQueue2 = std::make_shared<sgns::processing::ProcessingTaskQueueImpl>( globalDB2, "" );
+    auto taskQueue2 = std::make_shared<sgns::processing::ProcessingTaskQueueImpl>( globalDB2, "test" );
     auto enqueuer2  = std::make_shared<SubTaskEnqueuerImpl>( taskQueue2 );
 
     //Processing Core
@@ -133,7 +133,7 @@ int main( int argc, char *argv[] )
                                              maximalNodesCount,
                                              enqueuer2,
                                              std::make_shared<SubTaskStateStorageImpl>(),
-                                             std::make_shared<SubTaskResultStorageImpl>( globalDB2, "" ),
+                                             std::make_shared<SubTaskResultStorageImpl>( globalDB2, "test" ),
                                              processingCore2 );
 
     processingService.SetChannelListRequestTimeout( boost::posix_time::milliseconds( 10000 ) );

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -299,21 +299,6 @@ namespace sgns
         tx_globaldb_->AddTopicName( processing_channel_topic_ );
         tx_globaldb_->AddListenTopic( processing_channel_topic_ );
 
-        //global_db_ret = crdt::GlobalDB::New( io_,
-        //                                     write_base_path_ + gnus_network_full_path_,
-        //                                     pubsub_,
-        //                                     crdt::CrdtOptions::DefaultOptions(),
-        //                                     graphsyncnetwork,
-        //                                     scheduler,
-        //                                     generator,
-        //                                     tx_globaldb_->GetDataStore() );
-//
-        //if ( global_db_ret.has_error() )
-        //{
-        //    auto error = global_db_ret.error();
-        //    throw std::runtime_error( error.message() );
-        //}
-        //job_globaldb_ = std::move( global_db_ret.value() );
 
         task_queue_      = std::make_shared<processing::ProcessingTaskQueueImpl>( tx_globaldb_, processing_channel_topic_ );
         processing_core_ = std::make_shared<processing::ProcessingCoreImpl>( tx_globaldb_,
@@ -353,10 +338,6 @@ namespace sgns
             throw std::runtime_error( std::string( "Database migration failed: " ) +
                                       migrationResult.error().message() );
         }
-
-        //job_globaldb_->AddBroadcastTopic( processing_channel_topic_ );
-        //job_globaldb_->AddListenTopic( processing_channel_topic_ );
-        //job_globaldb_->Start();
 
         transaction_manager_ = std::make_shared<TransactionManager>( tx_globaldb_,
                                                                      io_,
@@ -574,7 +555,6 @@ namespace sgns
         auto enqueue_task_return = task_queue_->EnqueueTask( task, subTasks );
         if ( enqueue_task_return.has_failure() )
         {
-            task_queue_->ResetAtomicTransaction();
             return outcome::failure( Error::DATABASE_WRITE_ERROR );
         }
         auto send_escrow_return = task_queue_->SendEscrow( escrow_path, std::move( escrow_data ) );

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -151,7 +151,7 @@ namespace sgns
         loggerDAGSyncer->set_level( spdlog::level::err );
         loggerGraphsync->set_level( spdlog::level::err );
         loggerBroadcaster->set_level( spdlog::level::err );
-        loggerDataStore->set_level( spdlog::level::err );
+        loggerDataStore->set_level( spdlog::level::debug );
         loggerTransactions->set_level( spdlog::level::err );
         loggerMigration->set_level( spdlog::level::debug );
         loggerMigrationStep->set_level( spdlog::level::debug );

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -295,6 +295,7 @@ namespace sgns
             throw std::runtime_error( error.message() );
         }
         tx_globaldb_ = std::move( global_db_ret.value() );
+        tx_globaldb_->SetFullNode(is_full_node);
 
         global_db_ret = crdt::GlobalDB::New( io_,
                                              write_base_path_ + gnus_network_full_path_,

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -131,6 +131,7 @@ namespace sgns
         auto loggerGraphsync      = base::createLogger( "graphsync", logdir );
         auto loggerBroadcaster    = base::createLogger( "PubSubBroadcasterExt", logdir );
         auto loggerDataStore      = base::createLogger( "CrdtDatastore", logdir );
+        auto loggerCRDTHeads      = base::createLogger( "CrdtHeads", logdir );
         auto loggerTransactions   = base::createLogger( "TransactionManager", logdir );
         auto loggerMigration      = base::createLogger( "MigrationManager", logdir );
         auto loggerMigrationStep  = base::createLogger( "MigrationStep", logdir );
@@ -152,6 +153,7 @@ namespace sgns
         loggerGraphsync->set_level( spdlog::level::err );
         loggerBroadcaster->set_level( spdlog::level::err );
         loggerDataStore->set_level( spdlog::level::debug );
+        loggerCRDTHeads->set_level( spdlog::level::debug );
         loggerTransactions->set_level( spdlog::level::err );
         loggerMigration->set_level( spdlog::level::debug );
         loggerMigrationStep->set_level( spdlog::level::debug );
@@ -173,6 +175,7 @@ namespace sgns
         loggerGraphsync->set_level( spdlog::level::err );
         loggerBroadcaster->set_level( spdlog::level::err );
         loggerDataStore->set_level( spdlog::level::err );
+        loggerCRDTHeads->set_level( spdlog::level::err );
         loggerTransactions->set_level( spdlog::level::err );
         loggerMigration->set_level( spdlog::level::err );
         loggerMigrationStep->set_level( spdlog::level::err );
@@ -277,8 +280,7 @@ namespace sgns
         pubs.wait();
         auto scheduler = std::make_shared<libp2p::protocol::AsioScheduler>( io_, libp2p::protocol::SchedulerConfig{} );
         auto generator = std::make_shared<ipfs_lite::ipfs::graphsync::RequestIdGenerator>();
-        auto graphsyncnetwork = std::make_shared<ipfs_lite::ipfs::graphsync::Network>( pubsub_->GetHost(),
-                                                                                             scheduler );
+        auto graphsyncnetwork = std::make_shared<ipfs_lite::ipfs::graphsync::Network>( pubsub_->GetHost(), scheduler );
 
         auto global_db_ret = crdt::GlobalDB::New( io_,
                                                   write_base_path_ + gnus_network_full_path_,

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -190,8 +190,6 @@ namespace sgns
 #endif
         node_logger->info( sgns::version::SuperGeniusVersionText() );
 
-        auto tokenid = dev_config_.TokenID;
-
         auto pubsubport = GenerateRandomPort( base_port, account_->GetAddress() );
 
         std::vector<std::string> addresses;

--- a/src/account/Migration0_2_0To1_0_0.cpp
+++ b/src/account/Migration0_2_0To1_0_0.cpp
@@ -255,10 +255,6 @@ namespace sgns
             if ( migrated_count >= BATCH_SIZE )
             {
                 OUTCOME_TRY( crdt_transaction_->Commit( topics_ ) );
-                for ( auto &topic : topics_ )
-                {
-                    m_logger->debug( "Commiting migrating to topics {}", topic );
-                }
                 crdt_transaction_ = newDb_->BeginTransaction(); // start fresh
                 topics_.clear();
                 boost::format full_node_topic{ std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) };

--- a/src/account/Migration0_2_0To1_0_0.cpp
+++ b/src/account/Migration0_2_0To1_0_0.cpp
@@ -218,19 +218,19 @@ namespace sgns
             }
             if ( migrate_tx )
             {
-                topics_.push_back( tx->GetSrcAddress() );
+                topics_.emplace( tx->GetSrcAddress() );
                 if ( auto transfer_tx = std::dynamic_pointer_cast<TransferTransaction>( tx ) )
                 {
                     for ( const auto &dest_info : transfer_tx->GetDstInfos() )
                     {
-                        topics_.push_back( dest_info.dest_address );
+                        topics_.emplace( dest_info.dest_address );
                     }
                 }
                 if ( auto escrow_tx = std::dynamic_pointer_cast<EscrowReleaseTransaction>( tx ) )
                 {
                     if ( escrow_tx->GetSrcAddress() == tx->GetSrcAddress() )
                     {
-                        topics_.push_back( escrow_tx->GetSrcAddress() );
+                        topics_.emplace( escrow_tx->GetSrcAddress() );
                     }
                 }
 
@@ -263,7 +263,7 @@ namespace sgns
                 topics_.clear();
                 boost::format full_node_topic{ std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) };
                 full_node_topic % TransactionManager::TEST_NET_ID;
-                topics_.push_back( full_node_topic.str() );
+                topics_.emplace( full_node_topic.str() );
                 migrated_count = 0;
                 m_logger->debug( "Committed a batch of {} transactions", BATCH_SIZE );
             }
@@ -285,7 +285,7 @@ namespace sgns
         boost::format full_node_topic{ std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) };
         full_node_topic % TransactionManager::TEST_NET_ID;
 
-        topics_.push_back( full_node_topic.str() );
+        topics_.emplace( full_node_topic.str() );
 
         m_logger->debug( "Migrating output DB into new DB" );
         OUTCOME_TRY( auto &&remainder_outdb, MigrateDb( outDb, newDb_ ) );
@@ -299,7 +299,7 @@ namespace sgns
             OUTCOME_TRY( crdt_transaction_->Commit( topics_ ) );
             crdt_transaction_ = newDb_->BeginTransaction();
             topics_.clear();
-            topics_.push_back( full_node_topic.str() );
+            topics_.emplace( full_node_topic.str() );
             m_logger->debug( "Committed remainder of output transactions: {}", remainder_outdb );
         }
 

--- a/src/account/Migration0_2_0To1_0_0.cpp
+++ b/src/account/Migration0_2_0To1_0_0.cpp
@@ -11,6 +11,8 @@
 #include <boost/format.hpp>
 #include <boost/system/error_code.hpp>
 #include "account/TransactionManager.hpp"
+#include "account/TransferTransaction.hpp"
+#include "account/EscrowReleaseTransaction.hpp"
 #include "proof/IBasicProof.hpp"
 #include "MigrationManager.hpp"
 
@@ -109,6 +111,9 @@ namespace sgns
         m_logger->debug( "Found {} transaction keys to migrate", entries.size() );
         size_t migrated_count = 0;
         size_t BATCH_SIZE     = 50;
+
+        boost::format full_node_topic{ std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) };
+        full_node_topic % TransactionManager::TEST_NET_ID;
 
         for ( const auto &entry : entries )
         {
@@ -213,6 +218,22 @@ namespace sgns
             }
             if ( migrate_tx )
             {
+                topics_.push_back( tx->GetSrcAddress() );
+                if ( auto transfer_tx = std::dynamic_pointer_cast<TransferTransaction>( tx ) )
+                {
+                    for ( const auto &dest_info : transfer_tx->GetDstInfos() )
+                    {
+                        topics_.push_back( dest_info.dest_address );
+                    }
+                }
+                if ( auto escrow_tx = std::dynamic_pointer_cast<EscrowReleaseTransaction>( tx ) )
+                {
+                    if ( escrow_tx->GetSrcAddress() == tx->GetSrcAddress() )
+                    {
+                        topics_.push_back( escrow_tx->GetSrcAddress() );
+                    }
+                }
+
                 sgns::crdt::GlobalDB::Buffer data_transaction;
                 data_transaction.put( tx->SerializeByteVector() );
                 BOOST_OUTCOME_TRYV2( auto &&,
@@ -233,9 +254,17 @@ namespace sgns
             ++migrated_count;
             if ( migrated_count >= BATCH_SIZE )
             {
-                OUTCOME_TRY( crdt_transaction_->Commit() );
+                OUTCOME_TRY( crdt_transaction_->Commit( topics_ ) );
+                for ( auto &topic : topics_ )
+                {
+                    m_logger->debug( "Commiting migrating to topics {}", topic );
+                }
                 crdt_transaction_ = newDb_->BeginTransaction(); // start fresh
-                migrated_count    = 0;
+                topics_.clear();
+                boost::format full_node_topic{ std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) };
+                full_node_topic % TransactionManager::TEST_NET_ID;
+                topics_.push_back( full_node_topic.str() );
+                migrated_count = 0;
                 m_logger->debug( "Committed a batch of {} transactions", BATCH_SIZE );
             }
         }
@@ -252,14 +281,25 @@ namespace sgns
         OUTCOME_TRY( auto inDb, InitLegacyDb( "in" ) );
 
         crdt_transaction_ = newDb_->BeginTransaction();
+        topics_.clear();
+        boost::format full_node_topic{ std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) };
+        full_node_topic % TransactionManager::TEST_NET_ID;
+
+        topics_.push_back( full_node_topic.str() );
 
         m_logger->debug( "Migrating output DB into new DB" );
         OUTCOME_TRY( auto &&remainder_outdb, MigrateDb( outDb, newDb_ ) );
 
         if ( remainder_outdb > 0 )
         {
-            OUTCOME_TRY( crdt_transaction_->Commit() );
+            for ( auto &topic : topics_ )
+            {
+                m_logger->debug( "Commiting migrating to topics {}", topic );
+            }
+            OUTCOME_TRY( crdt_transaction_->Commit( topics_ ) );
             crdt_transaction_ = newDb_->BeginTransaction();
+            topics_.clear();
+            topics_.push_back( full_node_topic.str() );
             m_logger->debug( "Committed remainder of output transactions: {}", remainder_outdb );
         }
 
@@ -268,7 +308,11 @@ namespace sgns
 
         if ( remainder_indb > 0 )
         {
-            OUTCOME_TRY( crdt_transaction_->Commit() );
+            for ( auto &topic : topics_ )
+            {
+                m_logger->debug( "Commiting migrating to topics {}", topic );
+            }
+            OUTCOME_TRY( crdt_transaction_->Commit( topics_ ) );
         }
         sgns::crdt::GlobalDB::Buffer version_buffer;
         sgns::crdt::GlobalDB::Buffer version_key;

--- a/src/account/Migration0_2_0To1_0_0.hpp
+++ b/src/account/Migration0_2_0To1_0_0.hpp
@@ -105,7 +105,7 @@ namespace sgns
         std::shared_ptr<crdt::AtomicTransaction> crdt_transaction_; ///< CRDT transaction to make it all atomic
         std::string                              writeBasePath_;    ///< Base path for writing DB files.
         std::string                              base58key_;        ///< Key to build legacy paths.
-        std::vector<std::string>                 topics_;
+        std::set<std::string>                    topics_;
         base::Logger m_logger = base::createLogger( "MigrationStep" ); ///< Logger for this step.
     };
 } // namespace sgns

--- a/src/account/Migration0_2_0To1_0_0.hpp
+++ b/src/account/Migration0_2_0To1_0_0.hpp
@@ -102,9 +102,10 @@ namespace sgns
         std::shared_ptr<ipfs_lite::ipfs::graphsync::Network>            graphsync_; ///< GraphSync network.
         std::shared_ptr<libp2p::protocol::Scheduler>                    scheduler_; ///< libp2p scheduler.
         std::shared_ptr<ipfs_lite::ipfs::graphsync::RequestIdGenerator> generator_; ///< Request ID generator.
-        std::shared_ptr<crdt::AtomicTransaction> crdt_transaction_;    ///< CRDT transaction to make it all atomic
-        std::string                              writeBasePath_;       ///< Base path for writing DB files.
-        std::string                              base58key_;           ///< Key to build legacy paths.
+        std::shared_ptr<crdt::AtomicTransaction> crdt_transaction_; ///< CRDT transaction to make it all atomic
+        std::string                              writeBasePath_;    ///< Base path for writing DB files.
+        std::string                              base58key_;        ///< Key to build legacy paths.
+        std::vector<std::string>                 topics_;
         base::Logger m_logger = base::createLogger( "MigrationStep" ); ///< Logger for this step.
     };
 } // namespace sgns

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -51,16 +51,21 @@ namespace sgns
 
         boost::format full_node_topic{ std::string( GNUS_FULL_NODES_TOPIC ) };
         full_node_topic % TEST_NET_ID;
+        full_node_topic_m = full_node_topic.str();
 
         globaldb_m->AddBroadcastTopic( account_m->GetAddress() );
         globaldb_m->AddListenTopic( account_m->GetAddress() );
-        globaldb_m->AddBroadcastTopic( full_node_topic.str() );
-        globaldb_m->SetTopicName( account_m->GetAddress() );
-        m_logger->info( "Adding broadcast to full node on {}", full_node_topic.str() );
+        globaldb_m->AddBroadcastTopic( full_node_topic_m );
+        m_logger->info( "Adding broadcast to full node on {}", full_node_topic_m );
         if ( full_node_m )
         {
-            m_logger->info( "Listening full node on {}", full_node_topic.str() );
-            globaldb_m->AddListenTopic( full_node_topic.str() );
+            m_logger->info( "Listening full node on {}", full_node_topic_m );
+            globaldb_m->AddListenTopic( full_node_topic_m );
+            globaldb_m->SetTopicName( full_node_topic_m );
+        }
+        else
+        {
+            globaldb_m->SetTopicName( account_m->GetAddress() );
         }
 
         bool crdt_tx_filter_initialized = globaldb_m->RegisterElementFilter(
@@ -510,6 +515,7 @@ namespace sgns
                     topics.emplace( dest_info.dest_address );
                 }
                 topics.emplace( account_m->GetAddress() );
+                topics.emplace( full_node_topic_m );
             }
         }
         BOOST_OUTCOME_TRYV2( auto &&, crdt_transaction->Commit( topics ) );

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -59,12 +59,9 @@ namespace sgns
         {
             m_logger->info( "Listening full node on {}", full_node_topic_m );
             globaldb_m->AddListenTopic( full_node_topic_m );
-            globaldb_m->SetTopicName( full_node_topic_m );
+            globaldb_m->AddTopicName( full_node_topic_m );
         }
-        else
-        {
-            globaldb_m->SetTopicName( account_m->GetAddress() );
-        }
+        globaldb_m->AddTopicName( account_m->GetAddress() );
 
         bool crdt_tx_filter_initialized = globaldb_m->RegisterElementFilter(
             "^/?" + GetBlockChainBase() + "[^/]*/tx/[^/]*/[0-9]+",

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -59,7 +59,6 @@ namespace sgns
         {
             m_logger->info( "Listening full node on {}", full_node_topic_m );
             globaldb_m->AddListenTopic( full_node_topic_m );
-            
         }
         globaldb_m->AddTopicName( full_node_topic_m );
         globaldb_m->AddTopicName( account_m->GetAddress() );
@@ -133,6 +132,8 @@ namespace sgns
                         valid_proof = true;
                         break;
                     }
+                    valid_proof = true;
+                    break;
                     std::vector<uint8_t> proof_data_vector( element.value().begin(), element.value().end() );
                     auto                 maybe_valid_proof = IBasicProof::VerifyFullProof( proof_data_vector );
                     if ( maybe_valid_proof.has_error() || ( !maybe_valid_proof.value() ) )

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -509,6 +509,7 @@ namespace sgns
                 {
                     topics.push_back( dest_info.dest_address );
                 }
+                topics.push_back( account_m->GetAddress() );
             }
         }
         BOOST_OUTCOME_TRYV2( auto &&, crdt_transaction->Commit( topics ) );

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -55,6 +55,7 @@ namespace sgns
         globaldb_m->AddBroadcastTopic( account_m->GetAddress() );
         globaldb_m->AddListenTopic( account_m->GetAddress() );
         globaldb_m->AddBroadcastTopic( full_node_topic.str() );
+        globaldb_m->SetTopicName( account_m->GetAddress() );
         m_logger->info( "Adding broadcast to full node on {}", full_node_topic.str() );
         if ( full_node_m )
         {

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -499,7 +499,7 @@ namespace sgns
                 outgoing_tx_processed_m[GetTransactionPath( *transaction_pair.first )] = transaction_pair.first;
             }
         }
-        std::vector<std::string> topics;
+        std::set<std::string> topics;
         for ( auto &transaction_pair : transaction_batch )
         {
             auto tx = transaction_pair.first;
@@ -507,9 +507,9 @@ namespace sgns
             {
                 for ( const auto &dest_info : transfer_tx->GetDstInfos() )
                 {
-                    topics.push_back( dest_info.dest_address );
+                    topics.emplace( dest_info.dest_address );
                 }
-                topics.push_back( account_m->GetAddress() );
+                topics.emplace( account_m->GetAddress() );
             }
         }
         BOOST_OUTCOME_TRYV2( auto &&, crdt_transaction->Commit( topics ) );

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -50,9 +50,8 @@ namespace sgns
         m_logger->info( "Initializing values by reading whole blockchain" );
 
         boost::format full_node_topic{ std::string( GNUS_FULL_NODES_TOPIC ) };
-
         full_node_topic % TEST_NET_ID;
-        full_node_topic.str();
+
         globaldb_m->AddBroadcastTopic( account_m->GetAddress() );
         globaldb_m->AddListenTopic( account_m->GetAddress() );
         globaldb_m->AddBroadcastTopic( full_node_topic.str() );

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -171,7 +171,7 @@ namespace sgns
 
     void TransactionManager::Start()
     {
-        CheckIncoming( false );
+        CheckIncoming();
         CheckOutgoing();
 
         task_m = [this]()
@@ -401,6 +401,11 @@ namespace sgns
         if ( send_result.has_error() )
         {
             m_logger->error( "Unknown SendTranscation error in SendTransaction::Update()" );
+        }
+        auto check_out_result = CheckOutgoing();
+        if ( check_out_result.has_error() )
+        {
+            m_logger->error( "Unknown CheckOutgoing error in SendTransaction::Update()" );
         }
         auto check_result = CheckIncoming();
         if ( check_result.has_error() )
@@ -676,7 +681,7 @@ namespace sgns
 #endif
     }
 
-    outcome::result<void> TransactionManager::CheckIncoming( bool checkProofs )
+    outcome::result<void> TransactionManager::CheckIncoming()
     {
         m_logger->trace( "Probing incoming transactions on " + GetBlockChainBase() + "!" + account_m->GetAddress() +
                          "/tx" );

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -329,7 +329,7 @@ namespace sgns
 
         OUTCOME_TRY( ( auto &&, peer_total ), escrow_amount_ptr->Multiply( *peers_cut_ptr ) );
 
-        const auto &escrowTokenId = escrow_tx->GetUTXOParameters().outputs_[0].token_id;
+        const auto escrowTokenId = escrow_tx->GetUTXOParameters().outputs_[0].token_id;
 
         uint64_t peers_amount = peer_total.Value() / static_cast<uint64_t>( taskresult.subtask_results().size() );
         auto     remainder    = escrow_tx->GetAmount();

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -498,7 +498,19 @@ namespace sgns
                 outgoing_tx_processed_m[GetTransactionPath( *transaction_pair.first )] = transaction_pair.first;
             }
         }
-        BOOST_OUTCOME_TRYV2( auto &&, crdt_transaction->Commit() );
+        std::vector<std::string> topics;
+        for ( auto &transaction_pair : transaction_batch )
+        {
+            auto tx = transaction_pair.first;
+            if ( auto transfer_tx = std::dynamic_pointer_cast<TransferTransaction>( tx ) )
+            {
+                for ( const auto &dest_info : transfer_tx->GetDstInfos() )
+                {
+                    topics.push_back( dest_info.dest_address );
+                }
+            }
+        }
+        BOOST_OUTCOME_TRYV2( auto &&, crdt_transaction->Commit( topics ) );
 
         return outcome::success();
     }

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -119,7 +119,7 @@ namespace sgns
         outcome::result<bool> CheckProof( const std::shared_ptr<IGeniusTransactions> &tx );
         outcome::result<void> ParseTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
 
-        outcome::result<void> CheckIncoming( bool checkProofs = true );
+        outcome::result<void> CheckIncoming();
 
         outcome::result<void> CheckOutgoing();
 

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -23,6 +23,7 @@
 #include "account/TransferTransaction.hpp"
 #include "account/MintTransaction.hpp"
 #include "account/EscrowTransaction.hpp"
+#include "account/EscrowReleaseTransaction.hpp"
 #include "account/ProcessingTransaction.hpp"
 #include "account/GeniusAccount.hpp"
 #include "base/logger.hpp"

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -132,6 +132,8 @@ namespace sgns
         std::shared_ptr<crypto::Hasher>            hasher_m;
         std::shared_ptr<boost::asio::steady_timer> timer_m;
         bool                                       full_node_m;
+        std::string                                full_node_topic_m; ///< formatted full-node topic
+
         // for the SendTransaction thread support
         mutable std::mutex          mutex_m;
         std::deque<TransactionItem> tx_queue_m;

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -42,6 +42,9 @@ namespace sgns
     class TransactionManager : public std::enable_shared_from_this<TransactionManager>
     {
     public:
+        static constexpr std::uint16_t    MAIN_NET_ID           = 369;
+        static constexpr std::uint16_t    TEST_NET_ID           = 963;
+        static constexpr std::string_view GNUS_FULL_NODES_TOPIC = "SuperGNUSNode.TestNet.FullNode.%hu";
         using TransactionPair  = std::pair<std::shared_ptr<IGeniusTransactions>, std::optional<std::vector<uint8_t>>>;
         using TransactionBatch = std::vector<TransactionPair>;
         using TransactionItem  = std::pair<TransactionBatch, std::optional<std::shared_ptr<crdt::AtomicTransaction>>>;
@@ -97,10 +100,8 @@ namespace sgns
         void EnqueueTransaction( TransactionItem element );
 
     private:
-        static constexpr std::uint16_t    MAIN_NET_ID             = 369;
-        static constexpr std::uint16_t    TEST_NET_ID             = 963;
         static constexpr std::string_view TRANSACTION_BASE_FORMAT = "/bc-%hu/";
-        static constexpr std::string_view GNUS_FULL_NODES_TOPIC   = "SuperGNUSNode.TestNet.FullNode.%hu";
+
         using TransactionParserFn =
             outcome::result<void> ( TransactionManager::* )( const std::shared_ptr<IGeniusTransactions> & );
 

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <map>
 #include <unordered_map>
+#include <set>
 
 #include <boost/format.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
@@ -103,8 +104,9 @@ namespace sgns
     private:
         static constexpr std::string_view TRANSACTION_BASE_FORMAT = "/bc-%hu/";
 
-        using TransactionParserFn =
-            outcome::result<void> ( TransactionManager::* )( const std::shared_ptr<IGeniusTransactions> & );
+        // Parser function pointer alias: returns a set of topic strings or an error
+        using TransactionParserFn = outcome::result<std::set<std::string>> ( TransactionManager::* )(
+            const std::shared_ptr<IGeniusTransactions> & );
 
         void                     Update();
         SGTransaction::DAGStruct FillDAGStruct( std::string transaction_hash = "" ) const;
@@ -118,8 +120,8 @@ namespace sgns
                                                                  const std::shared_ptr<IGeniusTransactions> &tx );
         static outcome::result<std::string> GetExpectedTxKey( const std::string &proof_key );
 
-        outcome::result<bool> CheckProof( const std::shared_ptr<IGeniusTransactions> &tx );
-        outcome::result<void> ParseTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
+        outcome::result<bool>                  CheckProof( const std::shared_ptr<IGeniusTransactions> &tx );
+        outcome::result<std::set<std::string>> ParseTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
 
         outcome::result<void> CheckIncoming();
 
@@ -144,10 +146,12 @@ namespace sgns
         std::map<std::string, std::shared_ptr<IGeniusTransactions>> incoming_tx_processed_m;
         std::function<void()>                                       task_m;
 
-        outcome::result<void> ParseTransferTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
-        outcome::result<void> ParseMintTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
-        outcome::result<void> ParseEscrowTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
-        outcome::result<void> ParseEscrowReleaseTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
+        outcome::result<std::set<std::string>> ParseTransferTransaction(
+            const std::shared_ptr<IGeniusTransactions> &tx );
+        outcome::result<std::set<std::string>> ParseMintTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
+        outcome::result<std::set<std::string>> ParseEscrowTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
+        outcome::result<std::set<std::string>> ParseEscrowReleaseTransaction(
+            const std::shared_ptr<IGeniusTransactions> &tx );
 
         static inline const std::unordered_map<std::string, TransactionParserFn> transaction_parsers = {
             { "transfer", &TransactionManager::ParseTransferTransaction },

--- a/src/blockchain/impl/key_value_block_header_repository.cpp
+++ b/src/blockchain/impl/key_value_block_header_repository.cpp
@@ -58,9 +58,9 @@ namespace sgns::blockchain
         auto header_hash    = hasher_->blake2b_256( encoded_header );
 
         OUTCOME_TRY( ( auto &&, id_string ), idToStringKey( *db_, header.number ) );
-        BOOST_OUTCOME_TRYV2( auto &&, db_->Put( { header_hash.toReadableString() }, NumberToBuffer( header.number ) ) );
+        BOOST_OUTCOME_TRYV2( auto &&, db_->Put( { header_hash.toReadableString() }, NumberToBuffer( header.number ), {} ) );
         BOOST_OUTCOME_TRYV2(
-            auto &&, db_->Put( { block_header_key_prefix + id_string }, base::Buffer{ std::move( encoded_header ) } ) );
+            auto &&, db_->Put( { block_header_key_prefix + id_string }, base::Buffer{ std::move( encoded_header ) }, {} ) );
 
         return header_hash;
     }

--- a/src/blockchain/impl/key_value_block_header_repository.cpp
+++ b/src/blockchain/impl/key_value_block_header_repository.cpp
@@ -58,9 +58,13 @@ namespace sgns::blockchain
         auto header_hash    = hasher_->blake2b_256( encoded_header );
 
         OUTCOME_TRY( ( auto &&, id_string ), idToStringKey( *db_, header.number ) );
-        BOOST_OUTCOME_TRYV2( auto &&, db_->Put( { header_hash.toReadableString() }, NumberToBuffer( header.number ), {} ) );
         BOOST_OUTCOME_TRYV2(
-            auto &&, db_->Put( { block_header_key_prefix + id_string }, base::Buffer{ std::move( encoded_header ) }, {} ) );
+            auto &&,
+            db_->Put( { header_hash.toReadableString() }, NumberToBuffer( header.number ), { "topic" } ) );
+        BOOST_OUTCOME_TRYV2( auto &&,
+                             db_->Put( { block_header_key_prefix + id_string },
+                                       base::Buffer{ std::move( encoded_header ) },
+                                       { "topic" } ) );
 
         return header_hash;
     }
@@ -69,7 +73,7 @@ namespace sgns::blockchain
     {
         OUTCOME_TRY( ( auto &&, header_string_val ), idToStringKey( *db_, id ) );
 
-        return db_->Remove( { block_header_key_prefix + header_string_val } );
+        return db_->Remove( { block_header_key_prefix + header_string_val }, { "topic" } );
     }
 
     outcome::result<BlockStatus> KeyValueBlockHeaderRepository::getBlockStatus( const primitives::BlockId &id ) const

--- a/src/blockchain/impl/key_value_block_storage.cpp
+++ b/src/blockchain/impl/key_value_block_storage.cpp
@@ -119,7 +119,7 @@ namespace sgns::blockchain
 
         OUTCOME_TRY( ( auto &&, genesis_block_hash ), block_storage->putBlock( genesis_block ) );
         BOOST_OUTCOME_TRYV2( auto &&,
-                             db->Put( { storage::GetGenesisBlockHashLookupKey() }, Buffer{ genesis_block_hash } ) );
+                             db->Put( { storage::GetGenesisBlockHashLookupKey() }, Buffer{ genesis_block_hash }, {} ) );
         BOOST_OUTCOME_TRYV2( auto &&, block_storage->setLastFinalizedBlockHash( genesis_block_hash ) );
 
         on_genesis_created( genesis_block );
@@ -196,7 +196,7 @@ namespace sgns::blockchain
         //TODO - For now one block data per block header. Revisit this
         BOOST_OUTCOME_TRYV2(
             auto &&,
-            db_->Put( { header_repo_->GetHeaderPath() + id_string + "/tx/0" }, Buffer{ encoded_block_data } ) );
+            db_->Put( { header_repo_->GetHeaderPath() + id_string + "/tx/0" }, Buffer{ encoded_block_data }, {} ) );
 
         //BOOST_OUTCOME_TRYV2(auto &&, putWithPrefix(*db_,
         //                          Prefix::BLOCK_DATA,
@@ -322,7 +322,7 @@ namespace sgns::blockchain
         hash_proto.SerializeToArray( serialized_proto.data(), serialized_proto.size() );
         BOOST_OUTCOME_TRYV2(
             auto &&,
-            db_->Put( { storage::GetLastFinalizedBlockHashLookupKey() }, Buffer{ serialized_proto } ) );
+            db_->Put( { storage::GetLastFinalizedBlockHashLookupKey() }, Buffer{ serialized_proto }, {} ) );
 
         return outcome::success();
     }

--- a/src/blockchain/impl/key_value_block_storage.cpp
+++ b/src/blockchain/impl/key_value_block_storage.cpp
@@ -119,7 +119,7 @@ namespace sgns::blockchain
 
         OUTCOME_TRY( ( auto &&, genesis_block_hash ), block_storage->putBlock( genesis_block ) );
         BOOST_OUTCOME_TRYV2( auto &&,
-                             db->Put( { storage::GetGenesisBlockHashLookupKey() }, Buffer{ genesis_block_hash }, {} ) );
+                             db->Put( { storage::GetGenesisBlockHashLookupKey() }, Buffer{ genesis_block_hash }, {"topic"} ) );
         BOOST_OUTCOME_TRYV2( auto &&, block_storage->setLastFinalizedBlockHash( genesis_block_hash ) );
 
         on_genesis_created( genesis_block );
@@ -196,7 +196,7 @@ namespace sgns::blockchain
         //TODO - For now one block data per block header. Revisit this
         BOOST_OUTCOME_TRYV2(
             auto &&,
-            db_->Put( { header_repo_->GetHeaderPath() + id_string + "/tx/0" }, Buffer{ encoded_block_data }, {} ) );
+            db_->Put( { header_repo_->GetHeaderPath() + id_string + "/tx/0" }, Buffer{ encoded_block_data }, {"topic"} ) );
 
         //BOOST_OUTCOME_TRYV2(auto &&, putWithPrefix(*db_,
         //                          Prefix::BLOCK_DATA,
@@ -266,7 +266,7 @@ namespace sgns::blockchain
         OUTCOME_TRY( ( auto &&, key ), idToBufferKey( *db_, number ) );
 
         //TODO - For now one block data per block header. Revisit this
-        return db_->Remove( { header_repo_->GetHeaderPath() + std::string( key.toString() ) + "/tx/0" } );
+        return db_->Remove( { header_repo_->GetHeaderPath() + std::string( key.toString() ) + "/tx/0" }, {"topic"} );
     }
 
     outcome::result<primitives::BlockHash> KeyValueBlockStorage::getGenesisBlockHash() const
@@ -322,7 +322,7 @@ namespace sgns::blockchain
         hash_proto.SerializeToArray( serialized_proto.data(), serialized_proto.size() );
         BOOST_OUTCOME_TRYV2(
             auto &&,
-            db_->Put( { storage::GetLastFinalizedBlockHashLookupKey() }, Buffer{ serialized_proto }, {} ) );
+            db_->Put( { storage::GetLastFinalizedBlockHashLookupKey() }, Buffer{ serialized_proto }, {"topic"} ) );
 
         return outcome::success();
     }

--- a/src/blockchain/impl/storage_util.cpp
+++ b/src/blockchain/impl/storage_util.cpp
@@ -32,9 +32,9 @@ namespace sgns::blockchain {
         prependPrefix(NumberToBuffer(num), Prefix::ID_TO_LOOKUP_KEY);
     auto hash_to_idx_key =
         prependPrefix(Buffer{block_hash}, Prefix::ID_TO_LOOKUP_KEY);
-    BOOST_OUTCOME_TRYV2(auto &&, db.Put({"num_to_idx_key"}, block_lookup_key));
-    BOOST_OUTCOME_TRYV2(auto &&, db.Put({"hash_to_idx_key"}, block_lookup_key));
-    return db.Put({"value_lookup_key"}, value);
+    BOOST_OUTCOME_TRYV2(auto &&, db.Put({"num_to_idx_key"}, block_lookup_key, {}));
+    BOOST_OUTCOME_TRYV2(auto &&, db.Put({"hash_to_idx_key"}, block_lookup_key, {}));
+    return db.Put({"value_lookup_key"}, value, {});
   }
 
 

--- a/src/blockchain/impl/storage_util.cpp
+++ b/src/blockchain/impl/storage_util.cpp
@@ -32,9 +32,9 @@ namespace sgns::blockchain {
         prependPrefix(NumberToBuffer(num), Prefix::ID_TO_LOOKUP_KEY);
     auto hash_to_idx_key =
         prependPrefix(Buffer{block_hash}, Prefix::ID_TO_LOOKUP_KEY);
-    BOOST_OUTCOME_TRYV2(auto &&, db.Put({"num_to_idx_key"}, block_lookup_key, {}));
-    BOOST_OUTCOME_TRYV2(auto &&, db.Put({"hash_to_idx_key"}, block_lookup_key, {}));
-    return db.Put({"value_lookup_key"}, value, {});
+    BOOST_OUTCOME_TRYV2(auto &&, db.Put({"num_to_idx_key"}, block_lookup_key, {"topic"}));
+    BOOST_OUTCOME_TRYV2(auto &&, db.Put({"hash_to_idx_key"}, block_lookup_key, {"topic"}));
+    return db.Put({"value_lookup_key"}, value, {"topic"});
   }
 
 

--- a/src/crdt/CMakeLists.txt
+++ b/src/crdt/CMakeLists.txt
@@ -9,7 +9,6 @@ supergenius_install(hierarchical_key)
 
 add_proto_library(crdt_delta proto/delta.proto)
 add_proto_library(crdt_bcast proto/bcast.proto)
-add_proto_library(crdt_proto_heads proto/heads.proto)
 add_library(crdt_set
     impl/crdt_set.cpp
 )
@@ -30,7 +29,6 @@ target_link_libraries(crdt_heads
     hierarchical_key
     rocksdb
     ipfs-lite-cpp::cid
-    crdt_proto_heads
 )
 supergenius_install(crdt_heads)
 
@@ -72,7 +70,6 @@ target_link_libraries(crdt_datastore
     logger
     PRIVATE
     crdt_bcast
-    crdt_proto_heads
 )
 supergenius_install(crdt_datastore)
 

--- a/src/crdt/CMakeLists.txt
+++ b/src/crdt/CMakeLists.txt
@@ -9,6 +9,7 @@ supergenius_install(hierarchical_key)
 
 add_proto_library(crdt_delta proto/delta.proto)
 add_proto_library(crdt_bcast proto/bcast.proto)
+add_proto_library(crdt_proto_heads proto/heads.proto)
 add_library(crdt_set
     impl/crdt_set.cpp
 )
@@ -29,6 +30,7 @@ target_link_libraries(crdt_heads
     hierarchical_key
     rocksdb
     ipfs-lite-cpp::cid
+    crdt_proto_heads
 )
 supergenius_install(crdt_heads)
 
@@ -70,6 +72,7 @@ target_link_libraries(crdt_datastore
     logger
     PRIVATE
     crdt_bcast
+    crdt_proto_heads
 )
 supergenius_install(crdt_datastore)
 

--- a/src/crdt/atomic_transaction.hpp
+++ b/src/crdt/atomic_transaction.hpp
@@ -81,7 +81,6 @@ namespace sgns::crdt
          * @param[in] topic Optional topic name for targeted publishing. If not provided, the default broadcast behavior is used.
          * @return outcome::success on successful commit, or outcome::failure if an error occurs.
          */
-        outcome::result<void> Commit();
         outcome::result<void> Commit(const std::set<std::string>& topics);
 
     private:

--- a/src/crdt/atomic_transaction.hpp
+++ b/src/crdt/atomic_transaction.hpp
@@ -82,6 +82,7 @@ namespace sgns::crdt
          * @return outcome::success on successful commit, or outcome::failure if an error occurs.
          */
         outcome::result<void> Commit();
+        outcome::result<void> Commit(const std::vector<std::string>& topics);
 
     private:
         enum class Operation

--- a/src/crdt/atomic_transaction.hpp
+++ b/src/crdt/atomic_transaction.hpp
@@ -82,7 +82,7 @@ namespace sgns::crdt
          * @return outcome::success on successful commit, or outcome::failure if an error occurs.
          */
         outcome::result<void> Commit();
-        outcome::result<void> Commit(const std::vector<std::string>& topics);
+        outcome::result<void> Commit(const std::set<std::string>& topics);
 
     private:
         enum class Operation

--- a/src/crdt/broadcaster.hpp
+++ b/src/crdt/broadcaster.hpp
@@ -27,7 +27,7 @@ namespace sgns::crdt
          * Send {@param buff} payload to other replicas.
          * @return outcome::success on success or outcome::failure on error.
          */
-        virtual outcome::result<void> Broadcast( const base::Buffer &buff ) = 0;
+        virtual outcome::result<void> Broadcast( const base::Buffer &buff, std::string topic ) = 0;
 
         /**
          * Obtain the next payload and its topic received from the network.

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -141,7 +141,7 @@ namespace sgns::crdt
         * @param aKey HierarchicalKey to delete from set
         * @return outcome::failure on error or success otherwise
         */
-        outcome::result<void> DeleteKey( const HierarchicalKey &aKey );
+        outcome::result<void> DeleteKey( const HierarchicalKey &aKey, const std::set<std::string> &topics );
 
         /**
          * @brief Publishes a Delta.
@@ -149,7 +149,6 @@ namespace sgns::crdt
          * @param aDelta Delta to publish
          * @return returns outcome::success on success or outcome::failure otherwise
          */
-        outcome::result<CID> Publish( const std::shared_ptr<Delta> &aDelta );
         outcome::result<CID> Publish( const std::shared_ptr<Delta> &aDelta, const std::set<std::string> &topics );
 
         /** PrintDAG pretty prints the current Merkle-DAG using the given printFunc

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -199,9 +199,9 @@ namespace sgns::crdt
          *   The topic name to use when filtering links. Only links whose
          *   `IPLDLinkImpl::getName()` equals this string will be processed.
          */
-        void SetTopicName( const std::string &topic )
+        void AddTopicName( const std::string &topic )
         {
-            topicName_ = topic;
+            topicNames_.emplace( topic );
         }
 
     protected:
@@ -381,7 +381,7 @@ namespace sgns::crdt
 
         std::mutex              rebroadcastMutex_;
         std::condition_variable rebroadcastCv_;
-        std::string             topicName_;
+        std::set<std::string>   topicNames_;
     };
 
 } // namespace sgns::crdt

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -149,6 +149,7 @@ namespace sgns::crdt
          * @return returns outcome::success on success or outcome::failure otherwise
          */
         outcome::result<CID> Publish( const std::shared_ptr<Delta> &aDelta );
+        outcome::result<CID> Publish( const std::shared_ptr<Delta> &aDelta, const std::vector<std::string> &topics );
 
         /** PrintDAG pretty prints the current Merkle-DAG using the given printFunc
     * @return returns outcome::success on success or outcome::failure otherwise
@@ -300,15 +301,15 @@ namespace sgns::crdt
     * @param aDelta Delta to serialize into IPLD node
     * @return IPLD node or outcome::failure on error
     */
-        outcome::result<std::shared_ptr<IPLDNode>> PutBlock( const std::vector<CID>       &aHeads,
+        outcome::result<std::shared_ptr<IPLDNode>> PutBlock( const std::vector<std::pair<CID, std::string>>& aHeads,
                                                              const std::shared_ptr<Delta> &aDelta );
 
         /** AddDAGNode adds node to DAGSyncer and processes new blocks.
-    * @param aDelta Pointer to Delta used for generating node and process it
-    * @return CID or outcome::failure on error
-    * \sa PutBlock, ProcessNode
-    */
-        outcome::result<CID> AddDAGNode( const std::shared_ptr<Delta> &aDelta );
+         *  @param aDelta   Pointer to Delta used for generating node and process it
+         *  @param topics   Vector of topic names; the new block will have one link per topic
+         *  @return         CID or outcome::failure on error
+         */
+        outcome::result<CID> AddDAGNode( const std::shared_ptr<Delta> &aDelta, const std::vector<std::string> &topics );
 
         /** SyncDatastore sync heads and set datastore
     * @param: aKeyList all heads and the set entries related to the given prefix

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -295,8 +295,7 @@ namespace sgns::crdt
                                                        uint64_t                         aRootPrio,
                                                        std::shared_ptr<Delta>           aDelta,
                                                        const std::shared_ptr<IPLDNode> &aNode,
-                                                       bool                             filter_crdt = false,
-                                                       std::set<std::string>            node_topics = {} );
+                                                       bool                             filter_crdt = false );
 
         /** PutBlock add block node to DAGSyncer
     * @param aHeads list of CIDs to add to node as IPLD links
@@ -304,7 +303,8 @@ namespace sgns::crdt
     * @return IPLD node or outcome::failure on error
     */
         outcome::result<std::shared_ptr<IPLDNode>> PutBlock( const std::vector<std::pair<CID, std::string>> &aHeads,
-                                                             const std::shared_ptr<Delta>                   &aDelta );
+                                                             const std::shared_ptr<Delta>                   &aDelta,
+                                                             std::set<std::string>                           topics );
 
         /** AddDAGNode adds node to DAGSyncer and processes new blocks.
          *  @param aDelta   Pointer to Delta used for generating node and process it

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -177,11 +177,6 @@ namespace sgns::crdt
 
         void PrintDataStore();
 
-        auto GetDB()
-        {
-            return dataStore_->getDB();
-        }
-
         /** Close shuts down the CRDT datastore and worker threads. It should not be used afterwards.
     */
         void Close();

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -246,7 +246,7 @@ namespace sgns::crdt
     */
         outcome::result<void> SendNewJobs( const CID                &aRootCID,
                                            uint64_t                  aRootPriority,
-                                           const std::vector<CID>   &aChildren,
+                                           const std::set<CID>      &aChildren,
                                            std::shared_ptr<IPLDNode> aRootNode = nullptr );
 
         /** Sync ensures that all the data under the given prefix is flushed to disk in
@@ -295,11 +295,11 @@ namespace sgns::crdt
     * @param aNode Pointer to IPLD node
     * @return list of CIDs or outcome::failure on error
     */
-        outcome::result<std::vector<CID>> ProcessNode( const CID                       &aRoot,
-                                                       uint64_t                         aRootPrio,
-                                                       std::shared_ptr<Delta>           aDelta,
-                                                       const std::shared_ptr<IPLDNode> &aNode,
-                                                       bool                             filter_crdt = false );
+        outcome::result<std::set<CID>> ProcessNode( const CID                       &aRoot,
+                                                    uint64_t                         aRootPrio,
+                                                    std::shared_ptr<Delta>           aDelta,
+                                                    const std::shared_ptr<IPLDNode> &aNode,
+                                                    bool                             filter_crdt = false );
 
         /** PutBlock add block node to DAGSyncer
     * @param aHeads list of CIDs to add to node as IPLD links

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -187,6 +187,21 @@ namespace sgns::crdt
 
         bool RegisterElementFilter( const std::string &pattern, CRDTElementFilterCallback filter );
 
+        /**
+         * @brief Configure which topic this datastore should filter on.
+         *
+         * When processing or rebroadcasting Merkle-DAG links, only those whose
+         * name exactly matches the topic set via this call will be considered.
+         *
+         * @param[in] topic
+         *   The topic name to use when filtering links. Only links whose
+         *   `IPLDLinkImpl::getName()` equals this string will be processed.
+         */
+        void SetTopicName( const std::string &topic )
+        {
+            topicName_ = topic;
+        }
+
     protected:
         /** DAG jobs structure used by DAG worker threads to send new jobs
     */
@@ -363,6 +378,7 @@ namespace sgns::crdt
 
         std::mutex              rebroadcastMutex_;
         std::condition_variable rebroadcastCv_;
+        std::string             topicName_;
     };
 
 } // namespace sgns::crdt

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -129,7 +129,7 @@ namespace sgns::crdt
          * @param aValue Value to be stored
          * @return outcome::success if stored and broadcasted successfully, or outcome::failure otherwise.
          */
-        outcome::result<void> PutKey( const HierarchicalKey &aKey, const Buffer &aValue );
+        outcome::result<void> PutKey( const HierarchicalKey &aKey, const Buffer &aValue, std::set<std::string> topics );
 
         /** HasKey returns whether the `key` is mapped to a `value` in set
         * @param aKey HierarchicalKey to look for in set

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -295,15 +295,16 @@ namespace sgns::crdt
                                                        uint64_t                         aRootPrio,
                                                        std::shared_ptr<Delta>           aDelta,
                                                        const std::shared_ptr<IPLDNode> &aNode,
-                                                       bool                             filter_crdt = false );
+                                                       bool                             filter_crdt = false,
+                                                       std::set<std::string>            node_topics = {} );
 
         /** PutBlock add block node to DAGSyncer
     * @param aHeads list of CIDs to add to node as IPLD links
     * @param aDelta Delta to serialize into IPLD node
     * @return IPLD node or outcome::failure on error
     */
-        outcome::result<std::shared_ptr<IPLDNode>> PutBlock( const std::vector<std::pair<CID, std::string>>& aHeads,
-                                                             const std::shared_ptr<Delta> &aDelta );
+        outcome::result<std::shared_ptr<IPLDNode>> PutBlock( const std::vector<std::pair<CID, std::string>> &aHeads,
+                                                             const std::shared_ptr<Delta>                   &aDelta );
 
         /** AddDAGNode adds node to DAGSyncer and processes new blocks.
          *  @param aDelta   Pointer to Delta used for generating node and process it

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -269,13 +269,13 @@ namespace sgns::crdt
          * @param[in] cids The list of CIDs to broadcast.
          * @return outcome::success on success, or outcome::failure if an error occurs.
          */
-        outcome::result<void> Broadcast( const std::vector<CID> &cids );
+        outcome::result<void> Broadcast( const std::set<CID> &cids, std::string topic );
 
         /** EncodeBroadcast encodes list of CIDs to CRDT broadcast data
     * @param heads list of CIDs
     * @return data encoded into Buffer data or outcome::failure on error
     */
-        static outcome::result<Buffer> EncodeBroadcast( const std::vector<CID> &heads );
+        static outcome::result<Buffer> EncodeBroadcast( const std::set<CID> &heads );
 
         /** handleBlock takes care of vetting, retrieving and applying
     * CRDT blocks to the Datastore.

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -237,7 +237,7 @@ namespace sgns::crdt
     * @param aCrdtDatastore pointer to CRDT datastore
     * @param dagWorker pointer to DAG worker structure
     */
-        void SendJobWorkerIteration( std::shared_ptr<DagWorker> dagWorker, DagJob &dagJob );
+        void SendJobWorkerIteration( std::shared_ptr<DagWorker> dagWorker );
 
         /** SendNewJobs calls getDeltas with the given children and sends each response to the workers.
     * @param aRootCID root CID

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -204,6 +204,11 @@ namespace sgns::crdt
             topicNames_.emplace( topic );
         }
 
+        void SetFullNode( bool full_node )
+        {
+            isFullNode = std::move( full_node );
+        }
+
     protected:
         /** DAG jobs structure used by DAG worker threads to send new jobs
     */
@@ -382,6 +387,7 @@ namespace sgns::crdt
         std::mutex              rebroadcastMutex_;
         std::condition_variable rebroadcastCv_;
         std::set<std::string>   topicNames_;
+        bool                    isFullNode = false;
     };
 
 } // namespace sgns::crdt

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -150,7 +150,7 @@ namespace sgns::crdt
          * @return returns outcome::success on success or outcome::failure otherwise
          */
         outcome::result<CID> Publish( const std::shared_ptr<Delta> &aDelta );
-        outcome::result<CID> Publish( const std::shared_ptr<Delta> &aDelta, const std::vector<std::string> &topics );
+        outcome::result<CID> Publish( const std::shared_ptr<Delta> &aDelta, const std::set<std::string> &topics );
 
         /** PrintDAG pretty prints the current Merkle-DAG using the given printFunc
     * @return returns outcome::success on success or outcome::failure otherwise
@@ -310,7 +310,7 @@ namespace sgns::crdt
          *  @param topics   Vector of topic names; the new block will have one link per topic
          *  @return         CID or outcome::failure on error
          */
-        outcome::result<CID> AddDAGNode( const std::shared_ptr<Delta> &aDelta, const std::vector<std::string> &topics );
+        outcome::result<CID> AddDAGNode( const std::shared_ptr<Delta> &aDelta, const std::set<std::string> &topics );
 
         /** SyncDatastore sync heads and set datastore
     * @param: aKeyList all heads and the set entries related to the given prefix

--- a/src/crdt/crdt_heads.hpp
+++ b/src/crdt/crdt_heads.hpp
@@ -3,135 +3,139 @@
 
 #include <mutex>
 #include <storage/rocksdb/rocksdb.hpp>
+#include "base/logger.hpp"
 #include "crdt/hierarchical_key.hpp"
 #include <primitives/cid/cid.hpp>
 #include <map>
+#include <set>
 
 namespace sgns::crdt
 {
-  /** @brief CrdtHeads manages the current Merkle-CRDT heads.
+    /** @brief CrdtHeads manages the current Merkle-CRDT heads.
   */
-  class CrdtHeads
-  {
-  public:
-    using DataStore = storage::rocksdb;
-    using Buffer = base::Buffer;
+    class CrdtHeads
+    {
+    public:
+        using DataStore = storage::rocksdb;
+        using Buffer    = base::Buffer;
+        using CRDTHeadList = std::unordered_map<std::string, std::set<CID>>;
+        using CRDTListResult = std::pair<CRDTHeadList, uint64_t>;
 
-    /** Constructor
-    * @param aDatastore Pointer to datastore
-    * @param aNamespace Namespce key (e.g "/namespace")
-    */
-    CrdtHeads( std::shared_ptr<DataStore> aDatastore, const HierarchicalKey &aNamespace );
+        /** Constructor
+        * @param aDatastore Pointer to datastore
+        * @param aNamespace Namespce key (e.g "/namespace")
+        */
+        CrdtHeads( std::shared_ptr<DataStore> aDatastore, const HierarchicalKey &aNamespace );
 
-    /** Copy constructor
-    */
-    CrdtHeads(const CrdtHeads&);
+        /** Copy constructor
+         */
+        CrdtHeads( const CrdtHeads & );
 
-    /** Destructor
-    */
-    virtual ~CrdtHeads() = default;
+        /**
+         * @brief      Destroy the Crdt Heads object
+         */
+        virtual ~CrdtHeads() = default;
 
-    /** Equality operator
-    * @return true if equal otherwise, it returns false.
-    */
-    bool operator==(const CrdtHeads&);
+        /** Equality operator
+        * @return true if equal otherwise, it returns false.
+        */
+        bool operator==( const CrdtHeads & );
 
-    /** Equality operator
+        /** Equality operator
     * @return true if NOT equal otherwise, it returns false.
     */
-    bool operator!=(const CrdtHeads&);
+        bool operator!=( const CrdtHeads & );
 
-    /** Assignment operator
+        /** Assignment operator
     */
-    CrdtHeads& operator=(const CrdtHeads&);
+        CrdtHeads &operator=( const CrdtHeads & );
 
-    /** Get namespace hierarchical key
+        /** Get namespace hierarchical key
     */
-    HierarchicalKey GetNamespaceKey() const;
+        HierarchicalKey GetNamespaceKey() const;
 
-    /** Get full path to CID key
+        /** Get full path to CID key
     *   /<namespace>/<cid>
     * @param aCid Content identifier
     * @return full path to CID key as HierarchicalKey or outcome::failure on error
     */
-    outcome::result<HierarchicalKey> GetKey(const CID& aCid);
+        outcome::result<HierarchicalKey> GetKey( const CID &aCid );
 
-    /** Check if CID is among the current heads.
+        /** Check if CID is among the current heads.
     * @param aCid Content identifier
     * @return true is CID is head, false otherwise
     */
-    bool IsHead( const CID& aCid, const std::string &topic = "" );
+        bool IsHead( const CID &aCid, const std::string &topic = "" );
 
-    /** Check if CID is head and return it height if it is
+        /** Check if CID is head and return it height if it is
     * @param aCid Content identifier
     * @return Height of head or outcome::failure on error
     */
-    outcome::result<uint64_t> GetHeadHeight(const CID& aCid, const std::string &topic = "");
+        outcome::result<uint64_t> GetHeadHeight( const CID &aCid, const std::string &topic = "" );
 
-    /** Get current number of heads
+        /** Get current number of heads
     * @return lenght, current number of heads or outcome::failure on error
     */
-    outcome::result<int> GetLength( const std::string &topic = "" );
+        outcome::result<int> GetLength( const std::string &topic = "" );
 
-    /** Add head CID to datastore with full namespace
+        /** Add head CID to datastore with full namespace
     * @param aCid Content identifier
     * @param aHeight height of head
     * @return outcome::failure on error
     */
-    outcome::result<void> Add( const CID &aCid, uint64_t aHeight, const std::string &topic );
+        outcome::result<void> Add( const CID &aCid, uint64_t aHeight, const std::string &topic );
 
-    /** Replace a head with a new cid.
+        /** Replace a head with a new cid.
     * @param aCidHead Content identifier of head to replace
     * @param aNewHeadCid Content identifier of new head
     * @param aHeight height of head
     * @return outcome::failure on error
     */
-    outcome::result<void> Replace( const CID &aCidHead, const CID &aNewHeadCid, uint64_t aHeight, const std::string &topic );
+        outcome::result<void> Replace( const CID         &aCidHead,
+                                       const CID         &aNewHeadCid,
+                                       uint64_t           aHeight,
+                                       const std::string &topic );
 
-    /** Returns the list of current heads plus the max height.
+        /** Returns the list of current heads plus the max height.
     * @param aHeads output reference to list of CIDs
     * @param aMaxHeight output reference to maximum height
     * @return outcome::failure on error
     */
-    outcome::result<void> GetList(std::vector<CID>& aHeads, uint64_t& aMaxHeight, const std::string &topic = "" );
+        outcome::result<CRDTListResult> GetList( const std::string &topic = "" );
 
-          /** primeCache builds the heads cache based on what's in storage; since
+        /** primeCache builds the heads cache based on what's in storage; since
     * it is called from the constructor only we don't bother locking.
     * @return outcome::failure on error
     */
-      outcome::result<void> PrimeCache();
+        outcome::result<void> PrimeCache();
 
-  protected:
-
-    /** Write data to datastore in batch mode
+    protected:
+        /** Write data to datastore in batch mode
     * @param aDataStore Pointer to datastore batch
     * @param aCid Content identifier to add
     * @param aHeight height of CID head
     * @return outcome::failure on error
     */
-      outcome::result<void> Write( const std::unique_ptr<storage::BufferBatch> &aDataStore,
-                                   const CID                                   &aCid,
-                                   uint64_t                                     aHeight,
-                                   const std::string &topic );
+        outcome::result<void> Write( const std::unique_ptr<storage::BufferBatch> &aDataStore,
+                                     const CID                                   &aCid,
+                                     uint64_t                                     aHeight,
+                                     const std::string                           &topic );
 
-      /** Delete data from datastore in batch mode
-    * @param aDataStore Pointer to datastore batch
-    * @param aCid Content identifier to remove
-    */
-      outcome::result<void> Delete( const std::unique_ptr<storage::BufferBatch> &aDataStore, const CID &aCid );
+        /** Delete data from datastore in batch mode
+        * @param aDataStore Pointer to datastore batch
+        * @param aCid Content identifier to remove
+        */
+        outcome::result<void> Delete( const std::unique_ptr<storage::BufferBatch> &aDataStore, const CID &aCid );
 
+    private:
+        CrdtHeads() = default;
 
-
-  private:
-
-    CrdtHeads() = default;
-
-    std::shared_ptr<DataStore> dataStore_;
-    std::unordered_map<std::string, std::map<CID, uint64_t>> cache_;
-    HierarchicalKey namespaceKey_;
-    std::recursive_mutex mutex_;
-
-  };
+        std::shared_ptr<DataStore>                               dataStore_;
+        std::unordered_map<std::string, std::map<CID, uint64_t>> cache_;
+        HierarchicalKey                                          namespaceKey_;
+        std::recursive_mutex                                     mutex_;
+        base::Logger                                             logger_ = base::createLogger( "CrdtHeads" );
+    };
 
 } // namespace sgns::crdt
 

--- a/src/crdt/crdt_heads.hpp
+++ b/src/crdt/crdt_heads.hpp
@@ -55,24 +55,23 @@ namespace sgns::crdt
         HierarchicalKey GetNamespaceKey() const;
 
         /** Get full path to CID key
-    *   /<namespace>/<cid>
-    * @param aCid Content identifier
-    * @return full path to CID key as HierarchicalKey or outcome::failure on error
-    */
-        outcome::result<HierarchicalKey> GetKey( const CID &aCid );
-        outcome::result<HierarchicalKey> GetKeyForTopic( const std::string &topic, const CID &aCid );
+         *   /<namespace>/<topic>/<cid>
+         * @param aCid Content identifier
+         * @return full path to CID key as HierarchicalKey or outcome::failure on error
+         */
+        outcome::result<HierarchicalKey> GetKey( const std::string &topic, const CID &aCid );
 
         /** Check if CID is among the current heads.
-    * @param aCid Content identifier
-    * @return true is CID is head, false otherwise
-    */
-        bool IsHead( const CID &aCid, const std::string &topic = "" );
+         * @param aCid Content identifier
+         * @return true is CID is head, false otherwise
+         */
+        bool IsHead( const CID &aCid, const std::string &topic );
 
         /** Check if CID is head and return it height if it is
-    * @param aCid Content identifier
-    * @return Height of head or outcome::failure on error
-    */
-        outcome::result<uint64_t> GetHeadHeight( const CID &aCid, const std::string &topic = "" );
+         * @param aCid Content identifier
+         * @return Height of head or outcome::failure on error
+         */
+        outcome::result<uint64_t> GetHeadHeight( const CID &aCid, const std::string &topic );
 
         /** Get current number of heads
     * @return lenght, current number of heads or outcome::failure on error

--- a/src/crdt/crdt_heads.hpp
+++ b/src/crdt/crdt_heads.hpp
@@ -16,9 +16,9 @@ namespace sgns::crdt
     class CrdtHeads
     {
     public:
-        using DataStore = storage::rocksdb;
-        using Buffer    = base::Buffer;
-        using CRDTHeadList = std::unordered_map<std::string, std::set<CID>>;
+        using DataStore      = storage::rocksdb;
+        using Buffer         = base::Buffer;
+        using CRDTHeadList   = std::unordered_map<std::string, std::set<CID>>;
         using CRDTListResult = std::pair<CRDTHeadList, uint64_t>;
 
         /** Constructor
@@ -102,7 +102,7 @@ namespace sgns::crdt
     * @param aMaxHeight output reference to maximum height
     * @return outcome::failure on error
     */
-        outcome::result<CRDTListResult> GetList( const std::string &topic = "" );
+        outcome::result<CRDTListResult> GetList( const std::set<std::string> &topics = {} );
 
         /** primeCache builds the heads cache based on what's in storage; since
     * it is called from the constructor only we don't bother locking.

--- a/src/crdt/crdt_heads.hpp
+++ b/src/crdt/crdt_heads.hpp
@@ -78,7 +78,7 @@ namespace sgns::crdt
     * @param aHeight height of head
     * @return outcome::failure on error
     */
-    outcome::result<void> Add( const CID &aCid, uint64_t aHeight );
+    outcome::result<void> Add( const CID &aCid, uint64_t aHeight, const std::string &topic );
 
     /** Replace a head with a new cid.
     * @param aCidHead Content identifier of head to replace
@@ -86,7 +86,7 @@ namespace sgns::crdt
     * @param aHeight height of head
     * @return outcome::failure on error
     */
-    outcome::result<void> Replace( const CID &aCidHead, const CID &aNewHeadCid, uint64_t aHeight );
+    outcome::result<void> Replace( const CID &aCidHead, const CID &aNewHeadCid, uint64_t aHeight, const std::string &topic );
 
     /** Returns the list of current heads plus the max height.
     * @param aHeads output reference to list of CIDs
@@ -111,7 +111,8 @@ namespace sgns::crdt
     */
       outcome::result<void> Write( const std::unique_ptr<storage::BufferBatch> &aDataStore,
                                    const CID                                   &aCid,
-                                   uint64_t                                     aHeight );
+                                   uint64_t                                     aHeight,
+                                   const std::string &topic );
 
       /** Delete data from datastore in batch mode
     * @param aDataStore Pointer to datastore batch
@@ -126,7 +127,7 @@ namespace sgns::crdt
     CrdtHeads() = default;
 
     std::shared_ptr<DataStore> dataStore_;
-    std::map<CID, uint64_t> cache_;
+    std::map<CID, std::pair<uint64_t,std::string>> cache_;
     HierarchicalKey namespaceKey_;
     std::recursive_mutex mutex_;
 

--- a/src/crdt/crdt_heads.hpp
+++ b/src/crdt/crdt_heads.hpp
@@ -60,18 +60,18 @@ namespace sgns::crdt
     * @param aCid Content identifier
     * @return true is CID is head, false otherwise
     */
-    bool IsHead(const CID& aCid);
+    bool IsHead( const CID& aCid, const std::string &topic = "" );
 
     /** Check if CID is head and return it height if it is
     * @param aCid Content identifier
     * @return Height of head or outcome::failure on error
     */
-    outcome::result<uint64_t> GetHeadHeight(const CID& aCid);
+    outcome::result<uint64_t> GetHeadHeight(const CID& aCid, const std::string &topic = "");
 
     /** Get current number of heads
     * @return lenght, current number of heads or outcome::failure on error
     */
-    outcome::result<int> GetLength();
+    outcome::result<int> GetLength( const std::string &topic = "" );
 
     /** Add head CID to datastore with full namespace
     * @param aCid Content identifier
@@ -93,7 +93,7 @@ namespace sgns::crdt
     * @param aMaxHeight output reference to maximum height
     * @return outcome::failure on error
     */
-    outcome::result<void> GetList(std::vector<CID>& aHeads, uint64_t& aMaxHeight);
+    outcome::result<void> GetList(std::vector<CID>& aHeads, uint64_t& aMaxHeight, const std::string &topic = "" );
 
           /** primeCache builds the heads cache based on what's in storage; since
     * it is called from the constructor only we don't bother locking.
@@ -127,7 +127,7 @@ namespace sgns::crdt
     CrdtHeads() = default;
 
     std::shared_ptr<DataStore> dataStore_;
-    std::map<CID, std::pair<uint64_t,std::string>> cache_;
+    std::unordered_map<std::string, std::map<CID, uint64_t>> cache_;
     HierarchicalKey namespaceKey_;
     std::recursive_mutex mutex_;
 

--- a/src/crdt/crdt_heads.hpp
+++ b/src/crdt/crdt_heads.hpp
@@ -60,6 +60,7 @@ namespace sgns::crdt
     * @return full path to CID key as HierarchicalKey or outcome::failure on error
     */
         outcome::result<HierarchicalKey> GetKey( const CID &aCid );
+        outcome::result<HierarchicalKey> GetKeyForTopic( const std::string &topic, const CID &aCid );
 
         /** Check if CID is among the current heads.
     * @param aCid Content identifier
@@ -125,7 +126,9 @@ namespace sgns::crdt
         * @param aDataStore Pointer to datastore batch
         * @param aCid Content identifier to remove
         */
-        outcome::result<void> Delete( const std::unique_ptr<storage::BufferBatch> &aDataStore, const CID &aCid );
+        outcome::result<void> Delete( const std::unique_ptr<storage::BufferBatch> &aDataStore,
+                                      const CID                                   &aCid,
+                                      const std::string                           &topic );
 
     private:
         CrdtHeads() = default;

--- a/src/crdt/dagsyncer.hpp
+++ b/src/crdt/dagsyncer.hpp
@@ -17,6 +17,8 @@ namespace sgns::crdt
     class DAGSyncer : public ipfs_lite::ipfs::merkledag::MerkleDagService
     {
     public:
+        using LinkInfoPair = std::pair<CID, std::string>;
+        using LinkInfoSet  = std::set<LinkInfoPair>;
         /**
         * Check if the block with {@param cid} is locally available (therefore, it
         * is considered processed).
@@ -27,10 +29,10 @@ namespace sgns::crdt
 
         virtual outcome::result<std::shared_ptr<ipfs_lite::ipld::IPLDNode>> GetNodeWithoutRequest(
             const CID &cid ) const = 0;
-        virtual std::pair<std::set<CID>, std::set<CID>> TraverseCIDsLinks(
+        virtual std::pair<LinkInfoSet, LinkInfoSet> TraverseCIDsLinks(
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
             std::string                                       link_name,
-            std::set<CID>                                     visited_cids ) const = 0;
+            LinkInfoSet                                       visited_links ) const = 0;
 
         virtual void                  InitCIDBlock( const CID &cid )       = 0;
         virtual bool                  IsCIDInCache( const CID &cid ) const = 0;

--- a/src/crdt/dagsyncer.hpp
+++ b/src/crdt/dagsyncer.hpp
@@ -33,7 +33,8 @@ namespace sgns::crdt
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
             std::string                                       link_name,
             LinkInfoSet                                       visited_links,
-            bool                                              skip_if_visited_root ) const = 0;
+            bool                                              skip_if_visited_root,
+            int                                               max_depth ) const = 0;
 
         virtual void                  InitCIDBlock( const CID &cid )       = 0;
         virtual bool                  IsCIDInCache( const CID &cid ) const = 0;

--- a/src/crdt/dagsyncer.hpp
+++ b/src/crdt/dagsyncer.hpp
@@ -29,6 +29,7 @@ namespace sgns::crdt
             const CID &cid ) const = 0;
         virtual std::pair<std::set<CID>, std::set<CID>> TraverseCIDsLinks(
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
+            std::string                                       link_name,
             std::set<CID>                                     visited_cids ) const = 0;
 
         virtual void                  InitCIDBlock( const CID &cid )       = 0;

--- a/src/crdt/globaldb/globaldb.cpp
+++ b/src/crdt/globaldb/globaldb.cpp
@@ -318,9 +318,9 @@ namespace sgns::crdt
         m_crdtDatastore->PrintDataStore();
     }
     
-    void GlobalDB::SetTopicName(std::string topicName)
+    void GlobalDB::AddTopicName(std::string topicName)
     {
-        m_crdtDatastore->SetTopicName(topicName);
+        m_crdtDatastore->AddTopicName(topicName);
     }
 
     std::shared_ptr<AtomicTransaction> GlobalDB::BeginTransaction()

--- a/src/crdt/globaldb/globaldb.cpp
+++ b/src/crdt/globaldb/globaldb.cpp
@@ -125,12 +125,12 @@ namespace sgns::crdt
             // Create new database
             m_logger->info( "Opening database " + databasePathAbsolute );
             RocksDB::Options options;
-            options.create_if_missing = true; // intentionally
-            options.target_file_size_base = 32 * 1024 * 1024; 
-            options.max_compaction_bytes = 32 * 1024 * 1024;
-            options.write_buffer_size = 32 * 1024 * 1024;
-            options.level0_file_num_compaction_trigger = 1;
-            options.target_file_size_multiplier = 1;
+            options.create_if_missing                    = true; // intentionally
+            options.target_file_size_base                = 32 * 1024 * 1024;
+            options.max_compaction_bytes                 = 32 * 1024 * 1024;
+            options.write_buffer_size                    = 32 * 1024 * 1024;
+            options.level0_file_num_compaction_trigger   = 1;
+            options.target_file_size_multiplier          = 1;
             options.level_compaction_dynamic_level_bytes = false;
             try
             {
@@ -246,7 +246,6 @@ namespace sgns::crdt
 
     outcome::result<GlobalDB::Buffer> GlobalDB::Get( const HierarchicalKey &key )
     {
-
         return m_crdtDatastore->GetKey( key );
     }
 
@@ -263,7 +262,6 @@ namespace sgns::crdt
 
     outcome::result<GlobalDB::QueryResult> GlobalDB::QueryKeyValues( const std::string &keyPrefix )
     {
-
         return m_crdtDatastore->QueryKeyValues( keyPrefix );
     }
 
@@ -317,10 +315,15 @@ namespace sgns::crdt
     {
         m_crdtDatastore->PrintDataStore();
     }
-    
-    void GlobalDB::AddTopicName(std::string topicName)
+
+    void GlobalDB::AddTopicName( std::string topicName )
     {
-        m_crdtDatastore->AddTopicName(topicName);
+        m_crdtDatastore->AddTopicName( topicName );
+    }
+
+    void GlobalDB::SetFullNode( bool full_node )
+    {
+        m_crdtDatastore->SetFullNode( std::move( full_node ) );
     }
 
     std::shared_ptr<AtomicTransaction> GlobalDB::BeginTransaction()

--- a/src/crdt/globaldb/globaldb.cpp
+++ b/src/crdt/globaldb/globaldb.cpp
@@ -216,7 +216,7 @@ namespace sgns::crdt
         }
     }
 
-    outcome::result<void> GlobalDB::Put( const HierarchicalKey &key, const Buffer &value )
+    outcome::result<void> GlobalDB::Put( const HierarchicalKey &key, const Buffer &value, std::set<std::string> topics )
     {
         if ( !started_ )
         {
@@ -224,10 +224,10 @@ namespace sgns::crdt
             return outcome::failure( Error::GLOBALDB_NOT_STARTED );
         }
 
-        return m_crdtDatastore->PutKey( key, value );
+        return m_crdtDatastore->PutKey( key, value, std::move( topics ) );
     }
 
-    outcome::result<void> GlobalDB::Put( const std::vector<DataPair> &data_vector )
+    outcome::result<void> GlobalDB::Put( const std::vector<DataPair> &data_vector, std::set<std::string> topics )
     {
         if ( !started_ )
         {
@@ -241,7 +241,7 @@ namespace sgns::crdt
             BOOST_OUTCOME_TRYV2( auto &&, batch.Put( std::get<0>( data ), std::get<1>( data ) ) );
         }
 
-        return batch.Commit();
+        return batch.Commit( topics );
     }
 
     outcome::result<GlobalDB::Buffer> GlobalDB::Get( const HierarchicalKey &key )

--- a/src/crdt/globaldb/globaldb.cpp
+++ b/src/crdt/globaldb/globaldb.cpp
@@ -249,7 +249,7 @@ namespace sgns::crdt
         return m_crdtDatastore->GetKey( key );
     }
 
-    outcome::result<void> GlobalDB::Remove( const HierarchicalKey &key )
+    outcome::result<void> GlobalDB::Remove( const HierarchicalKey &key, const std::set<std::string> &topics )
     {
         if ( !started_ )
         {
@@ -257,7 +257,7 @@ namespace sgns::crdt
             return outcome::failure( Error::GLOBALDB_NOT_STARTED );
         }
 
-        return m_crdtDatastore->DeleteKey( key );
+        return m_crdtDatastore->DeleteKey( key, topics );
     }
 
     outcome::result<GlobalDB::QueryResult> GlobalDB::QueryKeyValues( const std::string &keyPrefix )

--- a/src/crdt/globaldb/globaldb.cpp
+++ b/src/crdt/globaldb/globaldb.cpp
@@ -317,6 +317,11 @@ namespace sgns::crdt
     {
         m_crdtDatastore->PrintDataStore();
     }
+    
+    void GlobalDB::SetTopicName(std::string topicName)
+    {
+        m_crdtDatastore->SetTopicName(topicName);
+    }
 
     std::shared_ptr<AtomicTransaction> GlobalDB::BeginTransaction()
     {

--- a/src/crdt/globaldb/globaldb.cpp
+++ b/src/crdt/globaldb/globaldb.cpp
@@ -126,9 +126,12 @@ namespace sgns::crdt
             m_logger->info( "Opening database " + databasePathAbsolute );
             RocksDB::Options options;
             options.create_if_missing = true; // intentionally
-            options.target_file_size_base = 24 * 1024 * 1024; 
+            options.target_file_size_base = 32 * 1024 * 1024; 
             options.max_compaction_bytes = 32 * 1024 * 1024;
-            options.write_buffer_size = 8 * 1024 * 1024;
+            options.write_buffer_size = 32 * 1024 * 1024;
+            options.level0_file_num_compaction_trigger = 1;
+            options.target_file_size_multiplier = 1;
+            options.level_compaction_dynamic_level_bytes = false;
             try
             {
                 if ( auto dataStoreResult = RocksDB::create( databasePathAbsolute, options );

--- a/src/crdt/globaldb/globaldb.hpp
+++ b/src/crdt/globaldb/globaldb.hpp
@@ -131,6 +131,7 @@ namespace sgns::crdt
         void AddListenTopic( const std::string &topicName );
 
         void PrintDataStore();
+        void SetTopicName(std::string topicName);
 
         auto GetDB()
         {

--- a/src/crdt/globaldb/globaldb.hpp
+++ b/src/crdt/globaldb/globaldb.hpp
@@ -134,11 +134,6 @@ namespace sgns::crdt
         void AddTopicName( std::string topicName );
         void SetFullNode( bool full_node );
 
-        auto GetDB()
-        {
-            return m_crdtDatastore->GetDB();
-        }
-
         std::shared_ptr<RocksDB> GetDataStore();
 
         bool RegisterElementFilter( const std::string &pattern, GlobalDBFilterCallback filter );

--- a/src/crdt/globaldb/globaldb.hpp
+++ b/src/crdt/globaldb/globaldb.hpp
@@ -78,14 +78,14 @@ namespace sgns::crdt
          * @param[in] value The value to store.
          * @return outcome::success on success, or outcome::failure otherwise.
          */
-        outcome::result<void> Put( const HierarchicalKey &key, const Buffer &value );
+        outcome::result<void> Put( const HierarchicalKey &key, const Buffer &value, std::set<std::string> topics );
 
         /**
          * @brief       Writes a batch of CRDT data all at once
          * @param[in]   data_vector A set of crdt to be written in a single transaction
          * @return      outcome::failure on error or success otherwise
          */
-        outcome::result<void> Put( const std::vector<DataPair> &data_vector );
+        outcome::result<void> Put( const std::vector<DataPair> &data_vector, std::set<std::string> topics );
 
         /** Gets a value that corresponds to specified key.
         * @param key - value key

--- a/src/crdt/globaldb/globaldb.hpp
+++ b/src/crdt/globaldb/globaldb.hpp
@@ -131,7 +131,8 @@ namespace sgns::crdt
         void AddListenTopic( const std::string &topicName );
 
         void PrintDataStore();
-        void AddTopicName(std::string topicName);
+        void AddTopicName( std::string topicName );
+        void SetFullNode( bool full_node );
 
         auto GetDB()
         {

--- a/src/crdt/globaldb/globaldb.hpp
+++ b/src/crdt/globaldb/globaldb.hpp
@@ -131,7 +131,7 @@ namespace sgns::crdt
         void AddListenTopic( const std::string &topicName );
 
         void PrintDataStore();
-        void SetTopicName(std::string topicName);
+        void AddTopicName(std::string topicName);
 
         auto GetDB()
         {

--- a/src/crdt/globaldb/globaldb.hpp
+++ b/src/crdt/globaldb/globaldb.hpp
@@ -97,7 +97,7 @@ namespace sgns::crdt
         * @param key to remove from storage
         * @return outcome::failure on error or success otherwise
         */
-        outcome::result<void> Remove( const HierarchicalKey &key );
+        outcome::result<void> Remove( const HierarchicalKey &key, const std::set<std::string> &topics );
 
         /** Queries CRDT key-value pairs by prefix. If the prefix is empty returns all elements that were not tombstoned
         * @param prefix - keys prefix to match. An empty prefix matches any key.

--- a/src/crdt/globaldb/pubsub_broadcaster.cpp
+++ b/src/crdt/globaldb/pubsub_broadcaster.cpp
@@ -26,7 +26,7 @@ namespace sgns::crdt
         }
     }
 
-outcome::result<void> PubSubBroadcaster::Broadcast(const base::Buffer &buff)
+outcome::result<void> PubSubBroadcaster::Broadcast(const base::Buffer &buff, std::string topic)
 {
     if (this->gossipPubSubTopic_ == nullptr)
     {

--- a/src/crdt/globaldb/pubsub_broadcaster.hpp
+++ b/src/crdt/globaldb/pubsub_broadcaster.hpp
@@ -25,7 +25,7 @@ public:
     * Send {@param buff} payload to other replicas.
     * @return outcome::success on success or outcome::failure on error
     */
-        outcome::result<void> Broadcast(const base::Buffer &buff) override;
+        outcome::result<void> Broadcast(const base::Buffer &buff, std::string topic) override;
     /**
     * Obtain the next {@return} payload received from the network.
     * @return buffer value or outcome::failure on error

--- a/src/crdt/globaldb/pubsub_broadcaster_ext.cpp
+++ b/src/crdt/globaldb/pubsub_broadcaster_ext.cpp
@@ -222,13 +222,15 @@ namespace sgns::crdt
         } while ( 0 );
     }
 
-    outcome::result<void> PubSubBroadcasterExt::Broadcast( const base::Buffer &buff )
+    outcome::result<void> PubSubBroadcasterExt::Broadcast( const base::Buffer &buff, std::string topic )
     {
         std::set<std::string> broadcastTopicsCopy;
         {
             std::lock_guard<std::mutex> lock( broadcastTopicsMutex_ );
             broadcastTopicsCopy = topicsToBroadcast_;
         }
+
+        broadcastTopicsCopy.emplace(topic);
 
         if ( broadcastTopicsCopy.empty() )
         {

--- a/src/crdt/globaldb/pubsub_broadcaster_ext.cpp
+++ b/src/crdt/globaldb/pubsub_broadcaster_ext.cpp
@@ -229,8 +229,10 @@ namespace sgns::crdt
             std::lock_guard<std::mutex> lock( broadcastTopicsMutex_ );
             broadcastTopicsCopy = topicsToBroadcast_;
         }
-
-        broadcastTopicsCopy.emplace(topic);
+        if ( !topic.empty() )
+        {
+            broadcastTopicsCopy.emplace( topic );
+        }
 
         if ( broadcastTopicsCopy.empty() )
         {
@@ -338,7 +340,7 @@ namespace sgns::crdt
         std::lock_guard lock( listenTopicsMutex_ );
         if ( topicsToListen_.find( topic ) != topicsToListen_.end() )
         {
-            this->m_logger->debug("Already listening to topic {}", topic);
+            this->m_logger->debug( "Already listening to topic {}", topic );
             return;
         }
 

--- a/src/crdt/globaldb/pubsub_broadcaster_ext.hpp
+++ b/src/crdt/globaldb/pubsub_broadcaster_ext.hpp
@@ -45,7 +45,7 @@ namespace sgns::crdt
          * @param buff       Buffer containing the data to broadcast.
          * @return outcome::success on successful publish, or outcome::failure on error.
          */
-        outcome::result<void> Broadcast( const base::Buffer &buff ) override;
+        outcome::result<void> Broadcast( const base::Buffer &buff, std::string topic ) override;
 
         /**
          * @brief Retrieves the next incoming broadcast payload.

--- a/src/crdt/graphsync_dagsyncer.hpp
+++ b/src/crdt/graphsync_dagsyncer.hpp
@@ -109,7 +109,8 @@ namespace sgns::crdt
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
             std::string                                       link_name            = "",
             DAGSyncer::LinkInfoSet                            visited_links        = {},
-            bool                                              skip_if_visited_root = false ) const override;
+            bool                                              skip_if_visited_root = false,
+            int                                               max_depth            = 100 ) const override;
         /* Returns peer ID */
         outcome::result<PeerId> GetId() const;
 

--- a/src/crdt/graphsync_dagsyncer.hpp
+++ b/src/crdt/graphsync_dagsyncer.hpp
@@ -105,10 +105,10 @@ namespace sgns::crdt
         outcome::result<bool>                                       HasBlock( const CID &cid ) const override;
         outcome::result<std::shared_ptr<ipfs_lite::ipld::IPLDNode>> GetNodeWithoutRequest(
             const CID &cid ) const override;
-        std::pair<std::set<CID>, std::set<CID>> TraverseCIDsLinks(
+        std::pair<DAGSyncer::LinkInfoSet, DAGSyncer::LinkInfoSet> TraverseCIDsLinks(
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
-            std::string                                       link_name    = "",
-            std::set<CID>                                     visited_cids = {} ) const override;
+            std::string                                       link_name     = "",
+            DAGSyncer::LinkInfoSet                                       visited_links = {} ) const override;
         /* Returns peer ID */
         outcome::result<PeerId> GetId() const;
 

--- a/src/crdt/graphsync_dagsyncer.hpp
+++ b/src/crdt/graphsync_dagsyncer.hpp
@@ -107,6 +107,7 @@ namespace sgns::crdt
             const CID &cid ) const override;
         std::pair<std::set<CID>, std::set<CID>> TraverseCIDsLinks(
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
+            std::string                                       link_name    = "",
             std::set<CID>                                     visited_cids = {} ) const override;
         /* Returns peer ID */
         outcome::result<PeerId> GetId() const;

--- a/src/crdt/impl/atomic_transaction.cpp
+++ b/src/crdt/impl/atomic_transaction.cpp
@@ -89,10 +89,6 @@ namespace sgns::crdt
         return modified_keys_.find( key.GetKey() ) != modified_keys_.end();
     }
 
-    outcome::result<void> AtomicTransaction::Commit()
-    {
-        return this->Commit({});
-    }
     outcome::result<void> AtomicTransaction::Commit(const std::set<std::string>& topics)
     {
         if ( is_committed_ )

--- a/src/crdt/impl/atomic_transaction.cpp
+++ b/src/crdt/impl/atomic_transaction.cpp
@@ -93,7 +93,7 @@ namespace sgns::crdt
     {
         return this->Commit({});
     }
-    outcome::result<void> AtomicTransaction::Commit(const std::vector<std::string>& topics)
+    outcome::result<void> AtomicTransaction::Commit(const std::set<std::string>& topics)
     {
         if ( is_committed_ )
         {

--- a/src/crdt/impl/atomic_transaction.cpp
+++ b/src/crdt/impl/atomic_transaction.cpp
@@ -91,6 +91,10 @@ namespace sgns::crdt
 
     outcome::result<void> AtomicTransaction::Commit()
     {
+        return this->Commit({});
+    }
+    outcome::result<void> AtomicTransaction::Commit(const std::vector<std::string>& topics)
+    {
         if ( is_committed_ )
         {
             return outcome::failure( boost::system::error_code{} );
@@ -129,7 +133,7 @@ namespace sgns::crdt
         }
         combined_delta->set_priority( max_priority );
 
-        auto result = datastore_->Publish( combined_delta );
+        auto result = datastore_->Publish( combined_delta, topics );
         if ( result.has_failure() )
         {
             return result.error();

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -785,7 +785,9 @@ namespace sgns::crdt
         {
             return outcome::failure( boost::system::error_code{} );
         }
-        std::set<std::string> topics_to_update_cid = aNode->getDestinations();
+
+        std::set<std::string> topics_to_update_cid;
+        topics_to_update_cid = aNode->getDestinations();
 
         auto current      = aNode->getCID();
         auto strCidResult = current.toString();
@@ -801,6 +803,10 @@ namespace sgns::crdt
             logger_->error( "ProcessNode: Processing INCOMING root {} node {}",
                             aRoot.toString().value(),
                             aNode->getCID().toString().value() );
+            if ( !isFullNode )
+            {
+                topics_to_update_cid = topicNames_;
+            }
         }
         else
         {

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -683,8 +683,8 @@ namespace sgns::crdt
         return newCID;
     }
 
-    outcome::result<CID> CrdtDatastore::Publish( const std::shared_ptr<Delta>   &aDelta,
-                                                 const std::vector<std::string> &topics )
+    outcome::result<CID> CrdtDatastore::Publish( const std::shared_ptr<Delta> &aDelta,
+                                                 const std::set<std::string>  &topics )
     {
         OUTCOME_TRY( auto &&newCID, AddDAGNode( aDelta, topics ) );
 
@@ -846,8 +846,8 @@ namespace sgns::crdt
         return children;
     }
 
-    outcome::result<CID> CrdtDatastore::AddDAGNode( const std::shared_ptr<Delta>   &aDelta,
-                                                    const std::vector<std::string> &topics )
+    outcome::result<CID> CrdtDatastore::AddDAGNode( const std::shared_ptr<Delta> &aDelta,
+                                                    const std::set<std::string>  &topics )
     {
         uint64_t         height = 0;
         std::vector<CID> heads;

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -112,6 +112,7 @@ namespace sgns::crdt
             } );
 
         dagWorkerJobListThreadRunning_ = true;
+        dagWorkers_.reserve(numberOfDagWorkers);
         for ( int i = 0; i < numberOfDagWorkers; ++i )
         {
             auto dagWorker                     = std::make_shared<DagWorker>();

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -649,7 +649,9 @@ namespace sgns::crdt
         return set_->IsValueInSet( aKey.GetKey() );
     }
 
-    outcome::result<void> CrdtDatastore::PutKey( const HierarchicalKey &aKey, const Buffer &aValue )
+    outcome::result<void> CrdtDatastore::PutKey( const HierarchicalKey &aKey,
+                                                 const Buffer          &aValue,
+                                                 std::set<std::string>  topics )
     {
         auto deltaResult = CreateDeltaToAdd( aKey.GetKey(), std::string( aValue.toString() ) );
         if ( deltaResult.has_failure() )
@@ -657,7 +659,7 @@ namespace sgns::crdt
             return outcome::failure( deltaResult.error() );
         }
 
-        auto publishResult = Publish( deltaResult.value() );
+        auto publishResult = Publish( deltaResult.value(), topics );
         if ( deltaResult.has_failure() )
         {
             return outcome::failure( publishResult.error() );

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -813,6 +813,10 @@ namespace sgns::crdt
                 //LET'S CHECK IF THE LINK IS FOR ME
                 if ( link.get().getName() != topicName_)
                 {
+                    logger_->debug( "Skipping link because its name '{}' does not match topicName '{}'",
+                                    link.get().getName(),
+                                    topicName_ );
+
                     // continue;
                 }
                 auto child        = link.get().getCID();
@@ -888,6 +892,8 @@ namespace sgns::crdt
         {
             for ( const auto &t : topics )
             {
+                // Debug each head-topic pairing
+                logger_->debug( "AddDAGNode: pairing head {} with topic '{}'", cid.toString().value(), t );
                 headsWithTopics.emplace_back( cid, t );
             }
         }

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -558,10 +558,10 @@ namespace sgns::crdt
             }
             else
             {
-                logger_->debug( "RebroadcastHeads: Broadcasted CIDs to topic {} ", topic_name );
+                logger_->trace( "RebroadcastHeads: Broadcasted CIDs to topic {} ", topic_name );
                 for ( const auto &cid : cid_set )
                 {
-                    logger_->debug( "RebroadcastHeads: CID {} ", cid.toString().value() );
+                    logger_->trace( "RebroadcastHeads: CID {} ", cid.toString().value() );
                 }
             }
         }

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -407,6 +407,9 @@ namespace sgns::crdt
                 logger_->error( "SendNewJobs: failed to process node:{}", current_root_cid.toString().value() );
                 continue; // Continue processing other nodes
             }
+            logger_->info( "SendJobWorker: Processed CID={} nodeCID={}",
+                           current_root_cid.toString().value(),
+                           dagJob.node_->getCID().toString().value() );
 
             // Aggregate CIDs to fetch
             auto CIDs_to_fetch = childrenResult.value();

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -671,7 +671,7 @@ namespace sgns::crdt
         return outcome::success();
     }
 
-    outcome::result<void> CrdtDatastore::DeleteKey( const HierarchicalKey &aKey )
+    outcome::result<void> CrdtDatastore::DeleteKey( const HierarchicalKey &aKey, const std::set<std::string>  &topics )
     {
         auto deltaResult = CreateDeltaToRemove( aKey.GetKey() );
         if ( deltaResult.has_failure() )
@@ -684,20 +684,13 @@ namespace sgns::crdt
             return outcome::success();
         }
 
-        auto publishResult = Publish( deltaResult.value() );
+        auto publishResult = Publish( deltaResult.value(), topics );
         if ( deltaResult.has_failure() )
         {
             return outcome::failure( publishResult.error() );
         }
 
         return outcome::success();
-    }
-
-    outcome::result<CID> CrdtDatastore::Publish( const std::shared_ptr<Delta> &aDelta )
-    {
-        OUTCOME_TRY( auto &&newCID, AddDAGNode( aDelta, topicNames_ ) );
-
-        return newCID;
     }
 
     outcome::result<CID> CrdtDatastore::Publish( const std::shared_ptr<Delta> &aDelta,

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -904,7 +904,7 @@ namespace sgns::crdt
                 logger_->error( "ProcessNode: Traversing to find links on topic {}", topic );
                 std::unique_lock lock( dagSyncherMutex_ );
                 auto [links_to_fetch,
-                      known_cids] = dagSyncer_->TraverseCIDsLinks( aNode, topic, {}, skip_if_visited, 100 );
+                      known_cids] = dagSyncer_->TraverseCIDsLinks( aNode, topic, {}, skip_if_visited, 50 );
                 lock.unlock();
                 for ( const auto &[cid, link_name] : known_cids )
                 {

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -678,7 +678,7 @@ namespace sgns::crdt
 
     outcome::result<CID> CrdtDatastore::Publish( const std::shared_ptr<Delta> &aDelta )
     {
-        OUTCOME_TRY( auto &&newCID, AddDAGNode( aDelta, {} ) );
+        OUTCOME_TRY( auto &&newCID, AddDAGNode( aDelta, { topicName_ } ) );
 
         return newCID;
     }

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -817,7 +817,7 @@ namespace sgns::crdt
                                     link.get().getName(),
                                     topicName_ );
 
-                    // continue;
+                    continue;
                 }
                 auto child        = link.get().getCID();
                 auto isHeadResult = heads_->IsHead( child );

--- a/src/crdt/impl/crdt_datastore.cpp
+++ b/src/crdt/impl/crdt_datastore.cpp
@@ -849,7 +849,8 @@ namespace sgns::crdt
             {
                 logger_->error( "ProcessNode: Traversing to find links on topic {}", topic );
                 std::unique_lock lock( dagSyncherMutex_ );
-                auto [links_to_fetch, known_cids] = dagSyncer_->TraverseCIDsLinks( aNode, topic, {}, skip_if_visited );
+                auto [links_to_fetch,
+                      known_cids] = dagSyncer_->TraverseCIDsLinks( aNode, topic, {}, skip_if_visited, 100 );
                 lock.unlock();
                 for ( const auto &[cid, link_name] : known_cids )
                 {

--- a/src/crdt/impl/crdt_heads.cpp
+++ b/src/crdt/impl/crdt_heads.cpp
@@ -258,14 +258,14 @@ namespace sgns::crdt
         return outcome::success();
     }
 
-    outcome::result<CrdtHeads::CRDTListResult> CrdtHeads::GetList( const std::string &topic )
+    outcome::result<CrdtHeads::CRDTListResult> CrdtHeads::GetList( const std::set<std::string> &topics )
     {
         CRDTHeadList result_heads;
         uint64_t     max_value = 0;
         logger_->debug( "GetList: Getting list of CIDs" );
         for ( const auto &[current_topic, cid_map] : cache_ )
         {
-            if ( !topic.empty() && current_topic != topic )
+            if ( !topics.empty() && topics.find( current_topic ) == topics.end() )
             {
                 continue;
             }

--- a/src/crdt/impl/crdt_heads.cpp
+++ b/src/crdt/impl/crdt_heads.cpp
@@ -205,7 +205,7 @@ namespace sgns::crdt
 
         {
             std::lock_guard lg( this->mutex_ );
-            this->cache_[topic][aCid] = height;
+            this->cache_[topic][aCid] = aHeight;
         }
         return outcome::success();
     }
@@ -292,7 +292,7 @@ namespace sgns::crdt
 
         for ( const auto &bufferKeyAndValue : queryResult.value() )
         {
-            std::string keyWithNamespace = bufferKeyAndValue.first.toString();
+            std::string keyWithNamespace = std::string( bufferKeyAndValue.first.toString() );
             std::string strCid           = keyWithNamespace.erase( 0, strNamespace.size() + 1 );
 
             auto cidResult = CID::fromString( strCid );

--- a/src/crdt/impl/crdt_heads.cpp
+++ b/src/crdt/impl/crdt_heads.cpp
@@ -259,7 +259,7 @@ namespace sgns::crdt
     {
         CRDTHeadList result_heads;
         uint64_t     max_value = 0;
-
+        logger_->debug( "GetList: Getting list of CIDs" );
         for ( const auto &[current_topic, cid_map] : cache_ )
         {
             if ( !topic.empty() && current_topic != topic )
@@ -274,10 +274,10 @@ namespace sgns::crdt
             }
         }
 
-        if ( result_heads.empty() )
-        {
-            return outcome::failure( boost::system::error_code{} );
-        }
+        //if ( result_heads.empty() )
+        //{
+        //    return outcome::failure( boost::system::error_code{} );
+        //}
 
         return outcome::success( CRDTListResult{ result_heads, max_value } );
     }

--- a/src/crdt/impl/graphsync_dagsyncer.cpp
+++ b/src/crdt/impl/graphsync_dagsyncer.cpp
@@ -497,7 +497,8 @@ namespace sgns::crdt
         const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
         std::string                                       link_name,
         DAGSyncer::LinkInfoSet                            visited_links,
-        bool                                              skip_if_visited_root ) const
+        bool                                              skip_if_visited_root,
+        int                                               max_depth ) const
     {
         DAGSyncer::LinkInfoSet links_to_fetch;
         DAGSyncer::LinkInfoSet visited = std::move( visited_links );
@@ -528,7 +529,7 @@ namespace sgns::crdt
             const std::string &name  = link.get().getName();
             LinkInfoPair       pair{ child, name };
 
-            logger_->debug( "TraverseCIDsLinks: Link: name '{}' != '{}'", name, link_name );
+            logger_->trace( "TraverseCIDsLinks: Link: name '{}' != '{}'", name, link_name );
             if ( !link_name.empty() && name != link_name )
             {
                 logger_->debug( "TraverseCIDsLinks: Skipping link: name '{}' != '{}'", name, link_name );
@@ -557,10 +558,19 @@ namespace sgns::crdt
                 continue;
             }
 
+            if ( max_depth == 0 )
+            {
+                logger_->debug( "TraverseCIDsLinks: Max depth reached at link {{ cid='{}', name='{}' }}",
+                                child.toString().value(),
+                                name );
+                continue;
+            }
+
             auto [child_links, child_visited] = TraverseCIDsLinks( get_child_result.value(),
                                                                    link_name,
                                                                    visited,
-                                                                   skip_if_visited_root );
+                                                                   skip_if_visited_root,
+                                                                   max_depth - 1 );
 
             links_to_fetch.merge( child_links );
             visited.merge( child_visited );

--- a/src/crdt/impl/graphsync_dagsyncer.cpp
+++ b/src/crdt/impl/graphsync_dagsyncer.cpp
@@ -511,6 +511,7 @@ namespace sgns::crdt
             const std::string &name  = link.get().getName();
             LinkInfoPair       pair{ child, name };
 
+            logger_->debug( "TraverseCIDsLinks: Link: name '{}' != '{}'", name, link_name );
             if ( !link_name.empty() && name != link_name )
             {
                 logger_->debug( "TraverseCIDsLinks: Skipping link: name '{}' != '{}'", name, link_name );
@@ -529,12 +530,6 @@ namespace sgns::crdt
                            child.toString().value(),
                            name,
                            link.get().getSize() );
-
-            if ( !link_name.empty() && name != link_name )
-            {
-                logger_->debug( "TraverseCIDsLinks: Skipping link: name '{}' != '{}'", name, link_name );
-                continue;
-            }
 
             auto get_child_result = GetNodeWithoutRequest( child );
 

--- a/src/crdt/proto/CMakeLists.txt
+++ b/src/crdt/proto/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PROTOS
     delta.proto
     bcast.proto
+    heads.proto
 )
 
 set(PROTO_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/proto_buf)
@@ -11,3 +12,5 @@ set(Protobuf_USE_STATIC_LIBS ON)
 protobuf_generate_cpp(DELTA_PROTO_SRCS DELTA_PROTO_HDRS ${CMAKE_CURRENT_LIST_DIR} PROTO_PATH delta.proto)
 
 protobuf_generate_cpp(BCAST_PROTO_SRCS BCAST_PROTO_HDRS ${CMAKE_CURRENT_LIST_DIR} PROTO_PATH bcast.proto)
+
+protobuf_generate_cpp(HEADS_PROTO_SRCS HEADS_PROTO_HDRS ${CMAKE_CURRENT_LIST_DIR} PROTO_PATH heads.proto)

--- a/src/crdt/proto/CMakeLists.txt
+++ b/src/crdt/proto/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(PROTOS
     delta.proto
     bcast.proto
-    heads.proto
 )
 
 set(PROTO_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/proto_buf)
@@ -12,5 +11,3 @@ set(Protobuf_USE_STATIC_LIBS ON)
 protobuf_generate_cpp(DELTA_PROTO_SRCS DELTA_PROTO_HDRS ${CMAKE_CURRENT_LIST_DIR} PROTO_PATH delta.proto)
 
 protobuf_generate_cpp(BCAST_PROTO_SRCS BCAST_PROTO_HDRS ${CMAKE_CURRENT_LIST_DIR} PROTO_PATH bcast.proto)
-
-protobuf_generate_cpp(HEADS_PROTO_SRCS HEADS_PROTO_HDRS ${CMAKE_CURRENT_LIST_DIR} PROTO_PATH heads.proto)

--- a/src/crdt/proto/heads.proto
+++ b/src/crdt/proto/heads.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package sgns.crdt.pb;
+
+// info stored for each head in the kv-store
+message HeadInfo {
+  uint64 height = 1;
+  string topic = 2;
+}
+

--- a/src/processing/impl/processing_subtask_result_storage_impl.cpp
+++ b/src/processing/impl/processing_subtask_result_storage_impl.cpp
@@ -25,7 +25,8 @@ namespace sgns::processing
 
     void SubTaskResultStorageImpl::RemoveSubTaskResult( const std::string &subTaskId )
     {
-        m_db->Remove( sgns::crdt::HierarchicalKey( ( boost::format( "results/%s" ) % subTaskId ).str() ) );
+        m_db->Remove( sgns::crdt::HierarchicalKey( ( boost::format( "results/%s" ) % subTaskId ).str() ),
+                      { m_processing_topic } );
     }
 
     std::vector<SGProcessing::SubTaskResult> SubTaskResultStorageImpl::GetSubTaskResults(

--- a/src/processing/impl/processing_subtask_result_storage_impl.hpp
+++ b/src/processing/impl/processing_subtask_result_storage_impl.hpp
@@ -14,7 +14,7 @@ namespace sgns::processing
         /** Create a subtask storage
         * @param db - CRDT globaldb to use
         */
-        SubTaskResultStorageImpl( std::shared_ptr<sgns::crdt::GlobalDB> db );
+        SubTaskResultStorageImpl( std::shared_ptr<sgns::crdt::GlobalDB> db, std::string topic );
 
         ~SubTaskResultStorageImpl();
 
@@ -36,6 +36,7 @@ namespace sgns::processing
 
     private:
         std::shared_ptr<sgns::crdt::GlobalDB> m_db;
+        std::string                           m_processing_topic;
     };
 }
 

--- a/src/processing/impl/processing_task_queue_impl.cpp
+++ b/src/processing/impl/processing_task_queue_impl.cpp
@@ -158,8 +158,6 @@ namespace sgns::processing
         data.put( taskResult.SerializeAsString() );
         BOOST_OUTCOME_TRYV2( auto &&, job_completion_transaction->Put( std::move( result_key ), std::move( data ) ) );
 
-        //BOOST_OUTCOME_TRYV2( auto &&, job_completion_transaction->Commit() );
-
         m_logger->debug( "TASK_COMPLETED: {}, results stored", taskKey );
         return job_completion_transaction;
     }
@@ -205,7 +203,7 @@ namespace sgns::processing
         sgns::base::Buffer lockData;
         lockData.put( lock.SerializeAsString() );
 
-        auto res = m_db->Put( sgns::crdt::HierarchicalKey( "lock_" + taskKey ), lockData );
+        auto res = m_db->Put( sgns::crdt::HierarchicalKey( "lock_" + taskKey ), lockData, { m_processing_topic } );
         return !res.has_failure();
     }
 
@@ -259,7 +257,7 @@ namespace sgns::processing
         sgns::crdt::HierarchicalKey key( path );
 
         BOOST_OUTCOME_TRYV2( auto &&, job_crdt_transaction_->Put( std::move( key ), std::move( value ) ) );
-        BOOST_OUTCOME_TRYV2( auto &&, job_crdt_transaction_->Commit() );
+        BOOST_OUTCOME_TRYV2( auto &&, job_crdt_transaction_->Commit( { m_processing_topic } ) );
 
         ResetAtomicTransaction();
 

--- a/src/processing/impl/processing_task_queue_impl.hpp
+++ b/src/processing/impl/processing_task_queue_impl.hpp
@@ -23,9 +23,10 @@ namespace sgns::processing
         /** Create a task queue
         * @param db - CRDT globaldb to use
         */
-        ProcessingTaskQueueImpl( std::shared_ptr<sgns::crdt::GlobalDB> db ) :
+        ProcessingTaskQueueImpl( std::shared_ptr<sgns::crdt::GlobalDB> db, std::string processing_topic ) :
             m_db( std::move( db ) ),
-            m_processingTimeout( std::chrono::seconds( 10 ) )
+            m_processingTimeout( std::chrono::seconds( 10 ) ),
+            m_processing_topic( std::move( processing_topic ) )
         {
         }
 
@@ -33,6 +34,7 @@ namespace sgns::processing
         {
             m_logger->debug( "~ProcessingTaskQueueImpl CALLED" );
         }
+
         /** Enqueue a task and subtasks
         * @param task - Task to add
         * @param subTasks - List of subtasks
@@ -56,7 +58,9 @@ namespace sgns::processing
         * @param taskKey - id to look for task
         * @param taskResult - Reference of a task result
         */
-       outcome::result<std::shared_ptr<crdt::AtomicTransaction>> CompleteTask( const std::string &taskKey, const SGProcessing::TaskResult &taskResult ) override;
+        outcome::result<std::shared_ptr<crdt::AtomicTransaction>> CompleteTask(
+            const std::string              &taskKey,
+            const SGProcessing::TaskResult &taskResult ) override;
 
         /**
          * @brief       
@@ -97,7 +101,7 @@ namespace sgns::processing
         std::chrono::system_clock::duration            m_processingTimeout;
         sgns::base::Logger                             m_logger = sgns::base::createLogger( "ProcessingTaskQueueImpl" );
         std::shared_ptr<sgns::crdt::AtomicTransaction> job_crdt_transaction_;
-
+        std::string                                    m_processing_topic;
     };
 
 }

--- a/src/storage/rocksdb/rocksdb.hpp
+++ b/src/storage/rocksdb/rocksdb.hpp
@@ -1,5 +1,3 @@
-
-
 #ifndef SUPERGENIUS_rocksdb_HPP
 #define SUPERGENIUS_rocksdb_HPP
 

--- a/test/src/crdt/crdt_atomic_transaction_test.cpp
+++ b/test/src/crdt/crdt_atomic_transaction_test.cpp
@@ -84,16 +84,16 @@ namespace sgns::crdt
                 EXPECT_OUTCOME_TRUE_1( transaction.Put( key1, value1 ) );
                 SimulateNetworkDelay(); // Still simulate delay but won't affect atomicity
                 EXPECT_OUTCOME_TRUE_1( transaction.Put( key2, value2 ) );
-                EXPECT_OUTCOME_TRUE_1( transaction.Commit() );
+                EXPECT_OUTCOME_TRUE_1( transaction.Commit( { "test" } ) );
             }
             else
             {
                 // Non-atomic updates - vulnerable to interleaving
-                EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, value1 ) );
+                EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, value1, { "test" } ) );
                 did_interrupt = true;   // Signal before delay to ensure interference
                 SimulateNetworkDelay(); // Longer delay to ensure t2 has time to interfere
                 SimulateNetworkDelay(); // Add extra delay
-                EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, value2 ) );
+                EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, value2, { "test" } ) );
             }
         }
 
@@ -108,8 +108,8 @@ namespace sgns::crdt
         Buffer initial_value;
         initial_value.put( "100" );
 
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, initial_value ) );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, initial_value ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, initial_value, { "test" } ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, initial_value, { "test" } ) );
 
         Buffer transfer_from_value;
         transfer_from_value.put( "50" );
@@ -137,8 +137,8 @@ namespace sgns::crdt
                     }
                     if ( !use_atomic && !t1_finished )
                     {
-                        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, initial_value ) );
-                        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, initial_value ) );
+                        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, initial_value, { "test" } ) );
+                        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, initial_value, { "test" } ) );
                     }
                 } );
 
@@ -160,8 +160,8 @@ namespace sgns::crdt
                 EXPECT_TRUE( has_interference );
             }
 
-            EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, initial_value ) );
-            EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, initial_value ) );
+            EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, initial_value, { "test" } ) );
+            EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, initial_value, { "test" } ) );
         }
     }
 
@@ -179,8 +179,8 @@ namespace sgns::crdt
         new_value2.put( "new2" );
 
         // Set initial values
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, initial_value ) );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, initial_value ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key1, initial_value, { "test" } ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( key2, initial_value, { "test" } ) );
 
         {
             // Create a transaction that will go out of scope without commit
@@ -207,7 +207,7 @@ namespace sgns::crdt
 
         // First operation should succeed
         EXPECT_OUTCOME_TRUE_1( transaction.Put( key, value ) );
-        EXPECT_OUTCOME_TRUE_1( transaction.Commit() );
+        EXPECT_OUTCOME_TRUE_1( transaction.Commit( {"test"} ) );
 
         // Second operation on same transaction should fail
         Buffer value2;

--- a/test/src/crdt/crdt_custom_broadcaster.cpp
+++ b/test/src/crdt/crdt_custom_broadcaster.cpp
@@ -3,7 +3,7 @@
 
 namespace sgns::crdt
 {
-    outcome::result<void> CustomBroadcaster::Broadcast(const base::Buffer& buff)
+    outcome::result<void> CustomBroadcaster::Broadcast(const base::Buffer& buff, std::string topic)
     {
         if (!buff.empty())
         {

--- a/test/src/crdt/crdt_custom_broadcaster.hpp
+++ b/test/src/crdt/crdt_custom_broadcaster.hpp
@@ -19,7 +19,7 @@ namespace sgns::crdt
          * @param buff buffer to broadcast
          * @return outcome::success on success or outcome::failure on error
          */
-        outcome::result<void> Broadcast(const base::Buffer& buff) override;
+        outcome::result<void> Broadcast(const base::Buffer& buff, std::string topic) override;
 
         /**
          * Obtain the next {@return} payload received from the network.

--- a/test/src/crdt/crdt_custom_dagsyncer.cpp
+++ b/test/src/crdt/crdt_custom_dagsyncer.cpp
@@ -66,7 +66,7 @@ namespace sgns::crdt
     outcome::result<std::shared_ptr<ipfs_lite::ipld::IPLDNode>> CustomDagSyncer::GetNodeWithoutRequest(
         const CID &cid ) const
     {
-        return getNode( cid );
+        return outcome::failure( boost::system::error_code{} );
     }
 
     std::pair<DAGSyncer::LinkInfoSet, DAGSyncer::LinkInfoSet> CustomDagSyncer::TraverseCIDsLinks(

--- a/test/src/crdt/crdt_custom_dagsyncer.cpp
+++ b/test/src/crdt/crdt_custom_dagsyncer.cpp
@@ -71,6 +71,7 @@ namespace sgns::crdt
 
     std::pair<std::set<CID>, std::set<CID>> CustomDagSyncer::TraverseCIDsLinks(
         const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
+        std::string                                       link_name,
         std::set<CID>                                     visited_cids ) const
     {
         std::set<CID> visited = std::move( visited_cids );
@@ -93,7 +94,7 @@ namespace sgns::crdt
                 continue;
             }
 
-            auto cid_pair = TraverseCIDsLinks( get_child_result.value(), visited );
+            auto cid_pair = TraverseCIDsLinks( get_child_result.value(), link_name, visited );
             links_to_fetch.merge( cid_pair.first );
             visited.merge( cid_pair.second );
         }

--- a/test/src/crdt/crdt_custom_dagsyncer.cpp
+++ b/test/src/crdt/crdt_custom_dagsyncer.cpp
@@ -73,7 +73,8 @@ namespace sgns::crdt
         const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
         std::string                                       link_name,
         DAGSyncer::LinkInfoSet                            visited_links,
-        bool                                              skip_if_visited_root ) const
+        bool                                              skip_if_visited_root,
+        int                                               max_depth ) const
     {
         DAGSyncer::LinkInfoSet links_to_fetch;
         DAGSyncer::LinkInfoSet visited = std::move( visited_links );
@@ -114,11 +115,16 @@ namespace sgns::crdt
                 links_to_fetch.insert( pair );
                 continue;
             }
+            if ( max_depth == 0 )
+            {
+                continue;
+            }
 
             auto [child_links, child_visited] = TraverseCIDsLinks( get_child_result.value(),
                                                                    link_name,
                                                                    visited,
-                                                                   skip_if_visited_root );
+                                                                   skip_if_visited_root,
+                                                                   max_depth - 1 );
 
             links_to_fetch.merge( child_links );
             visited.merge( child_visited );

--- a/test/src/crdt/crdt_custom_dagsyncer.hpp
+++ b/test/src/crdt/crdt_custom_dagsyncer.hpp
@@ -93,9 +93,10 @@ namespace sgns::crdt
             const CID &cid ) const override;
         std::pair<DAGSyncer::LinkInfoSet, DAGSyncer::LinkInfoSet> TraverseCIDsLinks(
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
-            std::string                                       link_name     = "",
-            DAGSyncer::LinkInfoSet                            visited_links = {},
-            bool                                              skip_if_visited_root  = true) const override;
+            std::string                                       link_name            = "",
+            DAGSyncer::LinkInfoSet                            visited_links        = {},
+            bool                                              skip_if_visited_root = true,
+            int                                               max_depth            = 50 ) const override;
         /** DAG service implementation */
         MerkleDagServiceImpl dagService_;
 

--- a/test/src/crdt/crdt_custom_dagsyncer.hpp
+++ b/test/src/crdt/crdt_custom_dagsyncer.hpp
@@ -93,6 +93,7 @@ namespace sgns::crdt
             const CID &cid ) const override;
         std::pair<std::set<CID>, std::set<CID>> TraverseCIDsLinks(
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
+            std::string                                       link_name = "",
             std::set<CID>                                     visited_cids = {} ) const override;
         /** DAG service implementation */
         MerkleDagServiceImpl dagService_;

--- a/test/src/crdt/crdt_custom_dagsyncer.hpp
+++ b/test/src/crdt/crdt_custom_dagsyncer.hpp
@@ -91,10 +91,10 @@ namespace sgns::crdt
 
         outcome::result<std::shared_ptr<ipfs_lite::ipld::IPLDNode>> GetNodeWithoutRequest(
             const CID &cid ) const override;
-        std::pair<std::set<CID>, std::set<CID>> TraverseCIDsLinks(
+        std::pair<DAGSyncer::LinkInfoSet, DAGSyncer::LinkInfoSet> TraverseCIDsLinks(
             const std::shared_ptr<ipfs_lite::ipld::IPLDNode> &node,
-            std::string                                       link_name = "",
-            std::set<CID>                                     visited_cids = {} ) const override;
+            std::string                                       link_name     = "",
+            DAGSyncer::LinkInfoSet                            visited_links = {} ) const override;
         /** DAG service implementation */
         MerkleDagServiceImpl dagService_;
 

--- a/test/src/crdt/crdt_datastore_test.cpp
+++ b/test/src/crdt/crdt_datastore_test.cpp
@@ -166,11 +166,11 @@ namespace sgns::crdt
         buffer.put( "Data" );
 
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey ), false );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( newKey, buffer ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->PutKey( newKey, buffer, { "topic"} ) );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey ), true );
         EXPECT_OUTCOME_TRUE( valueBuffer, crdtDatastore_->GetKey( newKey ) );
         EXPECT_TRUE( buffer.toString() == valueBuffer.toString() );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->DeleteKey( newKey ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->DeleteKey( newKey, { "topic"} ) );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey ), false );
     }
 
@@ -194,12 +194,11 @@ namespace sgns::crdt
         EXPECT_OUTCOME_TRUE_1( transaction.Put( newKey3, buffer3 ) );
         // this won't work as part of the same atomic transaction, because the Remove looks for the existing key
         // to create the delta, and since it's queued in the atomic transaction, it doesn't find key2
-        //EXPECT_OUTCOME_TRUE_1(transaction.Remove(newKey2));
-        EXPECT_OUTCOME_TRUE_1( transaction.Commit() );
+        EXPECT_OUTCOME_TRUE_1( transaction.Commit( { "topic"} ) );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey1 ), true );
         AtomicTransaction transactionRemoveKey2 = AtomicTransaction( crdtDatastore_ );
         EXPECT_OUTCOME_TRUE_1( transactionRemoveKey2.Remove( newKey2 ) );
-        EXPECT_OUTCOME_TRUE_1( transactionRemoveKey2.Commit() );
+        EXPECT_OUTCOME_TRUE_1( transactionRemoveKey2.Commit( { "topic"} ) );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey1 ), true );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey2 ), false );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey3 ), true );
@@ -239,7 +238,7 @@ namespace sgns::crdt
         auto e = mergedDelta->elements();
         ASSERT_TRUE( e.size() == 2 );
 
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( mergedDelta ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( mergedDelta, { "topic" } ) );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey3 ), true );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey4 ), true );
         EXPECT_OUTCOME_EQ( crdtDatastore_->HasKey( newKey5 ), false );
@@ -294,7 +293,7 @@ namespace sgns::crdt
 
         delta->set_priority( 1 );
 
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta, { "topic" } ) );
 
         std::chrono::milliseconds resultTime;
 
@@ -383,7 +382,7 @@ namespace sgns::crdt
 
         delta->set_priority( 1 );
 
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta, { "topic" } ) );
 
         std::chrono::milliseconds resultTime;
 
@@ -472,10 +471,10 @@ namespace sgns::crdt
         delta3->set_priority( 3 );
         delta4->set_priority( 4 );
 
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta1 ) );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta2 ) );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta3 ) );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta4 ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta1, { "topic" } ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta2, { "topic" } ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta3, { "topic" } ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta4, { "topic" } ) );
 
         std::chrono::milliseconds resultTime;
 
@@ -579,10 +578,10 @@ namespace sgns::crdt
         delta3->set_priority( 3 );
         delta4->set_priority( 4 );
 
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta1 ) );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta2 ) );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta3 ) );
-        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta4 ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta1, { "topic" } ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta2, { "topic" } ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta3, { "topic" } ) );
+        EXPECT_OUTCOME_TRUE_1( crdtDatastore_->Publish( delta4, { "topic" } ) );
 
         std::chrono::milliseconds resultTime;
 

--- a/test/src/crdt/crdt_heads_test.cpp
+++ b/test/src/crdt/crdt_heads_test.cpp
@@ -10,141 +10,144 @@
 
 namespace sgns::crdt
 {
-  using sgns::storage::rocksdb;
-  using sgns::base::Buffer;
-  using libp2p::multi::HashType;
-  using libp2p::multi::Multihash;
-  namespace fs = boost::filesystem;
+    using libp2p::multi::HashType;
+    using libp2p::multi::Multihash;
+    using sgns::base::Buffer;
+    using sgns::storage::rocksdb;
+    namespace fs = boost::filesystem;
 
-
-  TEST(CrdtHeadsTest, TestHeadsAdd)
-  {
-    const std::string strNamespace = "/namespace";
-    const auto hKey = HierarchicalKey(strNamespace);
-    const uint64_t height1 = 10;
-    const uint64_t height2 = 11;
-
-    const CID cid1 = CID(CID::Version::V1, CID::Multicodec::SHA2_256,
-      Multihash::create(HashType::sha256, "0123456789ABCDEF0123456789ABCDEF"_unhex).value());
-
-    const CID cid2 = CID(CID::Version::V1, CID::Multicodec::SHA2_256,
-      Multihash::create(HashType::sha256, "1123456789ABCDEF0123456789ABCDEF"_unhex).value());
-
-    // Remove leftover database
-    std::string databasePath = "supergenius_crdt_heads_test_set_value_add";
-    fs::remove_all(databasePath);
-
-    // Create new database
-    rocksdb::Options options;
-    options.create_if_missing = true;  // intentionally
-
-    auto dataStoreResult = rocksdb::create(databasePath, options);
-    auto dataStore = dataStoreResult.value();
-
-    // Create CrdtHead
-    CrdtHeads crdtHeads(dataStore, hKey);
-
-    auto cid1ToStringResult = cid1.toString();
-    auto hkeyTest = hKey.ChildString(cid1ToStringResult.value());
-
-    EXPECT_OUTCOME_TRUE(hKeyCID, crdtHeads.GetKey(cid1));
-    EXPECT_TRUE(hKeyCID == hkeyTest);
-
-    auto cid2ToStringResult = cid2.toString();
-    EXPECT_STRNE(cid1ToStringResult.value().c_str(), cid2ToStringResult.value().c_str());
-
-    // Test Add cid function
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid1, height1, ""));
-
-    // Test if cis is head
-    EXPECT_EQ(crdtHeads.IsHead(cid1), true);
-    EXPECT_EQ(crdtHeads.IsHead(cid2), false);
-
-    // Check cid height
-    EXPECT_OUTCOME_EQ(crdtHeads.GetHeadHeight(cid1), height1);
-    EXPECT_OUTCOME_EQ(crdtHeads.GetHeadHeight(cid2), 0);
-
-    EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 1);
-
-    // Add same cid again, should remain the same length
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid1, height1, ""));
-    EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 1);
-
-    // Add more cid
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid2, height2, ""));
-    EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
-
-    // Test getting heads
-    auto getListResult = crdtHeads.GetList();
-    EXPECT_OUTCOME_TRUE_1(getListResult);
-
-    auto [head_map, maxHeight] = getListResult.value();
-    uint64_t heads_size = 0;
-    for ( const auto &[topic_name, cid_set] : head_map )
+    TEST( CrdtHeadsTest, TestHeadsAdd )
     {
-        heads_size += cid_set.size();
+        const std::string strNamespace = "/namespace";
+        const auto        hKey         = HierarchicalKey( strNamespace );
+        const uint64_t    height1      = 10;
+        const uint64_t    height2      = 11;
+
+        const CID cid1 = CID( CID::Version::V1,
+                              CID::Multicodec::SHA2_256,
+                              Multihash::create( HashType::sha256, "0123456789ABCDEF0123456789ABCDEF"_unhex ).value() );
+
+        const CID cid2 = CID( CID::Version::V1,
+                              CID::Multicodec::SHA2_256,
+                              Multihash::create( HashType::sha256, "1123456789ABCDEF0123456789ABCDEF"_unhex ).value() );
+
+        // Remove leftover database
+        std::string databasePath = "supergenius_crdt_heads_test_set_value_add";
+        fs::remove_all( databasePath );
+
+        // Create new database
+        rocksdb::Options options;
+        options.create_if_missing = true; // intentionally
+
+        auto dataStoreResult = rocksdb::create( databasePath, options );
+        auto dataStore       = dataStoreResult.value();
+
+        // Create CrdtHead
+        CrdtHeads crdtHeads( dataStore, hKey );
+
+        auto cid1ToStringResult = cid1.toString();
+        auto hkeyTest           = hKey.ChildString( cid1ToStringResult.value() );
+
+        EXPECT_OUTCOME_TRUE( hKeyCID, crdtHeads.GetKey( cid1 ) );
+        EXPECT_TRUE( hKeyCID == hkeyTest );
+
+        auto cid2ToStringResult = cid2.toString();
+        EXPECT_STRNE( cid1ToStringResult.value().c_str(), cid2ToStringResult.value().c_str() );
+
+        // Test Add cid function
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid1, height1, "" ) );
+
+        // Test if cis is head
+        EXPECT_EQ( crdtHeads.IsHead( cid1 ), true );
+        EXPECT_EQ( crdtHeads.IsHead( cid2 ), false );
+
+        // Check cid height
+        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid1 ), height1 );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid2 ), 0 );
+
+        EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 1 );
+
+        // Add same cid again, should remain the same length
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid1, height1, "" ) );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 1 );
+
+        // Add more cid
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid2, height2, "" ) );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 2 );
+
+        // Test getting heads
+        auto getListResult = crdtHeads.GetList();
+        EXPECT_OUTCOME_TRUE_1( getListResult );
+
+        auto [head_map, maxHeight] = getListResult.value();
+        uint64_t heads_size        = 0;
+        for ( const auto &[topic_name, cid_set] : head_map )
+        {
+            heads_size += cid_set.size();
+        }
+
+        EXPECT_TRUE( heads_size == 2 );
+        EXPECT_TRUE( maxHeight == height2 );
     }
-    
-    EXPECT_TRUE(heads_size == 2);
-    EXPECT_TRUE(maxHeight == height2);
-  }
 
-  TEST(CrdtHeadsTest, TestHeadsReplace)
-  {
-    const std::string strNamespace = "/namespace";
-    const auto hKey = HierarchicalKey(strNamespace);
-    const uint64_t height1 = 10;
-    const uint64_t height2 = 11;
-
-    const CID cid1 = CID(CID::Version::V1, CID::Multicodec::SHA2_256,
-      Multihash::create(HashType::sha256, "0123456789ABCDEF0123456789ABCDEF"_unhex).value());
-
-    const CID cid2 = CID(CID::Version::V1, CID::Multicodec::SHA2_256,
-      Multihash::create(HashType::sha256, "1123456789ABCDEF0123456789ABCDEF"_unhex).value());
-
-    const CID cid3 = CID(CID::Version::V1, CID::Multicodec::SHA2_256,
-      Multihash::create(HashType::sha256, "2123456789ABCDEF0123456789ABCDEF"_unhex).value());
-
-    // Remove leftover database
-    std::string databasePath = "supergenius_crdt_heads_test_set_value_replace";
-    fs::remove_all(databasePath);
-
-    // Create new database
-    rocksdb::Options options;
-    options.create_if_missing = true;  // intentionally
-
-    auto dataStoreResult = rocksdb::create(databasePath, options);
-    auto dataStore = dataStoreResult.value();
-
-    // Create CrdtHead
-    CrdtHeads crdtHeads(dataStore, hKey);
-    auto addResult1 = crdtHeads.Add(cid1, height1, "");
-    auto addResult2 = crdtHeads.Add(cid2, height2, "");
-
-    EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Replace(cid2, cid3, height2, ""));
-    EXPECT_EQ(crdtHeads.IsHead(cid2), false);
-    EXPECT_EQ(crdtHeads.IsHead(cid3), true);
-    EXPECT_OUTCOME_EQ(crdtHeads.GetHeadHeight(cid3), height2);
-    EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
-
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Replace(cid3, cid3, height1, ""));
-    EXPECT_OUTCOME_EQ(crdtHeads.GetHeadHeight(cid3), height1);
-    EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
-
-    // Test getting heads
-    auto getListResult = crdtHeads.GetList();
-    EXPECT_OUTCOME_TRUE_1(getListResult);
-
-    auto [head_map, maxHeight] = getListResult.value();
-    uint64_t heads_size = 0;
-    for ( const auto &[topic_name, cid_set] : head_map )
+    TEST( CrdtHeadsTest, TestHeadsReplace )
     {
-        heads_size += cid_set.size();
-    }
-    
-    EXPECT_TRUE(heads_size == 2);
-    EXPECT_TRUE(maxHeight == height1);
+        const std::string strNamespace = "/namespace";
+        const auto        hKey         = HierarchicalKey( strNamespace );
+        const uint64_t    height1      = 10;
+        const uint64_t    height2      = 11;
 
-  }
+        const CID cid1 = CID( CID::Version::V1,
+                              CID::Multicodec::SHA2_256,
+                              Multihash::create( HashType::sha256, "0123456789ABCDEF0123456789ABCDEF"_unhex ).value() );
+
+        const CID cid2 = CID( CID::Version::V1,
+                              CID::Multicodec::SHA2_256,
+                              Multihash::create( HashType::sha256, "1123456789ABCDEF0123456789ABCDEF"_unhex ).value() );
+
+        const CID cid3 = CID( CID::Version::V1,
+                              CID::Multicodec::SHA2_256,
+                              Multihash::create( HashType::sha256, "2123456789ABCDEF0123456789ABCDEF"_unhex ).value() );
+
+        // Remove leftover database
+        std::string databasePath = "supergenius_crdt_heads_test_set_value_replace";
+        fs::remove_all( databasePath );
+
+        // Create new database
+        rocksdb::Options options;
+        options.create_if_missing = true; // intentionally
+
+        auto dataStoreResult = rocksdb::create( databasePath, options );
+        auto dataStore       = dataStoreResult.value();
+
+        // Create CrdtHead
+        CrdtHeads crdtHeads( dataStore, hKey );
+        auto      addResult1 = crdtHeads.Add( cid1, height1, "" );
+        auto      addResult2 = crdtHeads.Add( cid2, height2, "" );
+
+        EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 2 );
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Replace( cid2, cid3, height2, "" ) );
+        EXPECT_EQ( crdtHeads.IsHead( cid2 ), false );
+        EXPECT_EQ( crdtHeads.IsHead( cid3 ), true );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid3 ), height2 );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 2 );
+
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Replace( cid3, cid3, height1, "" ) );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid3 ), height1 );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 2 );
+
+        // Test getting heads
+        auto getListResult = crdtHeads.GetList();
+        EXPECT_OUTCOME_TRUE_1( getListResult );
+
+        auto [head_map, maxHeight] = getListResult.value();
+        uint64_t heads_size        = 0;
+        for ( const auto &[topic_name, cid_set] : head_map )
+        {
+            heads_size += cid_set.size();
+        }
+
+        EXPECT_TRUE( heads_size == 2 );
+        EXPECT_TRUE( maxHeight == height1 );
+    }
 }

--- a/test/src/crdt/crdt_heads_test.cpp
+++ b/test/src/crdt/crdt_heads_test.cpp
@@ -75,7 +75,7 @@ namespace sgns::crdt
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
 
     // Test getting heads
-    auto getListResult = heads_->GetList();
+    auto getListResult = crdtHeads.GetList();
     EXPECT_OUTCOME_TRUE_1(getListResult);
 
     auto [head_map, maxHeight] = getListResult.value();
@@ -133,10 +133,17 @@ namespace sgns::crdt
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
 
     // Test getting heads
-    std::vector<CID> heads;
-    uint64_t maxHeight = 0;
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.GetList(heads, maxHeight));
-    EXPECT_TRUE(heads.size() == 2);
+    auto getListResult = crdtHeads.GetList();
+    EXPECT_OUTCOME_TRUE_1(getListResult);
+
+    auto [head_map, maxHeight] = getListResult.value();
+    uint64_t heads_size = 0;
+    for ( const auto &[topic_name, cid_set] : head_map )
+    {
+        heads_size += cid_set.size();
+    }
+    
+    EXPECT_TRUE(heads_size == 2);
     EXPECT_TRUE(maxHeight == height1);
 
   }

--- a/test/src/crdt/crdt_heads_test.cpp
+++ b/test/src/crdt/crdt_heads_test.cpp
@@ -75,10 +75,17 @@ namespace sgns::crdt
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
 
     // Test getting heads
-    std::vector<CID> heads;
-    uint64_t maxHeight = 0;
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.GetList(heads, maxHeight));
-    EXPECT_TRUE(heads.size() == 2);
+    auto getListResult = heads_->GetList();
+    EXPECT_OUTCOME_TRUE_1(getListResult);
+
+    auto [head_map, maxHeight] = getListResult.value();
+    uint64_t heads_size = 0;
+    for ( const auto &[topic_name, cid_set] : head_map )
+    {
+        heads_size += cid_set.size();
+    }
+    
+    EXPECT_TRUE(heads_size == 2);
     EXPECT_TRUE(maxHeight == height2);
   }
 

--- a/test/src/crdt/crdt_heads_test.cpp
+++ b/test/src/crdt/crdt_heads_test.cpp
@@ -46,33 +46,33 @@ namespace sgns::crdt
         CrdtHeads crdtHeads( dataStore, hKey );
 
         auto cid1ToStringResult = cid1.toString();
-        auto hkeyTest           = hKey.ChildString( cid1ToStringResult.value() );
+        auto hkeyTest           = hKey.ChildString( "topic" ).ChildString( cid1ToStringResult.value() );
 
-        EXPECT_OUTCOME_TRUE( hKeyCID, crdtHeads.GetKey( cid1 ) );
+        EXPECT_OUTCOME_TRUE( hKeyCID, crdtHeads.GetKey( "topic", cid1 ) );
         EXPECT_TRUE( hKeyCID == hkeyTest );
 
         auto cid2ToStringResult = cid2.toString();
         EXPECT_STRNE( cid1ToStringResult.value().c_str(), cid2ToStringResult.value().c_str() );
 
         // Test Add cid function
-        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid1, height1, "" ) );
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid1, height1, "topic" ) );
 
         // Test if cis is head
-        EXPECT_EQ( crdtHeads.IsHead( cid1 ), true );
-        EXPECT_EQ( crdtHeads.IsHead( cid2 ), false );
+        EXPECT_EQ( crdtHeads.IsHead( cid1, "topic" ), true );
+        EXPECT_EQ( crdtHeads.IsHead( cid2, "topic" ), false );
 
         // Check cid height
-        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid1 ), height1 );
-        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid2 ), 0 );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid1, "topic" ), height1 );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid2, "topic" ), 0 );
 
         EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 1 );
 
         // Add same cid again, should remain the same length
-        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid1, height1, "" ) );
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid1, height1, "topic" ) );
         EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 1 );
 
         // Add more cid
-        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid2, height2, "" ) );
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Add( cid2, height2, "topic" ) );
         EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 2 );
 
         // Test getting heads
@@ -122,18 +122,18 @@ namespace sgns::crdt
 
         // Create CrdtHead
         CrdtHeads crdtHeads( dataStore, hKey );
-        auto      addResult1 = crdtHeads.Add( cid1, height1, "" );
-        auto      addResult2 = crdtHeads.Add( cid2, height2, "" );
+        auto      addResult1 = crdtHeads.Add( cid1, height1, "topic" );
+        auto      addResult2 = crdtHeads.Add( cid2, height2, "topic" );
 
         EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 2 );
-        EXPECT_OUTCOME_TRUE_1( crdtHeads.Replace( cid2, cid3, height2, "" ) );
-        EXPECT_EQ( crdtHeads.IsHead( cid2 ), false );
-        EXPECT_EQ( crdtHeads.IsHead( cid3 ), true );
-        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid3 ), height2 );
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Replace( cid2, cid3, height2, "topic" ) );
+        EXPECT_EQ( crdtHeads.IsHead( cid2, "topic" ), false );
+        EXPECT_EQ( crdtHeads.IsHead( cid3, "topic" ), true );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid3, "topic" ), height2 );
         EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 2 );
 
-        EXPECT_OUTCOME_TRUE_1( crdtHeads.Replace( cid3, cid3, height1, "" ) );
-        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid3 ), height1 );
+        EXPECT_OUTCOME_TRUE_1( crdtHeads.Replace( cid3, cid3, height1, "topic" ) );
+        EXPECT_OUTCOME_EQ( crdtHeads.GetHeadHeight( cid3, "topic" ), height1 );
         EXPECT_OUTCOME_EQ( crdtHeads.GetLength(), 2 );
 
         // Test getting heads

--- a/test/src/crdt/crdt_heads_test.cpp
+++ b/test/src/crdt/crdt_heads_test.cpp
@@ -54,7 +54,7 @@ namespace sgns::crdt
     EXPECT_STRNE(cid1ToStringResult.value().c_str(), cid2ToStringResult.value().c_str());
 
     // Test Add cid function
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid1, height1));
+    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid1, height1, ""));
 
     // Test if cis is head
     EXPECT_EQ(crdtHeads.IsHead(cid1), true);
@@ -67,11 +67,11 @@ namespace sgns::crdt
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 1);
 
     // Add same cid again, should remain the same length
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid1, height1));
+    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid1, height1, ""));
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 1);
 
     // Add more cid
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid2, height2));
+    EXPECT_OUTCOME_TRUE_1(crdtHeads.Add(cid2, height2, ""));
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
 
     // Test getting heads
@@ -111,17 +111,17 @@ namespace sgns::crdt
 
     // Create CrdtHead
     CrdtHeads crdtHeads(dataStore, hKey);
-    auto addResult1 = crdtHeads.Add(cid1, height1);
-    auto addResult2 = crdtHeads.Add(cid2, height2);
+    auto addResult1 = crdtHeads.Add(cid1, height1, "");
+    auto addResult2 = crdtHeads.Add(cid2, height2, "");
 
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Replace(cid2, cid3, height2));
+    EXPECT_OUTCOME_TRUE_1(crdtHeads.Replace(cid2, cid3, height2, ""));
     EXPECT_EQ(crdtHeads.IsHead(cid2), false);
     EXPECT_EQ(crdtHeads.IsHead(cid3), true);
     EXPECT_OUTCOME_EQ(crdtHeads.GetHeadHeight(cid3), height2);
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
 
-    EXPECT_OUTCOME_TRUE_1(crdtHeads.Replace(cid3, cid3, height1));
+    EXPECT_OUTCOME_TRUE_1(crdtHeads.Replace(cid3, cid3, height1, ""));
     EXPECT_OUTCOME_EQ(crdtHeads.GetHeadHeight(cid3), height1);
     EXPECT_OUTCOME_EQ(crdtHeads.GetLength(), 2);
 

--- a/test/src/crdt/crdt_mirror_broadcaster.cpp
+++ b/test/src/crdt/crdt_mirror_broadcaster.cpp
@@ -15,7 +15,7 @@ namespace sgns::crdt
         counterpart_ = dest;
     }
 
-    outcome::result<void> CRDTMirrorBroadcaster::Broadcast( const base::Buffer &buff )
+    outcome::result<void> CRDTMirrorBroadcaster::Broadcast( const base::Buffer &buff, std::string topic )
     {
         if ( ( !buff.empty() ) && ( counterpart_ ) )
         {

--- a/test/src/crdt/crdt_mirror_broadcaster.cpp
+++ b/test/src/crdt/crdt_mirror_broadcaster.cpp
@@ -19,16 +19,15 @@ namespace sgns::crdt
     {
         if ( ( !buff.empty() ) && ( counterpart_ ) )
         {
-            std::lock_guard<std::mutex> lock( counterpart_->mutex_ );
+            std::lock_guard<std::mutex>    lock( counterpart_->mutex_ );
             broadcasting::BroadcastMessage bmsg;
-            auto                                       bpi = new sgns::crdt::broadcasting::BroadcastMessage_PeerInfo;
-            std::string data( buff.toString() );
+            auto                           bpi = new sgns::crdt::broadcasting::BroadcastMessage_PeerInfo;
+            std::string                    data( buff.toString() );
             bmsg.set_data( data );
-            bpi->set_id(data);
-            bpi->add_addrs(data);
+            bpi->set_id( data );
+            bpi->add_addrs( data );
             bmsg.set_allocated_peer( bpi );
-            const std::string           bCastData( bmsg.SerializeAsString() );
-            
+            const std::string bCastData( bmsg.SerializeAsString() );
             counterpart_->listOfBroadcasts_.push( bCastData );
         }
         return outcome::success();
@@ -42,17 +41,13 @@ namespace sgns::crdt
             //Broadcaster::ErrorCode::ErrNoMoreBroadcast
             return outcome::failure( boost::system::error_code{} );
         }
-        
-        
-        
-        std::string strBuffer = listOfBroadcasts_.front();
+
+        std::string                    strBuffer = listOfBroadcasts_.front();
         broadcasting::BroadcastMessage bmsg;
 
         if ( !bmsg.ParseFromString( strBuffer ) )
         {
-
             return outcome::failure( boost::system::error_code{} );
-
         }
 
         std::string data_str = bmsg.data();

--- a/test/src/crdt/crdt_mirror_broadcaster.hpp
+++ b/test/src/crdt/crdt_mirror_broadcaster.hpp
@@ -26,7 +26,7 @@ namespace sgns::crdt
          * @param buff buffer to broadcast
          * @return outcome::success on success or outcome::failure on error
          */
-        outcome::result<void> Broadcast( const base::Buffer &buff ) override;
+        outcome::result<void> Broadcast( const base::Buffer &buff, std::string topic ) override;
 
         /**
          * Obtain the next {@return} payload received from the network.

--- a/test/src/crdt/globaldb_integration.cpp
+++ b/test/src/crdt/globaldb_integration.cpp
@@ -235,7 +235,7 @@ TEST_F( GlobalDBIntegrationTest, ReplicationWithoutTopicSuccessfulTest )
     ASSERT_NE( tx, nullptr );
     const auto putRes = tx->Put( key, value );
     ASSERT_TRUE( putRes.has_value() );
-    const auto commitRes = tx->Commit();
+    const auto commitRes = tx->Commit({"test"});
     ASSERT_TRUE( commitRes.has_value() );
 
     const bool replicated = waitForCondition(
@@ -279,7 +279,7 @@ TEST_F( GlobalDBIntegrationTest, ReplicationViaTopicBroadcastTest )
     ASSERT_NE( tx, nullptr );
     const auto putRes = tx->Put( key, value );
     ASSERT_TRUE( putRes.has_value() );
-    const auto commitRes = tx->Commit();
+    const auto commitRes = tx->Commit({"test"});
     ASSERT_TRUE( commitRes.has_value() );
 
     const bool replicated = waitForCondition(
@@ -332,14 +332,14 @@ TEST_F( GlobalDBIntegrationTest, ReplicationAcrossMultipleTopicsTest )
     ASSERT_NE( txA, nullptr );
     const auto putResA = txA->Put( keyA, valueA );
     ASSERT_TRUE( putResA.has_value() );
-    const auto commitResA = txA->Commit();
+    const auto commitResA = txA->Commit({"test"});
     ASSERT_TRUE( commitResA.has_value() );
 
     const auto txB = testNodes->getNodes()[1].db->BeginTransaction();
     ASSERT_NE( txB, nullptr );
     const auto putResB = txB->Put( keyB, valueB );
     ASSERT_TRUE( putResB.has_value() );
-    const auto commitResB = txB->Commit();
+    const auto commitResB = txB->Commit({"test"});
     ASSERT_TRUE( commitResB.has_value() );
 
     const bool replicated = waitForCondition(
@@ -375,9 +375,9 @@ TEST_F( GlobalDBIntegrationTest, PreventDoubleCommitTest )
     ASSERT_NE( tx, nullptr );
     const auto putRes = tx->Put( key, value );
     ASSERT_TRUE( putRes.has_value() );
-    const auto commitRes = tx->Commit();
+    const auto commitRes = tx->Commit({"test"});
     ASSERT_TRUE( commitRes.has_value() );
-    const auto secondCommit = tx->Commit();
+    const auto secondCommit = tx->Commit({"test"});
     EXPECT_FALSE( secondCommit.has_value() );
 }
 
@@ -395,7 +395,7 @@ TEST_F( GlobalDBIntegrationTest, DISABLED_CommitFailsForNonexistentTopicTest )
     ASSERT_NE( tx, nullptr );
     const auto putRes = tx->Put( key, value );
     ASSERT_TRUE( putRes.has_value() );
-    const auto commitRes = tx->Commit();
+    const auto commitRes = tx->Commit({"test"});
     EXPECT_FALSE( commitRes.has_value() );
 }
 
@@ -418,7 +418,7 @@ TEST_F( GlobalDBIntegrationTest, DirectPutWithTopicBroadcastTest )
     value.put( "Direct put with topic value" );
     const HierarchicalKey key( "/direct/with_topic" );
 
-    const auto putRes = testNodes->getNodes()[0].db->Put( key, value );
+    const auto putRes = testNodes->getNodes()[0].db->Put( key, value, {"topic"} );
     ASSERT_TRUE( putRes.has_value() );
 
     const bool replicated = waitForCondition(
@@ -458,7 +458,7 @@ TEST_F( GlobalDBIntegrationTest, DirectPutWithoutTopicBroadcastTest )
     value.put( "Direct put without topic value" );
     const HierarchicalKey key( "/direct/without_topic" );
 
-    const auto putRes = testNodes->getNodes()[0].db->Put( key, value );
+    const auto putRes = testNodes->getNodes()[0].db->Put( key, value,{"topic"} );
     ASSERT_TRUE( putRes.has_value() );
 
     const bool replicated = waitForCondition(
@@ -504,7 +504,7 @@ TEST_F( GlobalDBIntegrationTest, NonSubscriberDoesNotReceiveTopicMessageTest )
     ASSERT_NE( tx, nullptr );
     const auto putRes = tx->Put( key, value );
     ASSERT_TRUE( putRes.has_value() );
-    const auto commitRes = tx->Commit();
+    const auto commitRes = tx->Commit({"test"});
     ASSERT_TRUE( commitRes.has_value() );
 
     bool node0Received = waitForCondition( [&]() -> bool
@@ -546,7 +546,7 @@ TEST_F( GlobalDBIntegrationTest, UnconnectedNodeDoesNotReplicateBroadcastMessage
     ASSERT_NE( tx, nullptr );
     const auto putRes = tx->Put( key, value );
     ASSERT_TRUE( putRes.has_value() );
-    const auto commitRes = tx->Commit();
+    const auto commitRes = tx->Commit({"test"});
     ASSERT_TRUE( commitRes.has_value() );
 
     bool node1Replicated = waitForCondition( [&]() -> bool

--- a/test/src/graphsync/pubsub_graphsync_test.cpp
+++ b/test/src/graphsync/pubsub_graphsync_test.cpp
@@ -238,7 +238,7 @@ TEST_F( PubsubGraphsyncTest, MultiGlobalDBTest )
     data_transaction.put( gsl::span<const uint8_t>( dummy_data ) );
 
     transaction->Put( tx_key, data_transaction );
-    transaction->Commit();
+    transaction->Commit( {"test"} );
 
     auto                         transaction2 = gdb3->BeginTransaction();
     sgns::crdt::HierarchicalKey  tx_key2( "/test/test2" );
@@ -247,7 +247,7 @@ TEST_F( PubsubGraphsyncTest, MultiGlobalDBTest )
     data_transaction2.put( gsl::span<const uint8_t>( dummy_data2 ) );
 
     transaction2->Put( tx_key2, data_transaction2 );
-    transaction2->Commit();
+    transaction2->Commit( {"test"} );
 
     bool                         getConfirmed = false;
     sgns::crdt::GlobalDB::Buffer retrieved_data;

--- a/test/src/multiaccount/multi_account_sync.cpp
+++ b/test/src/multiaccount/multi_account_sync.cpp
@@ -89,7 +89,11 @@ DevConfig_st MultiAccountTest::DEV_CONFIG  = { "0xcafe",
                                                "1.0",
                                                sgns::TokenID::FromBytes( { 0x00 } ),
                                                "./node1" };
-DevConfig_st MultiAccountTest::DEV_CONFIG2 = { "0xcafe", "0.65", "1.0", sgns::TokenID::FromBytes( { 0x01 } ), "./node2" };
+DevConfig_st MultiAccountTest::DEV_CONFIG2 = { "0xcafe",
+                                               "0.65",
+                                               "1.0",
+                                               sgns::TokenID::FromBytes( { 0x00 } ),
+                                               "./node2" };
 
 std::string MultiAccountTest::binary_path = "";
 
@@ -105,14 +109,14 @@ TEST_F( MultiAccountTest, SyncThroughEachOther )
     auto mint_result = node_main->MintTokens( 50000000000,
                                               "",
                                               "",
-                                              sgns::TokenID::FromBytes({0x00}),
+                                              sgns::TokenID::FromBytes( { 0x00 } ),
                                               std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
     ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out";
 
     mint_result = node_proc1->MintTokens( 50000000000,
                                           "",
                                           "",
-                                          sgns::TokenID::FromBytes({0x00}),
+                                          sgns::TokenID::FromBytes( { 0x00 } ),
                                           std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
     ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out";
     auto transcount_main  = node_main->GetOutTransactions().size();

--- a/test/src/processing_nodes/CMakeLists.txt
+++ b/test/src/processing_nodes/CMakeLists.txt
@@ -45,3 +45,28 @@ else()
         "-Wl,--no-whole-archive"
     )
 endif()
+
+
+addtest(full_node_test
+    full_node_test.cpp
+)
+
+target_include_directories(full_node_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
+
+target_link_libraries(full_node_test
+    mp_utils
+    sgns_account
+)
+if(WIN32)
+    target_link_options(full_node_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:sgns_account>)
+
+elseif(APPLE)
+    target_link_options(full_node_test PUBLIC -force_load "$<TARGET_FILE:sgns_account>")
+
+else()
+    target_link_options(full_node_test PUBLIC
+        "-Wl,--whole-archive"
+        "$<TARGET_FILE:sgns_account>"
+        "-Wl,--no-whole-archive"
+    )
+endif()

--- a/test/src/processing_nodes/child_tokens_test.cpp
+++ b/test/src/processing_nodes/child_tokens_test.cpp
@@ -37,7 +37,7 @@ namespace
         DevConfig_st devConfig = { "", "0.65", tokenValue, tokenId, "" };
         std::strncpy( devConfig.Addr, self_address.c_str(), sizeof( devConfig.Addr ) - 1 );
         std::strncpy( devConfig.BaseWritePath, outPath.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
-        devConfig.Addr[sizeof( devConfig.Addr ) - 1] = '\0';
+        devConfig.Addr[sizeof( devConfig.Addr ) - 1]                   = '\0';
         devConfig.BaseWritePath[sizeof( devConfig.BaseWritePath ) - 1] = '\0';
 
         std::string key;
@@ -497,6 +497,14 @@ TEST_F( ProcessingNodesModuleTest, SinglePostProcessing )
 
     uint64_t expected_peer_gain = ( ( cost * 65 ) / 100 ) / 2;
 
+    assertWaitForCondition(
+        [&]()
+        {
+            return ( node_proc1->GetBalance() + node_proc2->GetBalance() ) ==
+                   ( bal_p1_init + bal_p2_init + 2 * expected_peer_gain );
+        },
+        std::chrono::milliseconds( 20000 ),
+        "Other nodes balance not updated in time" );
     ASSERT_EQ( bal_p1_init + bal_p2_init + 2 * expected_peer_gain,
                node_proc1->GetBalance() + node_proc2->GetBalance() );
     ASSERT_EQ( bal_p1_init + bal_p2_init + 2 * expected_peer_gain,

--- a/test/src/processing_nodes/full_node_test.cpp
+++ b/test/src/processing_nodes/full_node_test.cpp
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+#include <boost/dll.hpp>
+#include <thread>
+#include <cstring>
+#include <atomic>
+#include <iostream>
+#include "account/GeniusNode.hpp"
+#include "account/TokenID.hpp"
+#include "testutil/wait_condition.hpp"
+
+using namespace sgns;
+
+/**
+ * @brief Helper to create a GeniusNode with explicit full-node flag, custom folder, and fixed private key.
+ * @param self_address Address for this node
+ * @param tokenValue   TokenValueInGNUS to initialize DevConfig.
+ * @param tokenId      TokenID to initialize DevConfig.
+ * @param isProcessor  Whether this node is a processor node.
+ * @param isFullNode   Whether this node should run as a full node.
+ * @param folderName   Subfolder name under the binary path for storage.
+ * @param privKey      Hex string private key (64 chars) for deterministic identity.
+ * @return unique_ptr to the initialized GeniusNode.
+ */
+static std::unique_ptr<GeniusNode> CreateNodeWithMode( const std::string &self_address,
+                                                       const std::string &tokenValue,
+                                                       TokenID            tokenId,
+                                                       bool               isProcessor,
+                                                       bool               isFullNode,
+                                                       const std::string &folderName,
+                                                       const std::string &privKey )
+{
+    static std::atomic<int> nodeCounter{ 0 };
+    int                     id         = nodeCounter.fetch_add( 1 );
+    std::string             binaryPath = boost::dll::program_location().parent_path().string();
+    std::string             outPath    = binaryPath + "/" + folderName + "/";
+
+    DevConfig_st devConfig = { "", "1.0", tokenValue, tokenId, "" };
+    std::strncpy( devConfig.Addr, self_address.c_str(), sizeof( devConfig.Addr ) - 1 );
+    std::strncpy( devConfig.BaseWritePath, outPath.c_str(), sizeof( devConfig.BaseWritePath ) - 1 );
+    devConfig.Addr[sizeof( devConfig.Addr ) - 1]                   = '\0';
+    devConfig.BaseWritePath[sizeof( devConfig.BaseWritePath ) - 1] = '\0';
+
+    uint16_t port = static_cast<uint16_t>( 40001 + id );
+    auto     node = std::make_unique<GeniusNode>( devConfig, privKey.c_str(), false, isProcessor, port, isFullNode );
+
+    // allow startup
+    std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
+    return node;
+}
+
+TEST( NodeBalancePersistenceTest, BalancePersistsAfterRecreation )
+{
+    std::cout << "****** Removing old node_recovery folder ****" << std::endl;
+    {
+        std::string binaryPath   = boost::dll::program_location().parent_path().string();
+        std::string recoveryPath = binaryPath + "/node_recovery";
+        boost::filesystem::remove_all( recoveryPath );
+    }
+    const std::string fullKey   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    const std::string sharedKey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeea";
+
+    std::cout << "****** Full node creation ****" << std::endl;
+    auto fullNode = CreateNodeWithMode( "0xffff",
+                                        "1.0",
+                                        TokenID::FromBytes( { 0x01 } ),
+                                        /*isProcessor=*/false,
+                                        /*isFullNode=*/true,
+                                        /*folderName=*/"node_full",
+                                        fullKey );
+
+    std::cout << "****** Original node creation ****" << std::endl;
+    auto originalNode = CreateNodeWithMode( "0xabcd",
+                                            "1.0",
+                                            TokenID::FromBytes( { 0x00 } ),
+                                            /*isProcessor=*/false,
+                                            /*isFullNode=*/false,
+                                            /*folderName=*/"node_original",
+                                            sharedKey );
+
+    std::cout << "****** Minting tokens on original node ****" << std::endl;
+    uint64_t beforeMint = originalNode->GetBalance();
+    auto     mintRes    = originalNode->MintTokens(
+        /*amount=*/500000,
+        /*txHash=*/"",
+        /*chainId=*/"",
+        TokenID::FromBytes( { 0x00 } ) );
+    ASSERT_TRUE( mintRes.has_value() ) << "MintTokens failed on original node";
+    uint64_t afterMint = originalNode->GetBalance();
+    ASSERT_GT( afterMint, beforeMint );
+
+    std::cout << "****** Destroying original node after 10 seconds ****" << std::endl;
+    std::this_thread::sleep_for( std::chrono::seconds( 120 ) );
+    originalNode.reset();
+    std::this_thread::sleep_for( std::chrono::seconds( 10 ) );
+
+    std::cout << "****** Recovery node creation ****" << std::endl;
+    auto recoveryNode = CreateNodeWithMode( "0xabcd",
+                                            "1.0",
+                                            TokenID::FromBytes( { 0x01 } ),
+                                            /*isProcessor=*/false,
+                                            /*isFullNode=*/false,
+                                            /*folderName=*/"node_recovery",
+                                            sharedKey );
+
+    std::cout << "****** Verifying recovery node balance ****" << std::endl;
+    test::assertWaitForCondition( [&]() { return recoveryNode->GetBalance() == afterMint; },
+                                  std::chrono::milliseconds( 20000 ),
+                                  "Recovery node balance not updated in time" );
+}

--- a/test/src/processing_nodes/full_node_test.cpp
+++ b/test/src/processing_nodes/full_node_test.cpp
@@ -62,7 +62,7 @@ TEST( NodeBalancePersistenceTest, BalancePersistsAfterRecreation )
 
     std::cout << "****** Full node creation ****" << std::endl;
     auto fullNode =
-        CreateNodeWithMode( "0xffff", "1.0", TokenID::FromBytes( { 0x01 } ), false, true, "node_full", fullKey );
+        CreateNodeWithMode( "0xffff", "1.0", TokenID::FromBytes( { 0x01 } ), false, true, "node_full_2", fullKey );
 
     std::cout << "****** Original node creation ****" << std::endl;
     auto originalNode =

--- a/test/src/processing_nodes/full_node_test.cpp
+++ b/test/src/processing_nodes/full_node_test.cpp
@@ -78,6 +78,8 @@ TEST( NodeBalancePersistenceTest, BalancePersistsAfterRecreation )
                                             /*folderName=*/"node_original",
                                             sharedKey );
 
+    originalNode->GetPubSub()->AddPeers( { fullNode->GetPubSub()->GetLocalAddress() } );
+
     std::cout << "****** Minting tokens on original node ****" << std::endl;
     uint64_t beforeMint = originalNode->GetBalance();
     auto     mintRes    = originalNode->MintTokens(
@@ -90,7 +92,7 @@ TEST( NodeBalancePersistenceTest, BalancePersistsAfterRecreation )
     ASSERT_GT( afterMint, beforeMint );
 
     std::cout << "****** Destroying original node after 10 seconds ****" << std::endl;
-    std::this_thread::sleep_for( std::chrono::seconds( 120 ) );
+    std::this_thread::sleep_for( std::chrono::seconds( 15 ) );
     originalNode.reset();
     std::this_thread::sleep_for( std::chrono::seconds( 10 ) );
 
@@ -102,6 +104,7 @@ TEST( NodeBalancePersistenceTest, BalancePersistsAfterRecreation )
                                             /*isFullNode=*/false,
                                             /*folderName=*/"node_recovery",
                                             sharedKey );
+    recoveryNode->GetPubSub()->AddPeers( { fullNode->GetPubSub()->GetLocalAddress() } );
 
     std::cout << "****** Verifying recovery node balance ****" << std::endl;
     test::assertWaitForCondition( [&]() { return recoveryNode->GetBalance() == afterMint; },


### PR DESCRIPTION
### Fixes
- Fetching of the CID graph now works for more than 1 level. Old code didn't allow for traversal. Full node can now get all the content from a regular node
- Asan issues fixed regarding use-after-free
- Timestamp on transactions are fixed to ms
- Root/Head CID only recorded after links have been processed

### Features
- Recover of the synching of any CID head up to 50 levels of graph depth, meaning if a CID head is mid-sync and the application is shutdown until it's going through 50 levels of CID links, it's gonna recover after the next boot. This introduces some overhead on the case of just root update and could be improved in the future.
- Created CRDT topic to be inserted in every Put/Commit to CRDT. 
- CRDT heads now have topics tied with them. This enables SuperGenius to send to different peers different CIDs
- CID links also have topics, which means a CID list can be traversed according to a topic and avoid certain contents that are not relevant to a peer
- CRDT single instance now integrates jobs as well, since the jobs are just part of the "job topic" now
- Full node synching working with partial CRDT, so no regular node gets data that is not relevant to them
