### PR TITLE
Dev migration fix

### DIFF
--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -259,7 +259,7 @@ namespace sgns
 
         pubsub_ = std::make_shared<ipfs_pubsub::GossipPubSub>(
             crdt::KeyPairFileStorage( write_base_path_ + pubsubKeyPath ).GetKeyPair().value() );
-        auto pubs = pubsub_->Start( pubsubport_, { }, lanip, {} );
+        auto pubs = pubsub_->Start( pubsubport_, {}, lanip, {} );
         account_->InitMessenger( pubsub_ );
         pubs.wait();
 
@@ -272,6 +272,22 @@ namespace sgns
         auto scheduler = std::make_shared<libp2p::protocol::AsioScheduler>( io_, libp2p::protocol::SchedulerConfig{} );
         auto generator = std::make_shared<ipfs_lite::ipfs::graphsync::RequestIdGenerator>();
         auto graphsyncnetwork = std::make_shared<ipfs_lite::ipfs::graphsync::Network>( pubsub_->GetHost(), scheduler );
+
+        auto migrationManager = sgns::MigrationManager::New( io_,              // ioContext
+                                                             pubsub_,          // pubSub
+                                                             graphsyncnetwork, // graphsync
+                                                             scheduler,        // scheduler
+                                                             generator,        // generator
+                                                             write_base_path_, // writeBasePath
+                                                             base58key         // base58key
+        );
+
+        auto migrationResult = migrationManager->Migrate();
+        if ( migrationResult.has_error() )
+        {
+            throw std::runtime_error( std::string( "Database migration failed: " ) +
+                                      migrationResult.error().message() );
+        }
 
         auto global_db_ret = crdt::GlobalDB::New( io_,
                                                   write_base_path_ + gnus_network_full_path_,
@@ -301,23 +317,6 @@ namespace sgns
         task_result_storage_ = std::make_shared<processing::SubTaskResultStorageImpl>( tx_globaldb_,
                                                                                        processing_channel_topic_ );
 
-        auto migrationManager = sgns::MigrationManager::New( tx_globaldb_,     // newDb
-                                                             io_,              // ioContext
-                                                             pubsub_,          // pubSub
-                                                             graphsyncnetwork, // graphsync
-                                                             scheduler,        // scheduler
-                                                             generator,        // generator
-                                                             write_base_path_, // writeBasePath
-                                                             base58key         // base58key
-        );
-
-        auto migrationResult = migrationManager->Migrate();
-        if ( migrationResult.has_error() )
-        {
-            throw std::runtime_error( std::string( "Database migration failed: " ) +
-                                      migrationResult.error().message() );
-        }
-
         transaction_manager_ = TransactionManager::New( tx_globaldb_,
                                                         io_,
                                                         account_,
@@ -325,7 +324,9 @@ namespace sgns
                                                         is_full_node );
     }
 
-    base::Logger GeniusNode::ConfigureLogger( const std::string& tag, const std::string& logdir, spdlog::level::level_enum level )
+    base::Logger GeniusNode::ConfigureLogger( const std::string        &tag,
+                                              const std::string        &logdir,
+                                              spdlog::level::level_enum level )
     {
         auto logger = base::createLogger( tag, logdir );
         logger->set_level( level );
@@ -359,55 +360,55 @@ namespace sgns
 #endif
 #ifdef SGNS_DEBUGLOGS
         // Debug mode
-        node_logger_                = ConfigureLogger( "SuperGeniusNode", logdir, spdlog::level::debug );
-        auto loggerGeniusNode       = ConfigureLogger( "GeniusNode", logdir, spdlog::level::debug );
-        auto loggerGlobalDB         = ConfigureLogger( "GlobalDB", logdir, spdlog::level::err );
-        auto loggerDAGSyncer        = ConfigureLogger( "GraphsyncDAGSyncer", logdir, spdlog::level::err );
-        auto loggerGraphsync        = ConfigureLogger( "graphsync", logdir, spdlog::level::err );
-        auto loggerBroadcaster      = ConfigureLogger( "PubSubBroadcasterExt", logdir, spdlog::level::err );
-        auto loggerDataStore        = ConfigureLogger( "CrdtDatastore", logdir, spdlog::level::err );
-        auto loggerCRDTHeads        = ConfigureLogger( "CrdtHeads", logdir, spdlog::level::err );
-        auto loggerTransactions     = ConfigureLogger( "TransactionManager", logdir, spdlog::level::debug );
-        auto loggerMigration        = ConfigureLogger( "MigrationManager", logdir, spdlog::level::err );
-        auto loggerMigrationStep    = ConfigureLogger( "MigrationStep", logdir, spdlog::level::err );
-        auto loggerQueue            = ConfigureLogger( "ProcessingTaskQueueImpl", logdir, spdlog::level::err );
-        auto loggerRocksDB          = ConfigureLogger( "rocksdb", logdir, spdlog::level::err );
-        auto logkad                 = ConfigureLogger( "Kademlia", logdir, spdlog::level::err );
-        auto logNoise               = ConfigureLogger( "Noise", logdir, spdlog::level::err );
-        auto logProcessingEngine    = ConfigureLogger( "ProcessingEngine", logdir, spdlog::level::err );
-        auto loggerSubQueue         = ConfigureLogger( "ProcessingSubTaskQueueAccessorImpl", logdir, spdlog::level::err );
-        auto loggerProcServ         = ConfigureLogger( "ProcessingService", logdir, spdlog::level::err );
-        auto loggerProcqm           = ConfigureLogger( "ProcessingSubTaskQueueManager", logdir, spdlog::level::err );
-        auto loggerUPNP             = ConfigureLogger( "UPNP", logdir, spdlog::level::err );
-        auto loggerProcessingNode   = ConfigureLogger( "ProcessingNode", logdir, spdlog::level::err );
-        auto loggerGossipPubsub     = ConfigureLogger( "GossipPubSub", logdir, spdlog::level::err );
+        node_logger_              = ConfigureLogger( "SuperGeniusNode", logdir, spdlog::level::debug );
+        auto loggerGeniusNode     = ConfigureLogger( "GeniusNode", logdir, spdlog::level::debug );
+        auto loggerGlobalDB       = ConfigureLogger( "GlobalDB", logdir, spdlog::level::err );
+        auto loggerDAGSyncer      = ConfigureLogger( "GraphsyncDAGSyncer", logdir, spdlog::level::err );
+        auto loggerGraphsync      = ConfigureLogger( "graphsync", logdir, spdlog::level::err );
+        auto loggerBroadcaster    = ConfigureLogger( "PubSubBroadcasterExt", logdir, spdlog::level::err );
+        auto loggerDataStore      = ConfigureLogger( "CrdtDatastore", logdir, spdlog::level::err );
+        auto loggerCRDTHeads      = ConfigureLogger( "CrdtHeads", logdir, spdlog::level::err );
+        auto loggerTransactions   = ConfigureLogger( "TransactionManager", logdir, spdlog::level::debug );
+        auto loggerMigration      = ConfigureLogger( "MigrationManager", logdir, spdlog::level::err );
+        auto loggerMigrationStep  = ConfigureLogger( "MigrationStep", logdir, spdlog::level::err );
+        auto loggerQueue          = ConfigureLogger( "ProcessingTaskQueueImpl", logdir, spdlog::level::err );
+        auto loggerRocksDB        = ConfigureLogger( "rocksdb", logdir, spdlog::level::err );
+        auto logkad               = ConfigureLogger( "Kademlia", logdir, spdlog::level::err );
+        auto logNoise             = ConfigureLogger( "Noise", logdir, spdlog::level::err );
+        auto logProcessingEngine  = ConfigureLogger( "ProcessingEngine", logdir, spdlog::level::err );
+        auto loggerSubQueue       = ConfigureLogger( "ProcessingSubTaskQueueAccessorImpl", logdir, spdlog::level::err );
+        auto loggerProcServ       = ConfigureLogger( "ProcessingService", logdir, spdlog::level::err );
+        auto loggerProcqm         = ConfigureLogger( "ProcessingSubTaskQueueManager", logdir, spdlog::level::err );
+        auto loggerUPNP           = ConfigureLogger( "UPNP", logdir, spdlog::level::err );
+        auto loggerProcessingNode = ConfigureLogger( "ProcessingNode", logdir, spdlog::level::err );
+        auto loggerGossipPubsub   = ConfigureLogger( "GossipPubSub", logdir, spdlog::level::err );
         auto loggerAccountMessenger = ConfigureLogger( "AccountMessenger", logdir, spdlog::level::err );
         auto loggerGeniusAccount    = ConfigureLogger( "GeniusAccount", logdir, spdlog::level::err );
         auto loggerKeyPair          = ConfigureLogger( "KeyPairFileStorage", logdir, spdlog::level::err );
 #else
         // Release mode
-        node_logger_                = ConfigureLogger( "SuperGeniusNode", logdir, spdlog::level::err );
-        auto loggerGeniusNode       = ConfigureLogger( "GeniusNode", logdir, spdlog::level::err );
-        auto loggerGlobalDB         = ConfigureLogger( "GlobalDB", logdir, spdlog::level::err );
-        auto loggerDAGSyncer        = ConfigureLogger( "GraphsyncDAGSyncer", logdir, spdlog::level::err );
-        auto loggerGraphsync        = ConfigureLogger( "graphsync", logdir, spdlog::level::err );
-        auto loggerBroadcaster      = ConfigureLogger( "PubSubBroadcasterExt", logdir, spdlog::level::err );
-        auto loggerDataStore        = ConfigureLogger( "CrdtDatastore", logdir, spdlog::level::err );
-        auto loggerCRDTHeads        = ConfigureLogger( "CrdtHeads", logdir, spdlog::level::err );
-        auto loggerTransactions     = ConfigureLogger( "TransactionManager", logdir, spdlog::level::err );
-        auto loggerMigration        = ConfigureLogger( "MigrationManager", logdir, spdlog::level::err );
-        auto loggerMigrationStep    = ConfigureLogger( "MigrationStep", logdir, spdlog::level::err );
-        auto loggerQueue            = ConfigureLogger( "ProcessingTaskQueueImpl", logdir, spdlog::level::err );
-        auto loggerRocksDB          = ConfigureLogger( "rocksdb", logdir, spdlog::level::err );
-        auto logkad                 = ConfigureLogger( "Kademlia", logdir, spdlog::level::err );
-        auto logNoise               = ConfigureLogger( "Noise", logdir, spdlog::level::err );
-        auto logProcessingEngine    = ConfigureLogger( "ProcessingEngine", logdir, spdlog::level::err );
-        auto loggerSubQueue         = ConfigureLogger( "ProcessingSubTaskQueueAccessorImpl", logdir, spdlog::level::err );
-        auto loggerProcServ         = ConfigureLogger( "ProcessingService", logdir, spdlog::level::err );
-        auto loggerProcqm           = ConfigureLogger( "ProcessingSubTaskQueueManager", logdir, spdlog::level::err );
-        auto loggerUPNP             = ConfigureLogger( "UPNP", logdir, spdlog::level::err );
-        auto loggerProcessingNode   = ConfigureLogger( "ProcessingNode", logdir, spdlog::level::err );
-        auto loggerGossipPubsub     = ConfigureLogger( "GossipPubSub", logdir, spdlog::level::err );
+        node_logger_              = ConfigureLogger( "SuperGeniusNode", logdir, spdlog::level::err );
+        auto loggerGeniusNode     = ConfigureLogger( "GeniusNode", logdir, spdlog::level::err );
+        auto loggerGlobalDB       = ConfigureLogger( "GlobalDB", logdir, spdlog::level::err );
+        auto loggerDAGSyncer      = ConfigureLogger( "GraphsyncDAGSyncer", logdir, spdlog::level::err );
+        auto loggerGraphsync      = ConfigureLogger( "graphsync", logdir, spdlog::level::err );
+        auto loggerBroadcaster    = ConfigureLogger( "PubSubBroadcasterExt", logdir, spdlog::level::err );
+        auto loggerDataStore      = ConfigureLogger( "CrdtDatastore", logdir, spdlog::level::err );
+        auto loggerCRDTHeads      = ConfigureLogger( "CrdtHeads", logdir, spdlog::level::err );
+        auto loggerTransactions   = ConfigureLogger( "TransactionManager", logdir, spdlog::level::err );
+        auto loggerMigration      = ConfigureLogger( "MigrationManager", logdir, spdlog::level::err );
+        auto loggerMigrationStep  = ConfigureLogger( "MigrationStep", logdir, spdlog::level::err );
+        auto loggerQueue          = ConfigureLogger( "ProcessingTaskQueueImpl", logdir, spdlog::level::err );
+        auto loggerRocksDB        = ConfigureLogger( "rocksdb", logdir, spdlog::level::err );
+        auto logkad               = ConfigureLogger( "Kademlia", logdir, spdlog::level::err );
+        auto logNoise             = ConfigureLogger( "Noise", logdir, spdlog::level::err );
+        auto logProcessingEngine  = ConfigureLogger( "ProcessingEngine", logdir, spdlog::level::err );
+        auto loggerSubQueue       = ConfigureLogger( "ProcessingSubTaskQueueAccessorImpl", logdir, spdlog::level::err );
+        auto loggerProcServ       = ConfigureLogger( "ProcessingService", logdir, spdlog::level::err );
+        auto loggerProcqm         = ConfigureLogger( "ProcessingSubTaskQueueManager", logdir, spdlog::level::err );
+        auto loggerUPNP           = ConfigureLogger( "UPNP", logdir, spdlog::level::err );
+        auto loggerProcessingNode = ConfigureLogger( "ProcessingNode", logdir, spdlog::level::err );
+        auto loggerGossipPubsub   = ConfigureLogger( "GossipPubSub", logdir, spdlog::level::err );
         auto loggerAccountMessenger = ConfigureLogger( "AccountMessenger", logdir, spdlog::level::err );
         auto loggerGeniusAccount    = ConfigureLogger( "GeniusAccount", logdir, spdlog::level::err );
         auto loggerKeyPair          = ConfigureLogger( "KeyPairFileStorage", logdir, spdlog::level::err );
@@ -415,7 +416,7 @@ namespace sgns
 
         // Logger initialization complete
         node_logger_->info( "Logger initialized successfully" );
-        
+
         return true;
     }
 

--- a/src/account/Migration0_2_0To1_0_0.cpp
+++ b/src/account/Migration0_2_0To1_0_0.cpp
@@ -51,7 +51,11 @@ namespace sgns
     outcome::result<void> Migration0_2_0To1_0_0::Init()
     {
         OUTCOME_TRY( auto &&target_db, InitTargetDb() );
-        newDb_ = std::move( target_db );
+        db_1_0_0_ = std::move( target_db );
+        OUTCOME_TRY( auto &&outDb, InitLegacyDb( "out" ) );
+        db_0_0_2_out_ = std::move( outDb );
+        OUTCOME_TRY( auto &&inDb, InitLegacyDb( "in" ) );
+        db_0_0_2_in_ = std::move( inDb );
         return outcome::success();
     }
 
@@ -59,12 +63,14 @@ namespace sgns
     {
         sgns::crdt::GlobalDB::Buffer version_key;
         version_key.put( std::string( MigrationManager::VERSION_INFO_KEY ) );
-        auto version_ret = newDb_->GetDataStore()->get( version_key );
+        auto version_ret = db_1_0_0_->GetDataStore()->get( version_key );
 
         if ( version_ret.has_error() )
         {
+            m_logger->debug( "Can't find version on db {}, {}", ToVersion(), MigrationManager::VERSION_INFO_KEY );
             return true;
         }
+
         auto version = version_ret.value();
 
         if ( !IsVersionLessThan( std::string( version.toString() ), ToVersion() ) )
@@ -81,7 +87,7 @@ namespace sgns
 
     outcome::result<std::shared_ptr<crdt::GlobalDB>> Migration0_2_0To1_0_0::InitTargetDb()
     {
-        static constexpr auto DATABASE_1_0_0_PREFIX = "/SuperGNUSNode.TestNet.2a.01.%1%";
+        static constexpr auto DATABASE_1_0_0_PREFIX = "SuperGNUSNode.TestNet.2a.01.%1%";
 
         const auto legacyNetworkFullPath = ( boost::format( DATABASE_1_0_0_PREFIX ) % base58key_ ).str();
         const auto fullPath              = ( boost::format( "%s%s" ) % writeBasePath_ % legacyNetworkFullPath ).str();
@@ -99,17 +105,17 @@ namespace sgns
         if ( !maybe_db_1_0_0.has_value() )
         {
             m_logger->error( "1.0.0 database not created on {}", fullPath );
+            return outcome::failure( boost::system::error_code{} );
         }
-        else
-        {
-            m_logger->debug( "Started DB at path {}", fullPath );
-        }
+
+        m_logger->debug( "Started DB at path {}", fullPath );
+
         return std::move( maybe_db_1_0_0.value() );
     }
 
     outcome::result<std::shared_ptr<crdt::GlobalDB>> Migration0_2_0To1_0_0::InitLegacyDb( const std::string &suffix )
     {
-        static constexpr auto LEGACY_PREFIX_FMT = "/SuperGNUSNode.TestNet.2a.00.%1%";
+        static constexpr auto LEGACY_PREFIX_FMT = "SuperGNUSNode.TestNet.2a.00.%1%";
 
         const auto legacyNetworkFullPath = ( boost::format( LEGACY_PREFIX_FMT ) % base58key_ ).str();
         const auto fullPath = ( boost::format( "%s%s_%s" ) % writeBasePath_ % legacyNetworkFullPath % suffix ).str();
@@ -286,7 +292,7 @@ namespace sgns
             if ( migrated_count >= BATCH_SIZE )
             {
                 OUTCOME_TRY( crdt_transaction_->Commit( topics_ ) );
-                crdt_transaction_ = newDb_->BeginTransaction(); // start fresh
+                crdt_transaction_ = db_1_0_0_->BeginTransaction(); // start fresh
                 topics_.clear();
 
                 topics_.emplace( std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) );
@@ -303,16 +309,13 @@ namespace sgns
     {
         m_logger->debug( "Starting Apply step of Migration0_2_0To1_0_0" );
 
-        OUTCOME_TRY( auto outDb, InitLegacyDb( "out" ) );
-        OUTCOME_TRY( auto inDb, InitLegacyDb( "in" ) );
-
-        crdt_transaction_ = newDb_->BeginTransaction();
+        crdt_transaction_ = db_1_0_0_->BeginTransaction();
         topics_.clear();
 
         topics_.emplace( std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) );
 
         m_logger->debug( "Migrating output DB into new DB" );
-        OUTCOME_TRY( auto &&remainder_outdb, MigrateDb( outDb, newDb_ ) );
+        OUTCOME_TRY( auto &&remainder_outdb, MigrateDb( db_0_0_2_out_, db_1_0_0_ ) );
 
         if ( remainder_outdb > 0 )
         {
@@ -321,14 +324,14 @@ namespace sgns
                 m_logger->debug( "Commiting migrating to topics {}", topic );
             }
             OUTCOME_TRY( crdt_transaction_->Commit( topics_ ) );
-            crdt_transaction_ = newDb_->BeginTransaction();
+            crdt_transaction_ = db_1_0_0_->BeginTransaction();
             topics_.clear();
             topics_.emplace( std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) );
             m_logger->debug( "Committed remainder of output transactions: {}", remainder_outdb );
         }
 
         m_logger->debug( "Migrating input DB into new DB" );
-        OUTCOME_TRY( auto &&remainder_indb, MigrateDb( inDb, newDb_ ) );
+        OUTCOME_TRY( auto &&remainder_indb, MigrateDb( db_0_0_2_in_, db_1_0_0_ ) );
 
         if ( remainder_indb > 0 )
         {
@@ -343,7 +346,7 @@ namespace sgns
         version_key.put( std::string( MigrationManager::VERSION_INFO_KEY ) );
         version_buffer.put( ToVersion() );
 
-        OUTCOME_TRY( newDb_->GetDataStore()->put( version_key, version_buffer ) );
+        OUTCOME_TRY( db_1_0_0_->GetDataStore()->put( version_key, version_buffer ) );
 
         m_logger->debug( "Apply step of Migration0_2_0To1_0_0 finished successfully" );
 
@@ -352,9 +355,10 @@ namespace sgns
 
     outcome::result<void> Migration0_2_0To1_0_0::ShutDown()
     {
-        m_logger->debug( "Deleting 1.0.0 DB with previous count {}", newDb_.use_count() );
+        db_0_0_2_in_.reset();
+        db_0_0_2_out_.reset();
         crdt_transaction_.reset();
-        newDb_.reset();
+        db_1_0_0_.reset();
         return outcome::success();
     }
 

--- a/src/account/Migration0_2_0To1_0_0.hpp
+++ b/src/account/Migration0_2_0To1_0_0.hpp
@@ -105,8 +105,10 @@ namespace sgns
         outcome::result<uint32_t> MigrateDb( const std::shared_ptr<crdt::GlobalDB> &oldDb,
                                              const std::shared_ptr<crdt::GlobalDB> &newDb );
 
-        std::shared_ptr<crdt::GlobalDB>                                 newDb_;     ///< Target GlobalDB.
-        std::shared_ptr<boost::asio::io_context>                        ioContext_; ///< IO context for DB I/O.
+        std::shared_ptr<crdt::GlobalDB>                                 db_1_0_0_;     ///< Target GlobalDB.
+        std::shared_ptr<crdt::GlobalDB>                                 db_0_0_2_out_; ///< Target GlobalDB.
+        std::shared_ptr<crdt::GlobalDB>                                 db_0_0_2_in_;  ///< Target GlobalDB.
+        std::shared_ptr<boost::asio::io_context>                        ioContext_;    ///< IO context for DB I/O.
         std::shared_ptr<ipfs_pubsub::GossipPubSub>                      pubSub_;    ///< PubSub instance for legacy DB.
         std::shared_ptr<ipfs_lite::ipfs::graphsync::Network>            graphsync_; ///< GraphSync network.
         std::shared_ptr<libp2p::protocol::Scheduler>                    scheduler_; ///< libp2p scheduler.

--- a/src/account/Migration1_0_0To3_4_0.cpp
+++ b/src/account/Migration1_0_0To3_4_0.cpp
@@ -10,7 +10,6 @@ namespace sgns
 {
 
     Migration1_0_0To3_4_0::Migration1_0_0To3_4_0(
-        std::shared_ptr<crdt::GlobalDB>                                 db,
         std::shared_ptr<boost::asio::io_context>                        ioContext,
         std::shared_ptr<ipfs_pubsub::GossipPubSub>                      pubSub,
         std::shared_ptr<ipfs_lite::ipfs::graphsync::Network>            graphsync,
@@ -18,7 +17,6 @@ namespace sgns
         std::shared_ptr<ipfs_lite::ipfs::graphsync::RequestIdGenerator> generator,
         std::string                                                     writeBasePath,
         std::string                                                     base58key ) :
-        db_( std::move( db ) ),
         ioContext_( std::move( ioContext ) ),
         pubSub_( std::move( pubSub ) ),
         graphsync_( std::move( graphsync ) ),
@@ -45,7 +43,7 @@ namespace sgns
     {
         sgns::crdt::GlobalDB::Buffer version_key;
         version_key.put( std::string( MigrationManager::VERSION_INFO_KEY ) );
-        auto version_ret = db_->GetDataStore()->get( version_key );
+        auto version_ret = db_3_4_0_->GetDataStore()->get( version_key );
 
         if ( version_ret.has_error() )
         {
@@ -67,7 +65,7 @@ namespace sgns
         version_buffer.clear();
         version_buffer.put( ToVersion() );
 
-        OUTCOME_TRY( db_->GetDataStore()->put( version_key, version_buffer ) );
+        OUTCOME_TRY( db_3_4_0_->GetDataStore()->put( version_key, version_buffer ) );
 
         logger_->info( "GlobalDB at version {}, but updated already no migration to {} is required",
                        FromVersion(),
@@ -79,13 +77,15 @@ namespace sgns
     {
         OUTCOME_TRY( auto &&legacy_db, InitLegacyDb() );
         db_1_0_0_ = std::move( legacy_db );
+        OUTCOME_TRY( auto &&new_db, InitTargetDb() );
+        db_3_4_0_ = std::move( new_db );
         return outcome::success();
     }
 
     outcome::result<void> Migration1_0_0To3_4_0::Apply()
     {
         logger_->info( "Starting migration from {} to {}", FromVersion(), ToVersion() );
-        auto                  crdt_transaction_ = db_->BeginTransaction();
+        auto                  crdt_transaction_ = db_3_4_0_->BeginTransaction();
         std::set<std::string> topics_;
 
         topics_.emplace( std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) );
@@ -159,7 +159,7 @@ namespace sgns
             if ( migrated_count >= BATCH_SIZE )
             {
                 OUTCOME_TRY( crdt_transaction_->Commit( topics_ ) );
-                crdt_transaction_ = db_->BeginTransaction(); // start fresh
+                crdt_transaction_ = db_3_4_0_->BeginTransaction(); // start fresh
                 topics_.clear();
 
                 topics_.emplace( std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) );
@@ -178,7 +178,7 @@ namespace sgns
         version_key.put( std::string( MigrationManager::VERSION_INFO_KEY ) );
         version_buffer.put( ToVersion() );
 
-        OUTCOME_TRY( db_->GetDataStore()->put( version_key, version_buffer ) );
+        OUTCOME_TRY( db_3_4_0_->GetDataStore()->put( version_key, version_buffer ) );
         logger_->debug( "Migration from {} to {} completed successfully", FromVersion(), ToVersion() );
 
         return outcome::success();
@@ -186,7 +186,7 @@ namespace sgns
 
     outcome::result<std::shared_ptr<crdt::GlobalDB>> Migration1_0_0To3_4_0::InitLegacyDb()
     {
-        static constexpr auto LEGACY_PREFIX_FMT = "/SuperGNUSNode.TestNet.2a.01.%1%";
+        static constexpr auto LEGACY_PREFIX_FMT = "SuperGNUSNode.TestNet.2a.01.%1%";
 
         const auto legacyNetworkFullPath = ( boost::format( LEGACY_PREFIX_FMT ) % base58key_ ).str();
         const auto fullPath              = ( boost::format( "%s%s" ) % writeBasePath_ % legacyNetworkFullPath ).str();
@@ -211,9 +211,37 @@ namespace sgns
         return std::move( maybe_db_1_0_0.value() );
     }
 
+    outcome::result<std::shared_ptr<crdt::GlobalDB>> Migration1_0_0To3_4_0::InitTargetDb()
+    {
+        static constexpr std::string_view GNUS_NETWORK_PATH_3_4_0 = "SuperGNUSNode.Node";
+
+        auto full_path = writeBasePath_ + std::string( GNUS_NETWORK_PATH_3_4_0 ) +
+                         version::GetNetAndVersionAppendix( 3, 4, version::GetNetworkID() ) + base58key_;
+
+        logger_->debug( "Initializing target {} DB at path {}", ToVersion(), full_path );
+
+        auto maybe_db_3_4_0 = crdt::GlobalDB::New( ioContext_,
+                                                   full_path,
+                                                   pubSub_,
+                                                   crdt::CrdtOptions::DefaultOptions(),
+                                                   graphsync_,
+                                                   scheduler_,
+                                                   generator_ );
+
+        if ( !maybe_db_3_4_0.has_value() )
+        {
+            logger_->error( "Target {} DB error at path {}", ToVersion(), full_path );
+            return outcome::failure( boost::system::error_code{} );
+        }
+
+        logger_->debug( "Started target {} DB at path {}", ToVersion(), full_path );
+        return std::move( maybe_db_3_4_0.value() );
+    }
+
     outcome::result<void> Migration1_0_0To3_4_0::ShutDown()
     {
         db_1_0_0_.reset();
+        db_3_4_0_.reset();
         return outcome::success();
     }
 }

--- a/src/account/Migration1_0_0To3_4_0.hpp
+++ b/src/account/Migration1_0_0To3_4_0.hpp
@@ -23,8 +23,7 @@ namespace sgns
     class Migration1_0_0To3_4_0 : public IMigrationStep
     {
     public:
-        Migration1_0_0To3_4_0( std::shared_ptr<crdt::GlobalDB>                                 db,
-                               std::shared_ptr<boost::asio::io_context>                        ioContext,
+        Migration1_0_0To3_4_0( std::shared_ptr<boost::asio::io_context>                        ioContext,
                                std::shared_ptr<ipfs_pubsub::GossipPubSub>                      pubSub,
                                std::shared_ptr<ipfs_lite::ipfs::graphsync::Network>            graphsync,
                                std::shared_ptr<libp2p::protocol::Scheduler>                    scheduler,
@@ -67,6 +66,7 @@ namespace sgns
          * @return  opened DB or error.
          */
         outcome::result<std::shared_ptr<crdt::GlobalDB>>                InitLegacyDb();
+        outcome::result<std::shared_ptr<crdt::GlobalDB>>                InitTargetDb();
         std::shared_ptr<boost::asio::io_context>                        ioContext_; ///< IO context for DB I/O.
         std::shared_ptr<ipfs_pubsub::GossipPubSub>                      pubSub_;    ///< PubSub instance for legacy DB.
         std::shared_ptr<ipfs_lite::ipfs::graphsync::Network>            graphsync_; ///< GraphSync network.
@@ -75,8 +75,8 @@ namespace sgns
         std::string                     writeBasePath_;                             ///< Base path for writing DB files.
         std::string                     base58key_;                                 ///< Key to build legacy paths.
         base::Logger                    logger_ = base::createLogger( "MigrationStep" ); ///< Logger for this step.
-        std::shared_ptr<crdt::GlobalDB> db_;                                             ///< Target GlobalDB.
-        std::shared_ptr<crdt::GlobalDB> db_1_0_0_;
+        std::shared_ptr<crdt::GlobalDB> db_3_4_0_;                                       ///< Target GlobalDB.
+        std::shared_ptr<crdt::GlobalDB> db_1_0_0_;                                       ///< Legacy GlobalDB.
     };
 
 }

--- a/src/account/MigrationManager.cpp
+++ b/src/account/MigrationManager.cpp
@@ -18,7 +18,6 @@ namespace sgns
 {
 
     std::shared_ptr<MigrationManager> MigrationManager::New(
-        std::shared_ptr<crdt::GlobalDB>                                 newDb,
         std::shared_ptr<boost::asio::io_context>                        ioContext,
         std::shared_ptr<ipfs_pubsub::GossipPubSub>                      pubSub,
         std::shared_ptr<ipfs_lite::ipfs::graphsync::Network>            graphsync,
@@ -35,8 +34,7 @@ namespace sgns
                                                                          generator,
                                                                          writeBasePath,
                                                                          base58key ) );
-        instance->RegisterStep( std::make_unique<Migration1_0_0To3_4_0>( newDb,
-                                                                         ioContext,
+        instance->RegisterStep( std::make_unique<Migration1_0_0To3_4_0>( ioContext,
                                                                          pubSub,
                                                                          graphsync,
                                                                          scheduler,

--- a/src/account/MigrationManager.hpp
+++ b/src/account/MigrationManager.hpp
@@ -37,7 +37,6 @@ namespace sgns
     public:
         /**
          * @brief   Factory function to create a MigrationManager and register all known steps.
-         * @param   newDb         Shared pointer to the target GlobalDB.
          * @param   ioContext     Shared io_context for both legacy and new DB.
          * @param   pubSub        Shared GossipPubSub instance.
          * @param   graphsync     Shared GraphSync network object.
@@ -48,7 +47,6 @@ namespace sgns
          * @return  std::shared_ptr<MigrationManager> to the created instance.
          */
         static std::shared_ptr<MigrationManager> New(
-            std::shared_ptr<crdt::GlobalDB>                                 newDb,
             std::shared_ptr<boost::asio::io_context>                        ioContext,
             std::shared_ptr<ipfs_pubsub::GossipPubSub>                      pubSub,
             std::shared_ptr<ipfs_lite::ipfs::graphsync::Network>            graphsync,

--- a/src/base/sgns_version.cpp
+++ b/src/base/sgns_version.cpp
@@ -59,8 +59,14 @@ uint16_t sgns::version::GetNetworkID()
 
 std::string sgns::version::GetNetAndVersionAppendix()
 {
-    return ( boost::format( std::string( sgns::version::SGNS_VERSION_APPENDIX ) ) % sgns::version::SuperGeniusVersionMajor() %
-             sgns::version::SuperGeniusVersionMinor() )
+    return GetNetAndVersionAppendix( sgns::version::SuperGeniusVersionMajor(),
+                                     sgns::version::SuperGeniusVersionMinor(),
+                                     sgns::version::GetNetworkID() );
+}
+
+std::string sgns::version::GetNetAndVersionAppendix( uint32_t version_major, uint32_t version_minor, uint16_t net_id )
+{
+    return ( boost::format( std::string( sgns::version::SGNS_VERSION_APPENDIX ) ) % version_major % version_minor )
                .str() +
-           ( boost::format( std::string( sgns::version::NET_ID_APPENDIX ) ) % sgns::version::GetNetworkID() ).str();
+           ( boost::format( std::string( sgns::version::NET_ID_APPENDIX ) ) % net_id ).str();
 }

--- a/src/base/sgns_version.hpp
+++ b/src/base/sgns_version.hpp
@@ -64,5 +64,6 @@ namespace sgns
         uint16_t GetNetworkID();
 
         std::string GetNetAndVersionAppendix();
+        std::string GetNetAndVersionAppendix( uint32_t version_major, uint32_t version_minor, uint16_t net_id );
     }
 }


### PR DESCRIPTION
- Better interface of the migration manager
- The in-use database is not passed to the migration module, so we don't infer that it is from the latest version.
- Migration manager is triggered and ran before we even create the database we are gonna use. That makes it better encapsulated and basically the database is all done and created before GeniusNode tries to open it