### PR TITLE
Validator Registry created

### DIFF
--- a/src/account/AccountMessenger.cpp
+++ b/src/account/AccountMessenger.cpp
@@ -143,6 +143,9 @@ namespace sgns
                 case accountComm::AccountMessage::kBlockRequest:
                     HandleBlockRequest( acc_msg.block_request() );
                     break;
+                case accountComm::AccountMessage::kBlockCidRequest:
+                    HandleBlockCidRequest( acc_msg.block_cid_request() );
+                    break;
                 case accountComm::AccountMessage::kNonceResponse:
                 case accountComm::AccountMessage::kBlockResponse:
                     logger_->error( "{}: Unexpected response received ", __func__ );
@@ -176,6 +179,9 @@ namespace sgns
                     break;
                 case accountComm::AccountMessage::kBlockResponse:
                     HandleBlockResponse( acc_msg.block_response() );
+                    break;
+                case accountComm::AccountMessage::kBlockCidRequest:
+                    logger_->error( "{}: Unexpected response received ", __func__ );
                     break;
                 default:
                     logger_->error( "{}: Unknown AccountMessage type received on {}", __func__ );
@@ -219,7 +225,7 @@ namespace sgns
         auto future  = promise->get_future();
 
         EnqueueTask(
-            { RequestType::Nonce, timeout_ms, silent_time_ms, 0, nullptr, std::move( promise ) } );
+            { RequestType::Nonce, timeout_ms, silent_time_ms, 0, std::string{}, nullptr, std::move( promise ) } );
 
         return future.get();
     }
@@ -227,7 +233,16 @@ namespace sgns
     outcome::result<void> AccountMessenger::RequestGenesis(
         uint64_t timeout_ms, std::function<void( outcome::result<std::string> )> callback )
     {
-        EnqueueTask( { RequestType::Genesis, timeout_ms, 150, 0, std::move( callback ), nullptr } );
+        EnqueueTask( { RequestType::Genesis, timeout_ms, 150, 0, std::string{}, std::move( callback ), nullptr } );
+        return outcome::success();
+    }
+
+    outcome::result<void> AccountMessenger::RequestRegularBlock( uint64_t                                            timeout_ms,
+                                                                 std::string                                         cid,
+                                                                 std::function<void( outcome::result<std::string> )> callback )
+    {
+        EnqueueTask(
+            { RequestType::BlockByCid, timeout_ms, 150, 0, std::move( cid ), std::move( callback ), nullptr } );
         return outcome::success();
     }
 
@@ -256,6 +271,35 @@ namespace sgns
 
         accountComm::AccountMessage envelope;
         *envelope.mutable_block_request() = signed_req;
+
+        return SendAccountMessage( envelope, { requests_topic_ } );
+    }
+
+    outcome::result<void> AccountMessenger::RequestBlockByCid( uint64_t req_id, const std::string &cid )
+    {
+        accountComm::BlockCidRequest req;
+        req.set_requester_address( address_ );
+        req.set_request_id( req_id );
+        req.set_timestamp(
+            std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
+                .count() );
+        req.set_cid( cid );
+
+        std::string encoded;
+        if ( !req.SerializeToString( &encoded ) )
+        {
+            return outcome::failure( Error::PROTO_SERIALIZATION );
+        }
+
+        std::vector<uint8_t> serialized_vec( encoded.begin(), encoded.end() );
+        OUTCOME_TRY( auto &&signature, methods_.sign_( serialized_vec ) );
+
+        accountComm::SignedBlockCidRequest signed_req;
+        *signed_req.mutable_data() = req;
+        signed_req.set_signature( signature.data(), signature.size() );
+
+        accountComm::AccountMessage envelope;
+        *envelope.mutable_block_cid_request() = signed_req;
 
         return SendAccountMessage( envelope, { requests_topic_ } );
     }
@@ -339,6 +383,114 @@ namespace sgns
         std::vector<uint8_t> resp_bytes( resp_serialized.begin(), resp_serialized.end() );
 
         auto signature_res = methods_.sign_( resp_bytes );
+        if ( signature_res.has_error() )
+        {
+            logger_->error( "Failed to sign BlockResponse" );
+            return;
+        }
+
+        accountComm::SignedBlockResponse signed_resp;
+        *signed_resp.mutable_data() = resp;
+        auto signature              = signature_res.value();
+        signed_resp.set_signature( signature.data(), signature.size() );
+
+        accountComm::AccountMessage msg;
+        *msg.mutable_block_response() = signed_resp;
+
+        auto account_topic = req.requester_address() + std::string( ACCOUNT_COMM ) +
+                             sgns::version::GetNetAndVersionAppendix();
+
+        auto send_ret = SendAccountMessage( msg, { account_topic } );
+        if ( send_ret.has_error() )
+        {
+            logger_->error( "[{}] Failed to send BlockResponse for req_id {}",
+                            address_.substr( 0, 8 ),
+                            req.request_id() );
+        }
+        else
+        {
+            logger_->debug( "[{}] Sent BlockResponse ({} block entries) to {} (req_id {})",
+                            address_.substr( 0, 8 ),
+                            resp.blocks_size(),
+                            req.requester_address().substr( 0, 8 ),
+                            req.request_id() );
+        }
+    }
+
+    void AccountMessenger::HandleBlockCidRequest( const accountComm::SignedBlockCidRequest &signed_req )
+    {
+        const auto &req = signed_req.data();
+
+        logger_->debug( "[{}] Received a Block-by-CID request req_id {} cid {}",
+                        address_.substr( 0, 8 ),
+                        req.request_id(),
+                        req.cid() );
+
+        std::string serialized;
+        if ( !req.SerializeToString( &serialized ) )
+        {
+            logger_->error( "Failed to serialize BlockCidRequest for signature check" );
+            return;
+        }
+        std::vector<uint8_t> serialized_vec( serialized.begin(), serialized.end() );
+        auto                 verify_signature_result = methods_.verify_signature_( req.requester_address(),
+                                                                   signed_req.signature(),
+                                                                   serialized_vec );
+        if ( verify_signature_result.has_error() || !verify_signature_result.value() )
+        {
+            logger_->error( "Invalid signature on BlockCidRequest from {}", req.requester_address() );
+            return;
+        }
+
+        bool have_cid = false;
+        if ( methods_.has_block_cid_ )
+        {
+            auto has_cid_result = methods_.has_block_cid_( req.cid() );
+            have_cid = has_cid_result.has_value() && has_cid_result.value();
+        }
+        else
+        {
+            logger_->error( "No has_block_cid_ method configured" );
+        }
+
+        accountComm::BlockResponse resp;
+        resp.set_responder_address( address_ );
+        resp.set_requester_address( req.requester_address() );
+        resp.set_request_id( req.request_id() );
+        resp.set_timestamp(
+            std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
+                .count() );
+
+        if ( have_cid )
+        {
+            auto *info = resp.add_blocks();
+            info->set_cid( req.cid() );
+
+            auto peer_info = pubsub_->GetHost()->getPeerInfo();
+            info->set_peer_id( std::string( peer_info.id.toVector().begin(), peer_info.id.toVector().end() ) );
+
+            auto pubsubObserved = pubsub_->GetHost()->getObservedAddressesReal();
+            for ( auto &addr : pubsubObserved )
+            {
+                info->add_addresses( addr.getStringAddress() );
+                logger_->debug( "Address Broadcast: {}", addr.getStringAddress() );
+            }
+            for ( auto &addr : peer_info.addresses )
+            {
+                info->add_addresses( addr.getStringAddress() );
+                logger_->debug( "Address Broadcast: {}", addr.getStringAddress() );
+            }
+        }
+
+        std::string resp_serialized;
+        if ( !resp.SerializeToString( &resp_serialized ) )
+        {
+            logger_->error( "Failed to serialize BlockResponse" );
+            return;
+        }
+
+        std::vector<uint8_t> resp_bytes( resp_serialized.begin(), resp_serialized.end() );
+        auto                 signature_res = methods_.sign_( resp_bytes );
         if ( signature_res.has_error() )
         {
             logger_->error( "Failed to sign BlockResponse" );
@@ -469,7 +621,8 @@ namespace sgns
     outcome::result<void> AccountMessenger::RequestAccountCreation(
         uint64_t timeout_ms, std::function<void( outcome::result<std::string> )> callback )
     {
-        EnqueueTask( { RequestType::AccountCreation, timeout_ms, 150, 1, std::move( callback ), nullptr } );
+        EnqueueTask(
+            { RequestType::AccountCreation, timeout_ms, 150, 1, std::string{}, std::move( callback ), nullptr } );
         return outcome::success();
     }
 
@@ -548,6 +701,33 @@ namespace sgns
                 case RequestType::AccountCreation:
                 {
                     auto res = PerformBlockRequest( task.timeout_ms, task.block_index );
+                    if ( task.callback )
+                    {
+                        if ( res.has_error() )
+                        {
+                            task.callback( outcome::failure( res.error() ) );
+                        }
+                        else
+                        {
+                            const auto &cids = res.value();
+                            if ( cids.empty() )
+                            {
+                                task.callback( outcome::failure( boost::system::error_code{} ) );
+                            }
+                            else
+                            {
+                                for ( const auto &cid : cids )
+                                {
+                                    task.callback( outcome::success( cid ) );
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+                case RequestType::BlockByCid:
+                {
+                    auto res = PerformBlockCidRequest( task.timeout_ms, task.cid );
                     if ( task.callback )
                     {
                         if ( res.has_error() )
@@ -767,6 +947,106 @@ namespace sgns
                 }
             }
 
+
+            if ( std::chrono::steady_clock::now() - start_time >= full_timeout )
+            {
+                logger_->debug( "[{}] Timeout: no BlockResponse received for req_id {}",
+                                address_.substr( 0, 8 ),
+                                req_id );
+                return outcome::failure( Error::GENESIS_REQUEST_ERROR );
+            }
+
+            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+        }
+
+        std::set<std::string> cids;
+        bool                  any_response = false;
+        {
+            std::lock_guard lock( block_responses_mutex_ );
+            auto            it = block_responses_.find( req_id );
+            if ( it != block_responses_.end() )
+            {
+                any_response = true;
+                cids         = it->second;
+            }
+            block_responses_.erase( req_id );
+            block_first_response_time_.erase( req_id );
+        }
+
+        if ( !any_response )
+        {
+            logger_->warn( "[{}] No responses recorded for req_id {}", address_.substr( 0, 8 ), req_id );
+            return outcome::failure( Error::GENESIS_REQUEST_ERROR );
+        }
+
+        return outcome::success( cids );
+    }
+
+    outcome::result<std::set<std::string>> AccountMessenger::PerformBlockCidRequest( uint64_t timeout_ms,
+                                                                                      const std::string &cid )
+    {
+        std::mt19937_64 gen( rd_() );
+        uint64_t        random_value = gen();
+
+        std::string              to_hash = address_ + std::to_string( random_value );
+        sgns::crypto::HasherImpl hasher;
+        auto                     hash = hasher.sha2_256(
+            gsl::span<const uint8_t>( reinterpret_cast<const uint8_t *>( to_hash.data() ), to_hash.size() ) );
+
+        uint64_t req_id = 0;
+        std::memcpy( &req_id, hash.data(), sizeof( req_id ) );
+
+        logger_->debug( "[{}] Requesting block CID {} with req_id {} and timeout {}",
+                        address_.substr( 0, 8 ),
+                        cid,
+                        req_id,
+                        timeout_ms );
+
+        {
+            std::lock_guard lock( block_responses_mutex_ );
+            block_responses_.erase( req_id );
+            block_first_response_time_.erase( req_id );
+        }
+
+        auto request_result = RequestBlockByCid( req_id, cid );
+        if ( request_result.has_error() )
+        {
+            logger_->error( "[{}] Failed to request block CID {}",
+                            address_.substr( 0, 8 ),
+                            cid );
+            return request_result.error();
+        }
+
+        const auto start_time        = std::chrono::steady_clock::now();
+        const auto full_timeout      = std::chrono::milliseconds( timeout_ms );
+        const auto silent_time       = std::chrono::milliseconds( 150 );
+
+        bool first_seen = false;
+
+        while ( true )
+        {
+            const auto now = std::chrono::steady_clock::now();
+
+            {
+                std::lock_guard lock( block_responses_mutex_ );
+                auto            it = block_responses_.find( req_id );
+                if ( it != block_responses_.end() )
+                {
+                    if ( !first_seen )
+                    {
+                        first_seen                         = true;
+                        block_first_response_time_[req_id] = std::chrono::steady_clock::now();
+                    }
+                    else
+                    {
+                        auto elapsed = std::chrono::steady_clock::now() - block_first_response_time_[req_id];
+                        if ( elapsed >= silent_time )
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
 
             if ( std::chrono::steady_clock::now() - start_time >= full_timeout )
             {

--- a/src/account/AccountMessenger.hpp
+++ b/src/account/AccountMessenger.hpp
@@ -62,6 +62,9 @@ namespace sgns
             /// @brief Get local genesis block method
             std::function<outcome::result<std::string>( uint8_t block_index, const std::string &address )>
                 get_block_cid_;
+
+            /// @brief Check if a CID is locally available
+            std::function<outcome::result<bool>( const std::string &cid )> has_block_cid_;
         };
 
         // Global block response handler type
@@ -109,6 +112,16 @@ namespace sgns
         outcome::result<void> RequestAccountCreation(
             uint64_t timeout_ms,
             std::function<void( outcome::result<std::string> )> callback );
+
+        /**
+         * @brief       Request a block by CID from the network (retries until timeout)
+         * @param[in]   timeout_ms Total timeout in milliseconds to wait for responses
+         * @param[in]   cid CID to request
+         * @return      success on scheduled request, error otherwise
+         */
+        outcome::result<void> RequestRegularBlock( uint64_t                                            timeout_ms,
+                                                   std::string                                         cid,
+                                                   std::function<void( outcome::result<std::string> )> callback = nullptr );
 
         /**
          * @brief       Register global block response handler
@@ -163,7 +176,8 @@ namespace sgns
         {
             Nonce,
             Genesis,
-            AccountCreation
+            AccountCreation,
+            BlockByCid
         };
 
         struct RequestTask
@@ -172,6 +186,7 @@ namespace sgns
             uint64_t                                            timeout_ms;
             uint64_t                                            silent_time_ms{ 150 };
             uint8_t                                             block_index{ 0 };
+            std::string                                         cid;
             std::function<void( outcome::result<std::string> )> callback;
             std::shared_ptr<std::promise<outcome::result<uint64_t>>> nonce_promise;
         };
@@ -186,6 +201,7 @@ namespace sgns
         void EnqueueTask( RequestTask task );
         outcome::result<uint64_t> PerformNonceRequest( uint64_t timeout_ms, uint64_t silent_time_ms );
         outcome::result<std::set<std::string>> PerformBlockRequest( uint64_t timeout_ms, uint8_t block_index );
+        outcome::result<std::set<std::string>> PerformBlockCidRequest( uint64_t timeout_ms, const std::string &cid );
 
         /**
          * @brief       Private constructor of the Account Messenger 
@@ -208,6 +224,12 @@ namespace sgns
          * @param[in]   block_index index of the requested block (0 = genesis, 1 = account, ...)
          */
         outcome::result<void> RequestBlock( uint64_t req_id, uint8_t block_index );
+
+        /**
+         * @brief       Request a block (by CID) from the network (no callback)
+         * @param[in]   cid CID to request
+         */
+        outcome::result<void> RequestBlockByCid( uint64_t req_id, const std::string &cid );
 
         /**
          * @brief       Callback of pubsub message when a response was received
@@ -244,6 +266,11 @@ namespace sgns
          * @param[in]   req The proto genesis request package
          */
         void HandleBlockRequest( const accountComm::SignedBlockRequest &req );
+        /**
+         * @brief       Handles the Block-by-CID request package
+         * @param[in]   req The proto block-by-CID request package
+         */
+        void HandleBlockCidRequest( const accountComm::SignedBlockCidRequest &req );
         /**
          * @brief       Handles the Block response package (calls global handler)
          * @param[in]   resp The proto block response package

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -11,6 +11,9 @@
 #include "ipfs_pubsub/gossip_pubsub.hpp"
 #include "account/AccountMessenger.hpp"
 #include "crdt/globaldb/globaldb.hpp"
+#include "crdt/globaldb/pubsub_broadcaster_ext.hpp"
+#include "crdt/graphsync_dagsyncer.hpp"
+#include "primitives/cid/cid.hpp"
 
 namespace
 {
@@ -109,6 +112,21 @@ namespace sgns
 
             return outcome::failure( std::errc::owner_dead );
         };
+        methods.has_block_cid_ = [weakptr( weak_from_this() )]( const std::string &cid ) -> outcome::result<bool>
+        {
+            if ( auto self = weakptr.lock() )
+            {
+                std::lock_guard lock( self->get_cids_mutex_ );
+                if ( self->has_cid_method_ )
+                {
+                    return self->has_cid_method_( cid );
+                }
+
+                return outcome::failure( AccountMessenger::Error::GENESIS_REQUEST_ERROR );
+            }
+
+            return outcome::failure( std::errc::owner_dead );
+        };
         messenger_ = AccountMessenger::New( eth_keypair->GetEntirePubValue(),
                                             std::move( pubsub ),
                                             std::move( methods ) );
@@ -136,6 +154,32 @@ namespace sgns
                         return strong->AddSingleCIDInfo( cid, peer_id, address );
                     }
                     return false;
+                } );
+            SetHasBlockCidMethod(
+                [weakptr{ std::weak_ptr<crdt::PubSubBroadcasterExt>( broadcaster ) }](
+                    const std::string &cid ) -> outcome::result<bool>
+                {
+                    if ( auto strong = weakptr.lock() )
+                    {
+                        auto cid_result = CID::fromString( cid );
+                        if ( cid_result.has_error() )
+                        {
+                            return outcome::failure( std::errc::invalid_argument );
+                        }
+                        auto dag_syncer =
+                            std::static_pointer_cast<crdt::GraphsyncDAGSyncer>( strong->GetDagSyncer() );
+                        if ( !dag_syncer )
+                        {
+                            return outcome::failure( std::errc::no_such_device );
+                        }
+                        auto has_block = dag_syncer->HasBlock( cid_result.value() );
+                        if ( has_block.has_error() )
+                        {
+                            return outcome::failure( has_block.error() );
+                        }
+                        return has_block.value();
+                    }
+                    return outcome::failure( std::errc::owner_dead );
                 } );
             genius_account_logger()->debug( "Registered block response handler" );
             ret = true;
@@ -700,6 +744,20 @@ namespace sgns
         return messenger_->RequestAccountCreation( timeout_ms, std::move( callback ) );
     }
 
+    outcome::result<void> GeniusAccount::RequestRegularBlock(
+        uint64_t                                            timeout_ms,
+        const std::string                                  &cid,
+        std::function<void( outcome::result<std::string> )> callback ) const
+    {
+        if ( !messenger_ )
+        {
+            return outcome::failure( std::errc::no_such_device );
+        }
+        genius_account_logger()->debug( "Requesting block by CID {}", cid );
+
+        return messenger_->RequestRegularBlock( timeout_ms, cid, std::move( callback ) );
+    }
+
     void GeniusAccount::SetGetBlockChainCIDMethod(
         std::function<outcome::result<std::string>( uint8_t, const std::string & )> method )
     {
@@ -711,5 +769,17 @@ namespace sgns
     {
         std::lock_guard lock( get_cids_mutex_ );
         get_cids_method_ = nullptr;
+    }
+
+    void GeniusAccount::SetHasBlockCidMethod( std::function<outcome::result<bool>( const std::string & )> method )
+    {
+        std::lock_guard lock( get_cids_mutex_ );
+        has_cid_method_ = std::move( method );
+    }
+
+    void GeniusAccount::ClearHasBlockCidMethod( void )
+    {
+        std::lock_guard lock( get_cids_mutex_ );
+        has_cid_method_ = nullptr;
     }
 }

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -255,6 +255,10 @@ namespace sgns
         outcome::result<void> RequestAccountCreation(
             uint64_t                                            timeout_ms,
             std::function<void( outcome::result<std::string> )> callback ) const;
+        outcome::result<void> RequestRegularBlock(
+            uint64_t                                            timeout_ms,
+            const std::string                                  &cid,
+            std::function<void( outcome::result<std::string> )> callback = nullptr ) const;
         /**
          * @brief       Derives a Genius address from a given Ethereum private key
          * @param[in]   base_path The base path to store/retrieve the key
@@ -269,6 +273,8 @@ namespace sgns
         void SetGetBlockChainCIDMethod(
             std::function<outcome::result<std::string>( uint8_t, const std::string & )> method );
         void ClearGetBlockChainCIDMethod();
+        void SetHasBlockCidMethod( std::function<outcome::result<bool>( const std::string & )> method );
+        void ClearHasBlockCidMethod();
 
     private:
         static constexpr size_t SIGNATURE_EXP_SIZE = 64; ///< Expected size of the signature in bytes
@@ -297,6 +303,7 @@ namespace sgns
         std::mutex                                      get_cids_mutex_;        ///< Mutex for the genesis method
         std::function<outcome::result<std::string>( uint8_t, const std::string & )>
             get_cids_method_; ///< Function to get blockchain CIDs
+        std::function<outcome::result<bool>( const std::string & )> has_cid_method_; ///< Function to check CID presence
 
         uint64_t GetNextNonceLocked() const;
 

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -417,6 +417,7 @@ namespace sgns
         auto loggerGeniusAccount    = ConfigureLogger( "GeniusAccount", logdir, spdlog::level::err );
         auto loggerKeyPair          = ConfigureLogger( "KeyPairFileStorage", logdir, spdlog::level::err );
         auto loggerBlockchain       = ConfigureLogger( "Blockchain", logdir, spdlog::level::trace );
+        auto loggerValidator       = ConfigureLogger( "ValidatorRegistry", logdir, spdlog::level::debug );
         auto loggerProcMgr          = ConfigureLogger( "SGProcessingManager", logdir, spdlog::level::err );
         auto loggerProcessor        = ConfigureLogger( "SGProcessor", logdir, spdlog::level::err );
         auto loggerCrdtCallback     = ConfigureLogger( "CRDTCallbackManager", logdir, spdlog::level::err );
@@ -456,6 +457,7 @@ namespace sgns
         auto loggerGeniusAccount    = ConfigureLogger( "GeniusAccount", logdir, spdlog::level::err );
         auto loggerKeyPair          = ConfigureLogger( "KeyPairFileStorage", logdir, spdlog::level::err );
         auto loggerBlockchain       = ConfigureLogger( "Blockchain", logdir, spdlog::level::err );
+        auto loggerValidator       = ConfigureLogger( "ValidatorRegistry", logdir, spdlog::level::err );
         auto loggerProcMgr          = ConfigureLogger( "SGProcessingManager", logdir, spdlog::level::err );
         auto loggerProcessor        = ConfigureLogger( "SGProcessor", logdir, spdlog::level::err );
         auto loggerCrdtCallback     = ConfigureLogger( "CRDTCallbackManager", logdir, spdlog::level::err );

--- a/src/account/Migration3_4_0To3_5_0.cpp
+++ b/src/account/Migration3_4_0To3_5_0.cpp
@@ -134,11 +134,37 @@ namespace sgns
                         strong->blockchain_status_.store( Status::ST_SUCCESS );
                     }
                 } );
-            blockchain_->Start();
         }
+
+        auto retry_duration       = std::chrono::minutes( 2 );
+        auto retry_interval       = std::chrono::seconds( 5 );
+        auto retry_start_time     = std::chrono::steady_clock::now();
+        auto last_log_time        = retry_start_time;
+        outcome::result<void> start_result =
+            outcome::failure( Blockchain::Error::BLOCKCHAIN_NOT_INITIALIZED );
+        do
+        {
+            start_result = blockchain_->Start();
+            if ( start_result.has_error() )
+            {
+                logger_->error( "Error starting blockchain: {}", start_result.error().message() );
+            }
+
+            auto current_time = std::chrono::steady_clock::now();
+            if ( current_time - last_log_time >= std::chrono::seconds( 30 ) )
+            {
+                auto elapsed_seconds =
+                    std::chrono::duration_cast<std::chrono::seconds>( current_time - retry_start_time ).count();
+                logger_->info( "{}: Retrying blockchain start (elapsed: {}s)", __func__, elapsed_seconds );
+                last_log_time = current_time;
+            }
+            std::this_thread::sleep_for( retry_interval );
+        } while ( std::chrono::steady_clock::now() - retry_start_time < retry_duration &&
+                  start_result.has_error() );
+
         auto timeout_duration     = std::chrono::minutes( 4 );
         auto start_time           = std::chrono::steady_clock::now();
-        auto last_log_time        = start_time;
+        last_log_time             = start_time;
         bool blockchain_succeeded = false;
 
         while ( std::chrono::steady_clock::now() - start_time < timeout_duration )

--- a/src/account/proto/SGAccountComm.proto
+++ b/src/account/proto/SGAccountComm.proto
@@ -8,6 +8,7 @@ message AccountMessage {
     SignedNonceResponse nonce_response = 2;
     SignedBlockRequest block_request = 3;    // changed: generic block request with index
     SignedBlockResponse block_response = 4;
+    SignedBlockCidRequest block_cid_request = 5;
   }
 }
 
@@ -46,6 +47,18 @@ message BlockRequest {
 
 message SignedBlockRequest {
   BlockRequest data = 1;
+  bytes signature = 2;
+}
+
+message BlockCidRequest {
+  string requester_address = 1;
+  uint64 request_id = 2;
+  uint64 timestamp = 3;
+  string cid = 4;
+}
+
+message SignedBlockCidRequest {
+  BlockCidRequest data = 1;
   bytes signature = 2;
 }
 

--- a/src/blockchain/Blockchain.hpp
+++ b/src/blockchain/Blockchain.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <atomic>
 #include <optional>
 #include <unordered_map>
 #include "outcome/outcome.hpp"
@@ -49,6 +50,7 @@ namespace sgns
             ACCOUNT_CREATION_BLOCK_SERIALIZATION_FAILED, ///< Failed to serialize/deserialize account creation block
             ACCOUNT_CREATION_BLOCK_INVALID_GENESIS_LINK, ///< Account creation block not properly linked to genesis
             VALIDATOR_REGISTRY_CREATION_FAILED,          ///< Failed to create validator registry
+            BLOCKCHAIN_NOT_INITIALIZED,                  ///< Blockchain not fully initialized yet
         };
 
         // Callback type for when the blockchain is initialized
@@ -192,6 +194,10 @@ namespace sgns
 
         base::Logger logger_ = base::createLogger( "Blockchain" ); ///< Logger instance
 
+        bool               created_successfully_ = false;
+        bool               filters_registered_ = false;
+        bool               callbacks_registered_ = false;
+        std::atomic<bool>  validator_registry_initialized_{ false };
         bool genesis_ready_          = false;
         bool account_creation_ready_ = false;
     };

--- a/src/blockchain/Blockchain.hpp
+++ b/src/blockchain/Blockchain.hpp
@@ -25,6 +25,10 @@
 
 namespace sgns
 {
+    namespace blockchain
+    {
+        class ValidatorRegistry;
+    }
 
     class Blockchain : public std::enable_shared_from_this<Blockchain>
     {
@@ -44,6 +48,7 @@ namespace sgns
             ACCOUNT_CREATION_BLOCK_INVALID_SIGNATURE,    ///< Account creation block has invalid signature
             ACCOUNT_CREATION_BLOCK_SERIALIZATION_FAILED, ///< Failed to serialize/deserialize account creation block
             ACCOUNT_CREATION_BLOCK_INVALID_GENESIS_LINK, ///< Account creation block not properly linked to genesis
+            VALIDATOR_REGISTRY_CREATION_FAILED,          ///< Failed to create validator registry
         };
 
         // Callback type for when the blockchain is initialized
@@ -132,6 +137,7 @@ namespace sgns
         void                  InformGenesisResult( outcome::result<std::string> result );
         void                  InformAccountCreationResponse( outcome::result<std::string> creation_result );
         void                  WatchCIDDownload( const std::string &cid, Error error_on_failure, uint64_t timeout_ms );
+        outcome::result<void> EnsureValidatorRegistry();
 
         /// Topic used for the blockchain CRDT
         static constexpr std::string_view BLOCKCHAIN_TOPIC = "gnus-blockchain";
@@ -181,6 +187,8 @@ namespace sgns
         BlockchainCIDs cids_;
 
         static std::string &AuthorizedFullNodeAddressStorage();
+
+        std::shared_ptr<blockchain::ValidatorRegistry> validator_registry_;
 
         base::Logger logger_ = base::createLogger( "Blockchain" ); ///< Logger instance
 

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -67,6 +67,12 @@ namespace sgns::blockchain
                                                                                    std::move( weight_config ),
                                                                                    std::move( genesis_authority ) ) );
         instance->InitializeCache();
+
+        if ( !RegisterFilter() )
+        {
+            return nullptr;
+        }
+
         return instance;
     }
 
@@ -301,6 +307,9 @@ namespace sgns::blockchain
                     strong->RegistryUpdateReceived( std::move( new_data ), cid );
                 }
             } );
+
+        db_->AddListenTopic( std::string( ValidatorTopic() ) );
+
         return filter_registered && callback_registered;
     }
 
@@ -499,25 +508,24 @@ namespace sgns::blockchain
         const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
         auto                        registry_get    = db_->Get( registry_key );
         bool                        content_present = registry_get.has_value();
-        if ( content_present )
-        {
-            const auto          &buffer = registry_get.value();
-            std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
-            auto                 decoded = DeserializeRegistryUpdate( bytes );
-            if ( decoded.has_value() )
-            {
-                cached_update_   = decoded.value();
-                cached_registry_ = decoded.value().registry();
-            }
-            else
-            {
-                logger_->warn( "Failed to parse registry content during cache init" );
-            }
-        }
-        else
+        if ( !content_present )
         {
             logger_->warn( "Registry content not found during cache init" );
+            return;
         }
+        const auto          &buffer = registry_get.value();
+        std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
+        auto                 decoded = DeserializeRegistryUpdate( bytes );
+        if ( !decoded.has_value() )
+        {
+            logger_->warn( "Failed to parse registry content during cache init" );
+            return;
+        }
+
+        cached_update_   = decoded.value();
+        cached_registry_ = decoded.value().registry();
+
+        cache_initialized_ = true;
 
         sgns::crdt::GlobalDB::Buffer registry_cid_key;
         registry_cid_key.put( std::string( RegistryCidKey() ) );
@@ -525,38 +533,28 @@ namespace sgns::blockchain
         if ( registry_cid.has_value() )
         {
             cached_registry_id_ = registry_cid.value().toString();
-        }
-
-        const bool    missing_cid = cached_registry_id_.empty();
-        std::set<CID> heads_to_request;
-
-        if ( content_present && missing_cid )
-        {
-            logger_->warn( "Registry content found, but CID is missing; requesting heads" );
-
-            auto heads_result = db_->GetCRDTHeadList();
-            if ( heads_result.has_value() )
-            {
-                const auto &heads_map = heads_result.value().first;
-                auto        it        = heads_map.find( std::string( ValidatorTopic() ) );
-                if ( it != heads_map.end() )
-                {
-                    heads_to_request = it->second;
-                }
-            }
-        }
-        cache_initialized_      = true;
-        const bool has_registry = cached_registry_.has_value() && !cached_registry_->validators().empty();
-
-        lock.unlock();
-
-        if ( has_registry && !missing_cid )
-        {
             NotifyInitialized( true );
             return;
         }
 
-        if ( missing_cid && !heads_to_request.empty() )
+        std::set<CID> heads_to_request;
+
+        logger_->warn( "Registry content found, but CID is missing; requesting heads" );
+
+        auto heads_result = db_->GetCRDTHeadList();
+        if ( heads_result.has_value() )
+        {
+            const auto &heads_map = heads_result.value().first;
+            auto        it        = heads_map.find( std::string( ValidatorTopic() ) );
+            if ( it != heads_map.end() )
+            {
+                heads_to_request = it->second;
+            }
+        }
+
+        lock.unlock();
+
+        if ( !heads_to_request.empty() )
         {
             RequestHeadCids( heads_to_request );
         }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -23,15 +23,15 @@ namespace sgns::blockchain
                                           uint64_t                        quorum_denominator,
                                           WeightConfig                    weight_config,
                                           std::string                     genesis_authority,
-                                          InitCallback                    init_callback,
-                                          BlockRequestMethod              block_request_method ) :
+                                          BlockRequestMethod              block_request_method,
+                                          InitCallback                    init_callback ) :
         db_( std::move( db ) ),
         quorum_numerator_( quorum_numerator ),
         quorum_denominator_( quorum_denominator ),
         weight_config_( std::move( weight_config ) ),
         genesis_authority_( std::move( genesis_authority ) ),
-        init_callback_( std::move( init_callback ) ),
-        request_block_by_cid_( std::move( block_request_method ) )
+        request_block_by_cid_( std::move( block_request_method ) ),
+        init_callback_( std::move( init_callback ) )
     {
     }
 
@@ -40,8 +40,8 @@ namespace sgns::blockchain
                                                                uint64_t                        quorum_denominator,
                                                                WeightConfig                    weight_config,
                                                                std::string                     genesis_authority,
-                                                               InitCallback                    init_callback,
-                                                               BlockRequestMethod              block_request_method )
+                                                               BlockRequestMethod              block_request_method,
+                                                               InitCallback                    init_callback )
     {
         if ( !db )
         {
@@ -63,10 +63,14 @@ namespace sgns::blockchain
                                                                                    quorum_numerator,
                                                                                    quorum_denominator,
                                                                                    std::move( weight_config ),
-                                                                                   std::move( genesis_authority ) ) );
+                                                                                   std::move( genesis_authority ),
+                                                                                   std::move( block_request_method ),
+                                                                                   std::move( init_callback ) ) );
+
+        instance->logger_->trace( "ValidatorRegistry instance created" );
         instance->InitializeCache();
 
-        if ( !RegisterFilter() )
+        if ( !instance->RegisterFilter() )
         {
             return nullptr;
         }
@@ -237,7 +241,7 @@ namespace sgns::blockchain
         base::Buffer update_buffer(
             gsl::span<const uint8_t>( serialized_update.value().data(), serialized_update.value().size() ) );
 
-        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
+        crdt::HierarchicalKey registry_key{ std::string( RegistryKey() ) };
 
         auto registry_put = db_->Put( registry_key, update_buffer, { std::string( ValidatorTopic() ) } );
         if ( registry_put.has_error() )
@@ -421,6 +425,7 @@ namespace sgns::blockchain
         }
         if ( current_id.empty() || prev_registry_cid != current_id )
         {
+            //TODO - Check if the CID checking is necessary, because we could receive out-of-order updates
             return false;
         }
 
@@ -481,15 +486,17 @@ namespace sgns::blockchain
         std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
         if ( cache_initialized_ )
         {
+            logger_->error( "Cache already initialized" );
             return;
         }
+        logger_->trace( "Grabbing Validator Registry from CRDT" );
 
-        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
-        auto                        registry_get    = db_->Get( registry_key );
-        bool                        content_present = registry_get.has_value();
+        crdt::HierarchicalKey registry_key{ std::string( RegistryKey() ) };
+        auto                  registry_get    = db_->Get( registry_key );
+        bool                  content_present = registry_get.has_value();
         if ( !content_present )
         {
-            logger_->warn( "Registry content not found during cache init" );
+            logger_->error( "Registry content not found during cache init" );
             return;
         }
         const auto          &buffer = registry_get.value();
@@ -559,9 +566,11 @@ namespace sgns::blockchain
         {
             std::atomic<size_t> remaining;
             std::atomic<bool>   success_reported{ false };
+
+            explicit RequestState( size_t remaining_count ) : remaining( remaining_count ) {}
         };
 
-        auto state = std::make_shared<RequestState>( RequestState{ cids.size() } );
+        auto state = std::make_shared<RequestState>( cids.size() );
 
         for ( const auto &cid : cids )
         {

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -7,6 +7,7 @@
 #include "blockchain/ValidatorRegistry.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <set>
 #include <system_error>
 
@@ -36,7 +37,8 @@ namespace sgns::blockchain
                                                                uint64_t                        quorum_numerator,
                                                                uint64_t                        quorum_denominator,
                                                                WeightConfig                    weight_config,
-                                                               std::string                     genesis_authority )
+                                                               std::string                     genesis_authority,
+                                                               InitCallback                    init_callback )
     {
         if ( !db )
         {
@@ -51,7 +53,7 @@ namespace sgns::blockchain
                                                                                    quorum_denominator,
                                                                                    std::move( weight_config ),
                                                                                    std::move( genesis_authority ) ) );
-        instance->InitializeCache();
+        instance->InitializeCache( std::move( init_callback ) );
         return instance;
     }
 
@@ -265,9 +267,9 @@ namespace sgns::blockchain
 
     bool ValidatorRegistry::RegisterFilter()
     {
-        const std::string pattern   = "/?" + std::string( RegistryKey() );
-        auto              weak_self = weak_from_this();
-        const bool filter_registered = db_->RegisterElementFilter(
+        const std::string pattern           = "/?" + std::string( RegistryKey() );
+        auto              weak_self         = weak_from_this();
+        const bool        filter_registered = db_->RegisterElementFilter(
             pattern,
             [weak_self]( const crdt::pb::Element &element ) -> std::optional<std::vector<crdt::pb::Element>>
             {
@@ -279,7 +281,8 @@ namespace sgns::blockchain
             } );
         const bool callback_registered = db_->RegisterNewElementCallback(
             pattern,
-            [weak_self]( crdt::CRDTCallbackManager::NewDataPair new_data, const std::string &cid ) {
+            [weak_self]( crdt::CRDTCallbackManager::NewDataPair new_data, const std::string &cid )
+            {
                 if ( auto strong = weak_self.lock() )
                 {
                     strong->RegistryUpdateReceived( std::move( new_data ), cid );
@@ -299,7 +302,7 @@ namespace sgns::blockchain
             return std::vector<crdt::pb::Element>{};
         }
 
-        RegistryUpdate update = decoded_update.value();
+        RegistryUpdate  update      = decoded_update.value();
         const Registry *current_ptr = nullptr;
 
         {
@@ -333,13 +336,14 @@ namespace sgns::blockchain
 
         {
             std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
-            cached_update_ = decoded.value();
-            cached_registry_ = decoded.value().registry();
+            cached_update_      = decoded.value();
+            cached_registry_    = decoded.value().registry();
             cached_registry_id_ = cid;
-            cache_initialized_ = true;
+            cache_initialized_  = true;
         }
 
         PersistLocalState( cid );
+        NotifyInitialized( true );
     }
 
     outcome::result<std::vector<uint8_t>> ValidatorRegistry::ComputeUpdateSigningBytes(
@@ -471,8 +475,14 @@ namespace sgns::blockchain
         return nullptr;
     }
 
-    void ValidatorRegistry::InitializeCache()
+    void ValidatorRegistry::InitializeCache( InitCallback init_callback )
     {
+        if ( init_callback )
+        {
+            std::lock_guard<std::mutex> lock( init_mutex_ );
+            init_callback_ = std::move( init_callback );
+        }
+
         std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
         if ( cache_initialized_ )
         {
@@ -480,16 +490,16 @@ namespace sgns::blockchain
         }
 
         const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
-        auto                        registry_get = db_->Get( registry_key );
+        auto                        registry_get    = db_->Get( registry_key );
         bool                        content_present = registry_get.has_value();
-        if ( registry_get.has_value() )
+        if ( content_present )
         {
             const auto          &buffer = registry_get.value();
             std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
             auto                 decoded = DeserializeRegistryUpdate( bytes );
             if ( decoded.has_value() )
             {
-                cached_update_ = decoded.value();
+                cached_update_   = decoded.value();
                 cached_registry_ = decoded.value().registry();
             }
             else
@@ -510,41 +520,64 @@ namespace sgns::blockchain
             cached_registry_id_ = registry_cid.value().toString();
         }
 
-        const bool missing_cid = cached_registry_id_.empty();
+        const bool    missing_cid = cached_registry_id_.empty();
         std::set<CID> heads_to_request;
 
         if ( content_present && missing_cid )
         {
             logger_->warn( "Registry content found, but CID is missing; requesting heads" );
-        }
 
-        if ( missing_cid )
-        {
             auto heads_result = db_->GetCRDTHeadList();
             if ( heads_result.has_value() )
             {
                 const auto &heads_map = heads_result.value().first;
-                auto        it = heads_map.find( std::string( ValidatorTopic() ) );
+                auto        it        = heads_map.find( std::string( ValidatorTopic() ) );
                 if ( it != heads_map.end() )
                 {
                     heads_to_request = it->second;
                 }
             }
         }
-        cache_initialized_ = true;
+        cache_initialized_      = true;
+        const bool has_registry = cached_registry_.has_value() && !cached_registry_->validators().empty();
 
         lock.unlock();
+
+        if ( has_registry && !missing_cid )
+        {
+            NotifyInitialized( true );
+            return;
+        }
+
         if ( missing_cid && !heads_to_request.empty() )
         {
-            RequestHeadCids( heads_to_request );
+            if ( request_block_by_cid_ )
+            {
+                RequestHeadCids( heads_to_request );
+            }
+            else
+            {
+                std::lock_guard<std::mutex> init_lock( init_mutex_ );
+                pending_head_requests_.insert( heads_to_request.begin(), heads_to_request.end() );
+            }
         }
     }
 
     void ValidatorRegistry::SetRequestBlockByCidMethod(
-        std::function<void( const std::string &cid,
-                            std::function<void( outcome::result<std::string> )> callback )> method )
+        std::function<void( const std::string &cid, std::function<void( outcome::result<std::string> )> callback )>
+            method )
     {
         request_block_by_cid_ = std::move( method );
+
+        std::set<CID> pending;
+        {
+            std::lock_guard<std::mutex> lock( init_mutex_ );
+            pending.swap( pending_head_requests_ );
+        }
+        if ( !pending.empty() )
+        {
+            RequestHeadCids( pending );
+        }
     }
 
     void ValidatorRegistry::PersistLocalState( const std::string &cid )
@@ -568,9 +601,76 @@ namespace sgns::blockchain
             return;
         }
 
+        struct RequestState
+        {
+            std::atomic<size_t> remaining;
+            std::atomic<bool>   success_reported{ false };
+        };
+
+        auto state = std::make_shared<RequestState>( RequestState{ cids.size() } );
+
         for ( const auto &cid : cids )
         {
-            request_block_by_cid_( cid.toString().value(), nullptr );
+            auto cid_string = cid.toString();
+            if ( !cid_string.has_value() )
+            {
+                if ( state->remaining.fetch_sub( 1 ) == 1 && !state->success_reported.load() )
+                {
+                    NotifyInitialized( false );
+                }
+                continue;
+            }
+
+            request_block_by_cid_(
+                cid_string.value(),
+                [weak_self = weak_from_this(), state]( outcome::result<std::string> result )
+                {
+                    if ( auto self = weak_self.lock() )
+                    {
+                        if ( !result.has_error() )
+                        {
+                            if ( !state->success_reported.exchange( true ) )
+                            {
+                                self->NotifyInitialized( true );
+                            }
+                        }
+
+                        if ( state->remaining.fetch_sub( 1 ) == 1 && !state->success_reported.load() )
+                        {
+                            self->NotifyInitialized( false );
+                        }
+                    }
+                } );
+        }
+    }
+
+    void ValidatorRegistry::NotifyInitialized( bool success )
+    {
+        InitCallback callback;
+        {
+            std::lock_guard<std::mutex> lock( init_mutex_ );
+            if ( !init_callback_ )
+            {
+                return;
+            }
+            if ( init_state_.has_value() && init_state_.value() == success )
+            {
+                return;
+            }
+            init_state_ = success;
+            if ( success )
+            {
+                callback = std::move( init_callback_ );
+            }
+            else
+            {
+                callback = init_callback_;
+            }
+        }
+
+        if ( callback )
+        {
+            callback( success );
         }
     }
 }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -1,0 +1,421 @@
+/**
+ * @file       ValidatorRegistry.cpp
+ * @brief      Validator registry and quorum logic for governance.
+ * @date       2025-10-16
+ * @author     Henrique A. Klein (hklein@gnus.ai)
+ */
+#include "blockchain/ValidatorRegistry.hpp"
+
+#include <algorithm>
+#include <set>
+#include <system_error>
+
+#include "account/GeniusAccount.hpp"
+#include "base/hexutil.hpp"
+#include "crypto/hasher/hasher_impl.hpp"
+#include "scale/scale.hpp"
+
+namespace sgns::blockchain
+{
+    ValidatorRegistry::ValidatorRegistry( std::shared_ptr<crdt::GlobalDB> db,
+                                          uint64_t                        quorum_numerator,
+                                          uint64_t                        quorum_denominator,
+                                          WeightConfig                    weight_config,
+                                          std::string                     genesis_authority )
+        : db_( std::move( db ) )
+        , quorum_numerator_( quorum_numerator )
+        , quorum_denominator_( quorum_denominator )
+        , weight_config_( std::move( weight_config ) )
+        , genesis_authority_( std::move( genesis_authority ) )
+    {
+        if ( quorum_denominator_ == 0 )
+        {
+            quorum_denominator_ = 1;
+        }
+    }
+
+    uint64_t ValidatorRegistry::ComputeWeight( Role role ) const
+    {
+        const uint64_t base_weight = weight_config_.base_weight_;
+        uint64_t       multiplier  = 1;
+
+        switch ( role )
+        {
+            case Role::Genesis:
+                multiplier = weight_config_.genesis_multiplier_;
+                break;
+            case Role::Full:
+                multiplier = weight_config_.full_multiplier_;
+                break;
+            case Role::Sharded:
+                multiplier = weight_config_.sharded_multiplier_;
+                break;
+            case Role::Regular:
+            default:
+                multiplier = 1;
+                break;
+        }
+
+        if ( multiplier == 0 )
+        {
+            return 0;
+        }
+
+        if ( base_weight > weight_config_.max_weight_ / multiplier )
+        {
+            return weight_config_.max_weight_;
+        }
+
+        const uint64_t weighted = base_weight * multiplier;
+        return std::min( weighted, weight_config_.max_weight_ );
+    }
+
+    uint64_t ValidatorRegistry::TotalWeight( const Registry &registry ) const
+    {
+        uint64_t total_weight = 0;
+        for ( const auto &entry : registry.validators_ )
+        {
+            if ( entry.status_ != Status::Active )
+            {
+                continue;
+            }
+            total_weight += entry.weight_;
+        }
+        return total_weight;
+    }
+
+    uint64_t ValidatorRegistry::QuorumThreshold( uint64_t total_weight ) const
+    {
+        if ( total_weight == 0 )
+        {
+            return 0;
+        }
+        const uint64_t numerator = total_weight * quorum_numerator_;
+        return ( numerator + quorum_denominator_ - 1 ) / quorum_denominator_;
+    }
+
+    bool ValidatorRegistry::IsQuorum( uint64_t accumulated_weight, uint64_t total_weight ) const
+    {
+        return accumulated_weight >= QuorumThreshold( total_weight );
+    }
+
+    ValidatorRegistry::Registry ValidatorRegistry::CreateGenesisRegistry(
+        const std::string &genesis_validator_id ) const
+    {
+        Registry registry;
+        ValidatorEntry entry;
+        entry.validator_id_ = genesis_validator_id;
+        entry.role_          = Role::Genesis;
+        entry.status_        = Status::Active;
+        entry.weight_        = ComputeWeight( entry.role_ );
+
+        registry.validators_.push_back( std::move( entry ) );
+        return registry;
+    }
+
+    outcome::result<base::Buffer> ValidatorRegistry::SerializeRegistry( const Registry &registry ) const
+    {
+        auto encoded = scale::encode( registry );
+        if ( encoded.has_error() )
+        {
+            return outcome::failure( encoded.error() );
+        }
+        return base::Buffer( std::move( encoded.value() ) );
+    }
+
+    outcome::result<ValidatorRegistry::Registry> ValidatorRegistry::DeserializeRegistry(
+        const base::Buffer &buffer ) const
+    {
+        auto decoded = scale::decode<Registry>( gsl::span<const uint8_t>( buffer.data(), buffer.size() ) );
+        if ( decoded.has_error() )
+        {
+            return outcome::failure( decoded.error() );
+        }
+        return decoded.value();
+    }
+
+    outcome::result<base::Buffer> ValidatorRegistry::SerializeRegistryUpdate( const RegistryUpdate &update ) const
+    {
+        auto encoded = scale::encode( update );
+        if ( encoded.has_error() )
+        {
+            return outcome::failure( encoded.error() );
+        }
+        return base::Buffer( std::move( encoded.value() ) );
+    }
+
+    outcome::result<ValidatorRegistry::RegistryUpdate> ValidatorRegistry::DeserializeRegistryUpdate(
+        const base::Buffer &buffer ) const
+    {
+        auto decoded = scale::decode<RegistryUpdate>( gsl::span<const uint8_t>( buffer.data(), buffer.size() ) );
+        if ( decoded.has_error() )
+        {
+            return outcome::failure( decoded.error() );
+        }
+        return decoded.value();
+    }
+
+    outcome::result<void> ValidatorRegistry::StoreGenesisRegistry(
+        const std::string &genesis_validator_id,
+        std::function<std::vector<uint8_t>( std::vector<uint8_t> )> sign )
+    {
+        if ( !db_ )
+        {
+            return outcome::failure( std::errc::bad_address );
+        }
+
+        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
+        const auto                  registry_get = db_->Get( registry_key );
+        bool                        registry_empty = true;
+
+        if ( registry_get.has_value() )
+        {
+            auto decoded_update = DeserializeRegistryUpdate( registry_get.value() );
+            if ( decoded_update.has_value() )
+            {
+                registry_empty = decoded_update.value().registry_.validators_.empty();
+            }
+        }
+
+        if ( !registry_empty )
+        {
+            return outcome::success();
+        }
+
+        if ( !sign )
+        {
+            return outcome::failure( std::errc::invalid_argument );
+        }
+
+        RegistryUpdate update;
+        update.registry_ = CreateGenesisRegistry( genesis_validator_id );
+        update.prev_registry_hash_.clear();
+
+        auto signing_bytes = ComputeUpdateSigningBytes( update );
+        if ( signing_bytes.has_error() )
+        {
+            return outcome::failure( signing_bytes.error() );
+        }
+
+        SignatureEntry signature_entry;
+        signature_entry.validator_id_ = genesis_validator_id;
+        auto signature = sign( signing_bytes.value() );
+        signature_entry.signature_ = std::string( signature.begin(), signature.end() );
+        update.signatures_.push_back( std::move( signature_entry ) );
+
+        auto serialized_update = SerializeRegistryUpdate( update );
+        if ( serialized_update.has_error() )
+        {
+            return outcome::failure( serialized_update.error() );
+        }
+
+        auto registry_put = db_->Put( registry_key,
+                                      serialized_update.value(),
+                                      { std::string( ValidatorTopic() ) } );
+        if ( registry_put.has_error() )
+        {
+            return outcome::failure( registry_put.error() );
+        }
+
+        return outcome::success();
+    }
+
+    outcome::result<ValidatorRegistry::Registry> ValidatorRegistry::LoadRegistry() const
+    {
+        auto update_result = LoadRegistryUpdate();
+        if ( update_result.has_error() )
+        {
+            return outcome::failure( update_result.error() );
+        }
+        return update_result.value().registry_;
+    }
+
+    outcome::result<ValidatorRegistry::RegistryUpdate> ValidatorRegistry::LoadRegistryUpdate() const
+    {
+        if ( !db_ )
+        {
+            return outcome::failure( std::errc::bad_address );
+        }
+
+        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
+        auto                        registry_get = db_->Get( registry_key );
+        if ( registry_get.has_error() )
+        {
+            return outcome::failure( registry_get.error() );
+        }
+
+        return DeserializeRegistryUpdate( registry_get.value() );
+    }
+
+    bool ValidatorRegistry::RegisterFilter()
+    {
+        if ( !db_ )
+        {
+            return false;
+        }
+
+        const std::string pattern = "/?" + std::string( RegistryKey() );
+        auto              weak_self = weak_from_this();
+        return db_->RegisterElementFilter(
+            pattern,
+            [weak_self]( const crdt::pb::Element &element ) -> std::optional<std::vector<crdt::pb::Element>>
+            {
+                if ( auto strong = weak_self.lock() )
+                {
+                    return strong->FilterRegistryUpdate( element );
+                }
+                return std::nullopt;
+            } );
+    }
+
+    std::optional<std::vector<crdt::pb::Element>> ValidatorRegistry::FilterRegistryUpdate(
+        const crdt::pb::Element &element )
+    {
+        auto decoded_update = DeserializeRegistryUpdate( base::Buffer{
+            gsl::span<const uint8_t>( reinterpret_cast<const uint8_t *>( element.value().data() ),
+                                      element.value().size() ) } );
+        if ( decoded_update.has_error() )
+        {
+            logger_->warn( "Failed to parse validator registry update, rejecting: {}", element.key() );
+            return std::vector<crdt::pb::Element>{};
+        }
+
+        RegistryUpdate update = decoded_update.value();
+        std::optional<Registry> current_registry;
+        if ( db_ )
+        {
+            const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
+            auto                        registry_get = db_->Get( registry_key );
+            if ( registry_get.has_value() )
+            {
+                auto stored_update = DeserializeRegistryUpdate( registry_get.value() );
+                if ( stored_update.has_value() )
+                {
+                    current_registry = stored_update.value().registry_;
+                }
+            }
+        }
+
+        const Registry *current_ptr = current_registry ? &current_registry.value() : nullptr;
+        if ( !VerifyUpdate( update, current_ptr ) )
+        {
+            logger_->warn( "Validator registry update failed verification, rejecting: {}", element.key() );
+            return std::vector<crdt::pb::Element>{};
+        }
+
+        return std::nullopt;
+    }
+
+    outcome::result<std::vector<uint8_t>> ValidatorRegistry::ComputeUpdateSigningBytes(
+        const RegistryUpdate &update ) const
+    {
+        return scale::encode( update.prev_registry_hash_, update.registry_ );
+    }
+
+    std::string ValidatorRegistry::ComputeRegistryHash( const Registry &registry ) const
+    {
+        auto encoded = SerializeRegistry( registry );
+        if ( encoded.has_error() )
+        {
+            return {};
+        }
+
+        sgns::crypto::HasherImpl hasher;
+        auto hash = hasher.sha2_256( gsl::span<const uint8_t>( encoded.value().data(),
+                                                              encoded.value().size() ) );
+        return base::hex_lower( gsl::span<const uint8_t>( hash.data(), hash.size() ) );
+    }
+
+    bool ValidatorRegistry::VerifyUpdate( const RegistryUpdate &update, const Registry *current_registry ) const
+    {
+        if ( update.registry_.validators_.empty() )
+        {
+            return false;
+        }
+
+        auto signing_bytes = ComputeUpdateSigningBytes( update );
+        if ( signing_bytes.has_error() )
+        {
+            return false;
+        }
+
+        if ( !current_registry )
+        {
+            if ( update.prev_registry_hash_.empty() && !genesis_authority_.empty() )
+            {
+                for ( const auto &signature : update.signatures_ )
+                {
+                    if ( signature.validator_id_ != genesis_authority_ )
+                    {
+                        continue;
+                    }
+                    if ( GeniusAccount::VerifySignature( signature.validator_id_,
+                                                         signature.signature_,
+                                                         signing_bytes.value() ) )
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        const std::string current_hash = ComputeRegistryHash( *current_registry );
+        if ( current_hash.empty() || update.prev_registry_hash_ != current_hash )
+        {
+            return false;
+        }
+
+        if ( update.registry_.epoch_ <= current_registry->epoch_ )
+        {
+            return false;
+        }
+
+        uint64_t total_weight = TotalWeight( *current_registry );
+        uint64_t accumulated_weight = 0;
+        std::set<std::string> seen;
+
+        for ( const auto &signature : update.signatures_ )
+        {
+            if ( !seen.insert( signature.validator_id_ ).second )
+            {
+                continue;
+            }
+
+            const auto *validator = FindValidator( *current_registry, signature.validator_id_ );
+            if ( !validator || validator->status_ != Status::Active )
+            {
+                continue;
+            }
+
+            if ( !GeniusAccount::VerifySignature( signature.validator_id_,
+                                                  signature.signature_,
+                                                  signing_bytes.value() ) )
+            {
+                continue;
+            }
+
+            accumulated_weight += validator->weight_;
+            if ( IsQuorum( accumulated_weight, total_weight ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    const ValidatorRegistry::ValidatorEntry *ValidatorRegistry::FindValidator(
+        const Registry &registry,
+        const std::string &validator_id ) const
+    {
+        for ( const auto &validator : registry.validators_ )
+        {
+            if ( validator.validator_id_ == validator_id )
+            {
+                return &validator;
+            }
+        }
+        return nullptr;
+    }
+}

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -237,15 +237,12 @@ namespace sgns::blockchain
         base::Buffer update_buffer(
             gsl::span<const uint8_t>( serialized_update.value().data(), serialized_update.value().size() ) );
 
+        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
+
         auto registry_put = db_->Put( registry_key, update_buffer, { std::string( ValidatorTopic() ) } );
         if ( registry_put.has_error() )
         {
             return outcome::failure( registry_put.error() );
-        }
-
-        if ( registry_put.value().toString().has_value() )
-        {
-            PersistLocalState( registry_put.value().toString().value() );
         }
 
         return outcome::success();
@@ -350,7 +347,7 @@ namespace sgns::blockchain
         auto                 decoded = DeserializeRegistryUpdate( bytes );
         if ( decoded.has_error() )
         {
-            logger_->warn( "Failed to parse registry update for cache refresh" );
+            logger_->error( "Failed to parse registry update for cache refresh" );
             return;
         }
 

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -24,12 +24,16 @@ namespace sgns::blockchain
                                           uint64_t                        quorum_numerator,
                                           uint64_t                        quorum_denominator,
                                           WeightConfig                    weight_config,
-                                          std::string                     genesis_authority ) :
+                                          std::string                     genesis_authority,
+                                          InitCallback                    init_callback,
+                                          BlockRequestMethod              block_request_method ) :
         db_( std::move( db ) ),
         quorum_numerator_( quorum_numerator ),
         quorum_denominator_( quorum_denominator ),
         weight_config_( std::move( weight_config ) ),
-        genesis_authority_( std::move( genesis_authority ) )
+        genesis_authority_( std::move( genesis_authority ) ),
+        init_callback_( std::move( init_callback ) ),
+        request_block_by_cid_( std::move( block_request_method ) )
     {
     }
 
@@ -38,9 +42,18 @@ namespace sgns::blockchain
                                                                uint64_t                        quorum_denominator,
                                                                WeightConfig                    weight_config,
                                                                std::string                     genesis_authority,
-                                                               InitCallback                    init_callback )
+                                                               InitCallback                    init_callback,
+                                                               BlockRequestMethod              block_request_method )
     {
         if ( !db )
+        {
+            return nullptr;
+        }
+        if ( genesis_authority.empty() )
+        {
+            return nullptr;
+        }
+        if ( block_request_method == nullptr )
         {
             return nullptr;
         }
@@ -53,7 +66,7 @@ namespace sgns::blockchain
                                                                                    quorum_denominator,
                                                                                    std::move( weight_config ),
                                                                                    std::move( genesis_authority ) ) );
-        instance->InitializeCache( std::move( init_callback ) );
+        instance->InitializeCache();
         return instance;
     }
 
@@ -390,7 +403,7 @@ namespace sgns::blockchain
 
         if ( !current_registry )
         {
-            if ( update.prev_registry_hash().empty() && !genesis_authority_.empty() )
+            if ( update.prev_registry_hash().empty() )
             {
                 for ( const auto &signature : update.signatures() )
                 {
@@ -475,14 +488,8 @@ namespace sgns::blockchain
         return nullptr;
     }
 
-    void ValidatorRegistry::InitializeCache( InitCallback init_callback )
+    void ValidatorRegistry::InitializeCache()
     {
-        if ( init_callback )
-        {
-            std::lock_guard<std::mutex> lock( init_mutex_ );
-            init_callback_ = std::move( init_callback );
-        }
-
         std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
         if ( cache_initialized_ )
         {
@@ -551,32 +558,7 @@ namespace sgns::blockchain
 
         if ( missing_cid && !heads_to_request.empty() )
         {
-            if ( request_block_by_cid_ )
-            {
-                RequestHeadCids( heads_to_request );
-            }
-            else
-            {
-                std::lock_guard<std::mutex> init_lock( init_mutex_ );
-                pending_head_requests_.insert( heads_to_request.begin(), heads_to_request.end() );
-            }
-        }
-    }
-
-    void ValidatorRegistry::SetRequestBlockByCidMethod(
-        std::function<void( const std::string &cid, std::function<void( outcome::result<std::string> )> callback )>
-            method )
-    {
-        request_block_by_cid_ = std::move( method );
-
-        std::set<CID> pending;
-        {
-            std::lock_guard<std::mutex> lock( init_mutex_ );
-            pending.swap( pending_head_requests_ );
-        }
-        if ( !pending.empty() )
-        {
-            RequestHeadCids( pending );
+            RequestHeadCids( heads_to_request );
         }
     }
 
@@ -593,11 +575,6 @@ namespace sgns::blockchain
     {
         if ( cids.empty() )
         {
-            return;
-        }
-        if ( !request_block_by_cid_ )
-        {
-            logger_->warn( "No RequestBlockByCid method configured" );
             return;
         }
 
@@ -646,31 +623,9 @@ namespace sgns::blockchain
 
     void ValidatorRegistry::NotifyInitialized( bool success )
     {
-        InitCallback callback;
+        if ( init_callback_ )
         {
-            std::lock_guard<std::mutex> lock( init_mutex_ );
-            if ( !init_callback_ )
-            {
-                return;
-            }
-            if ( init_state_.has_value() && init_state_.value() == success )
-            {
-                return;
-            }
-            init_state_ = success;
-            if ( success )
-            {
-                callback = std::move( init_callback_ );
-            }
-            else
-            {
-                callback = init_callback_;
-            }
-        }
-
-        if ( callback )
-        {
-            callback( success );
+            init_callback_( success );
         }
     }
 }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -479,6 +479,29 @@ namespace sgns::blockchain
             return;
         }
 
+        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
+        auto                        registry_get = db_->Get( registry_key );
+        bool                        content_present = registry_get.has_value();
+        if ( registry_get.has_value() )
+        {
+            const auto          &buffer = registry_get.value();
+            std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
+            auto                 decoded = DeserializeRegistryUpdate( bytes );
+            if ( decoded.has_value() )
+            {
+                cached_update_ = decoded.value();
+                cached_registry_ = decoded.value().registry();
+            }
+            else
+            {
+                logger_->warn( "Failed to parse registry content during cache init" );
+            }
+        }
+        else
+        {
+            logger_->warn( "Registry content not found during cache init" );
+        }
+
         sgns::crdt::GlobalDB::Buffer registry_cid_key;
         registry_cid_key.put( std::string( RegistryCidKey() ) );
         auto registry_cid = db_->GetDataStore()->get( registry_cid_key );
@@ -487,37 +510,41 @@ namespace sgns::blockchain
             cached_registry_id_ = registry_cid.value().toString();
         }
 
-        if ( cached_registry_ )
+        const bool missing_cid = cached_registry_id_.empty();
+        std::set<CID> heads_to_request;
+
+        if ( content_present && missing_cid )
         {
-            cache_initialized_ = true;
-            return;
+            logger_->warn( "Registry content found, but CID is missing; requesting heads" );
         }
 
-        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
-        auto                        registry_get = db_->Get( registry_key );
-        if ( registry_get.has_error() )
+        if ( missing_cid )
         {
-            cache_initialized_ = true;
-            return;
-        }
-
-        const auto          &buffer = registry_get.value();
-        std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
-        auto                 decoded = DeserializeRegistryUpdate( bytes );
-        if ( decoded.has_error() )
-        {
-            logger_->warn( "Failed to initialize registry cache from CRDT" );
-            cache_initialized_ = true;
-            return;
-        }
-
-        cached_update_ = decoded.value();
-        cached_registry_ = decoded.value().registry();
-        if ( cached_registry_id_.empty() )
-        {
-            cached_registry_id_ = ComputeRegistryHash( decoded.value().registry() );
+            auto heads_result = db_->GetCRDTHeadList();
+            if ( heads_result.has_value() )
+            {
+                const auto &heads_map = heads_result.value().first;
+                auto        it = heads_map.find( std::string( ValidatorTopic() ) );
+                if ( it != heads_map.end() )
+                {
+                    heads_to_request = it->second;
+                }
+            }
         }
         cache_initialized_ = true;
+
+        lock.unlock();
+        if ( missing_cid && !heads_to_request.empty() )
+        {
+            RequestHeadCids( heads_to_request );
+        }
+    }
+
+    void ValidatorRegistry::SetRequestBlockByCidMethod(
+        std::function<void( const std::string &cid,
+                            std::function<void( outcome::result<std::string> )> callback )> method )
+    {
+        request_block_by_cid_ = std::move( method );
     }
 
     void ValidatorRegistry::PersistLocalState( const std::string &cid )
@@ -527,5 +554,23 @@ namespace sgns::blockchain
         sgns::crdt::GlobalDB::Buffer registry_cid;
         registry_cid.put( cid );
         (void)db_->GetDataStore()->put( registry_cid_key, registry_cid );
+    }
+
+    void ValidatorRegistry::RequestHeadCids( const std::set<CID> &cids )
+    {
+        if ( cids.empty() )
+        {
+            return;
+        }
+        if ( !request_block_by_cid_ )
+        {
+            logger_->warn( "No RequestBlockByCid method configured" );
+            return;
+        }
+
+        for ( const auto &cid : cids )
+        {
+            request_block_by_cid_( cid.toString().value(), nullptr );
+        }
     }
 }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -33,6 +33,7 @@ namespace sgns::blockchain
         request_block_by_cid_( std::move( block_request_method ) ),
         init_callback_( std::move( init_callback ) )
     {
+        logger_->trace( "{}: constructed", __func__ );
     }
 
     std::shared_ptr<ValidatorRegistry> ValidatorRegistry::New( std::shared_ptr<crdt::GlobalDB> db,
@@ -67,19 +68,22 @@ namespace sgns::blockchain
                                                                                    std::move( block_request_method ),
                                                                                    std::move( init_callback ) ) );
 
-        instance->logger_->trace( "ValidatorRegistry instance created" );
+        instance->logger_->trace( "{}: instance created", __func__ );
         instance->InitializeCache();
 
         if ( !instance->RegisterFilter() )
         {
+            instance->logger_->error( "{}: failed to register filters", __func__ );
             return nullptr;
         }
 
+        instance->logger_->info( "{}: instance ready", __func__ );
         return instance;
     }
 
     uint64_t ValidatorRegistry::ComputeWeight( Role role ) const
     {
+        logger_->trace( "{}: entry role={}", __func__, static_cast<int>( role ) );
         const uint64_t base_weight = weight_config_.base_weight_;
         uint64_t       multiplier  = 1;
 
@@ -102,20 +106,25 @@ namespace sgns::blockchain
 
         if ( multiplier == 0 )
         {
+            logger_->debug( "{}: multiplier is zero, weight=0", __func__ );
             return 0;
         }
 
         if ( base_weight > weight_config_.max_weight_ / multiplier )
         {
+            logger_->debug( "{}: weight clamped to max {}", __func__, weight_config_.max_weight_ );
             return weight_config_.max_weight_;
         }
 
         const uint64_t weighted = base_weight * multiplier;
-        return std::min( weighted, weight_config_.max_weight_ );
+        const uint64_t result = std::min( weighted, weight_config_.max_weight_ );
+        logger_->debug( "{}: computed weight={}", __func__, result );
+        return result;
     }
 
     uint64_t ValidatorRegistry::TotalWeight( const Registry &registry ) const
     {
+        logger_->trace( "{}: entry validators={}", __func__, registry.validators().size() );
         uint64_t total_weight = 0;
         for ( const auto &entry : registry.validators() )
         {
@@ -125,27 +134,36 @@ namespace sgns::blockchain
             }
             total_weight += entry.weight();
         }
+        logger_->debug( "{}: total_weight={}", __func__, total_weight );
         return total_weight;
     }
 
     uint64_t ValidatorRegistry::QuorumThreshold( uint64_t total_weight ) const
     {
+        logger_->trace( "{}: entry total_weight={}", __func__, total_weight );
         if ( total_weight == 0 )
         {
+            logger_->debug( "{}: total_weight is zero, threshold=0", __func__ );
             return 0;
         }
         const uint64_t numerator = total_weight * quorum_numerator_;
-        return ( numerator + quorum_denominator_ - 1 ) / quorum_denominator_;
+        const uint64_t threshold = ( numerator + quorum_denominator_ - 1 ) / quorum_denominator_;
+        logger_->debug( "{}: threshold={}", __func__, threshold );
+        return threshold;
     }
 
     bool ValidatorRegistry::IsQuorum( uint64_t accumulated_weight, uint64_t total_weight ) const
     {
-        return accumulated_weight >= QuorumThreshold( total_weight );
+        logger_->trace( "{}: entry accumulated={} total={}", __func__, accumulated_weight, total_weight );
+        const bool is_quorum = accumulated_weight >= QuorumThreshold( total_weight );
+        logger_->debug( "{}: is_quorum={}", __func__, is_quorum );
+        return is_quorum;
     }
 
     ValidatorRegistry::Registry ValidatorRegistry::CreateGenesisRegistry(
         const std::string &genesis_validator_id ) const
     {
+        logger_->trace( "{}: entry genesis_id={}", __func__, genesis_validator_id.substr( 0, 8 ) );
         Registry registry;
         registry.set_epoch( 0 );
         auto *entry = registry.add_validators();
@@ -153,49 +171,62 @@ namespace sgns::blockchain
         entry->set_role( Role::GENESIS );
         entry->set_status( Status::ACTIVE );
         entry->set_weight( ComputeWeight( entry->role() ) );
+        logger_->debug( "{}: registry created with weight={}", __func__, entry->weight() );
         return registry;
     }
 
     outcome::result<std::vector<uint8_t>> ValidatorRegistry::SerializeRegistry( const Registry &registry ) const
     {
+        logger_->trace( "{}: entry validators={}", __func__, registry.validators().size() );
         std::string serialized;
         if ( !registry.SerializeToString( &serialized ) )
         {
+            logger_->error( "{}: serialization failed", __func__ );
             return outcome::failure( std::errc::invalid_argument );
         }
+        logger_->debug( "{}: serialized size={}", __func__, serialized.size() );
         return std::vector<uint8_t>( serialized.begin(), serialized.end() );
     }
 
     outcome::result<ValidatorRegistry::Registry> ValidatorRegistry::DeserializeRegistry(
         const std::vector<uint8_t> &buffer ) const
     {
+        logger_->trace( "{}: entry size={}", __func__, buffer.size() );
         Registry proto;
         if ( !proto.ParseFromArray( buffer.data(), static_cast<int>( buffer.size() ) ) )
         {
+            logger_->error( "{}: parse failed", __func__ );
             return outcome::failure( std::errc::invalid_argument );
         }
+        logger_->debug( "{}: parsed validators={}", __func__, proto.validators().size() );
         return proto;
     }
 
     outcome::result<std::vector<uint8_t>> ValidatorRegistry::SerializeRegistryUpdate(
         const RegistryUpdate &update ) const
     {
+        logger_->trace( "{}: entry validators={}", __func__, update.registry().validators().size() );
         std::string serialized;
         if ( !update.SerializeToString( &serialized ) )
         {
+            logger_->error( "{}: serialization failed", __func__ );
             return outcome::failure( std::errc::invalid_argument );
         }
+        logger_->debug( "{}: serialized size={}", __func__, serialized.size() );
         return std::vector<uint8_t>( serialized.begin(), serialized.end() );
     }
 
     outcome::result<ValidatorRegistry::RegistryUpdate> ValidatorRegistry::DeserializeRegistryUpdate(
         const std::vector<uint8_t> &buffer ) const
     {
+        logger_->trace( "{}: entry size={}", __func__, buffer.size() );
         RegistryUpdate proto;
         if ( !proto.ParseFromArray( buffer.data(), static_cast<int>( buffer.size() ) ) )
         {
+            logger_->error( "{}: parse failed", __func__ );
             return outcome::failure( std::errc::invalid_argument );
         }
+        logger_->debug( "{}: parsed validators={}", __func__, proto.registry().validators().size() );
         return proto;
     }
 
@@ -203,19 +234,23 @@ namespace sgns::blockchain
         const std::string                                          &genesis_validator_id,
         std::function<std::vector<uint8_t>( std::vector<uint8_t> )> sign )
     {
+        logger_->trace( "{}: entry genesis_id={}", __func__, genesis_validator_id.substr( 0, 8 ) );
         {
             std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
             if ( cache_initialized_ && cached_registry_ && !cached_registry_->validators().empty() )
             {
+                logger_->info( "{}: registry already initialized, skipping", __func__ );
                 return outcome::success();
             }
         }
 
         if ( !sign )
         {
+            logger_->error( "{}: missing sign callback", __func__ );
             return outcome::failure( std::errc::invalid_argument );
         }
 
+        logger_->debug( "{}: creating genesis registry", __func__ );
         RegistryUpdate update;
         *update.mutable_registry() = CreateGenesisRegistry( genesis_validator_id );
         update.clear_prev_registry_hash();
@@ -223,6 +258,7 @@ namespace sgns::blockchain
         auto signing_bytes = ComputeUpdateSigningBytes( update );
         if ( signing_bytes.has_error() )
         {
+            logger_->error( "{}: failed to compute signing bytes", __func__ );
             return outcome::failure( signing_bytes.error() );
         }
 
@@ -235,6 +271,7 @@ namespace sgns::blockchain
         auto serialized_update = SerializeRegistryUpdate( update );
         if ( serialized_update.has_error() )
         {
+            logger_->error( "{}: failed to serialize registry update", __func__ );
             return outcome::failure( serialized_update.error() );
         }
 
@@ -246,18 +283,32 @@ namespace sgns::blockchain
         auto registry_put = db_->Put( registry_key, update_buffer, { std::string( ValidatorTopic() ) } );
         if ( registry_put.has_error() )
         {
+            logger_->error( "{}: failed to store registry in CRDT", __func__ );
             return outcome::failure( registry_put.error() );
         }
 
+        auto cid_string = registry_put.value().toString();
+        if ( cid_string.has_value() )
+        {
+            logger_->info( "{}: stored genesis registry CID {}", __func__, cid_string.value() );
+        }
+        else
+        {
+            logger_->error( "{}: registry stored but CID missing", __func__ );
+        }
+
+        logger_->info( "{}: success", __func__ );
         return outcome::success();
     }
 
     outcome::result<ValidatorRegistry::Registry> ValidatorRegistry::LoadRegistry() const
     {
+        logger_->trace( "{}: entry", __func__ );
         {
             std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
             if ( cached_registry_ )
             {
+                logger_->debug( "{}: returning cached registry", __func__ );
                 return cached_registry_.value();
             }
         }
@@ -265,26 +316,32 @@ namespace sgns::blockchain
         auto update_result = LoadRegistryUpdate();
         if ( update_result.has_error() )
         {
+            logger_->error( "{}: failed to load registry update", __func__ );
             return outcome::failure( update_result.error() );
         }
+        logger_->debug( "{}: returning registry from update", __func__ );
         return update_result.value().registry();
     }
 
     outcome::result<ValidatorRegistry::RegistryUpdate> ValidatorRegistry::LoadRegistryUpdate() const
     {
+        logger_->trace( "{}: entry", __func__ );
         {
             std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
             if ( cached_update_ )
             {
+                logger_->debug( "{}: returning cached update", __func__ );
                 return cached_update_.value();
             }
         }
 
+        logger_->error( "{}: registry update not available", __func__ );
         return outcome::failure( std::errc::no_such_file_or_directory );
     }
 
     bool ValidatorRegistry::RegisterFilter()
     {
+        logger_->trace( "{}: entry", __func__ );
         const std::string pattern           = "/?" + std::string( RegistryKey() );
         auto              weak_self         = weak_from_this();
         const bool        filter_registered = db_->RegisterElementFilter(
@@ -309,17 +366,20 @@ namespace sgns::blockchain
 
         db_->AddListenTopic( std::string( ValidatorTopic() ) );
 
-        return filter_registered && callback_registered;
+        const bool result = filter_registered && callback_registered;
+        logger_->info( "{}: result={}", __func__, result );
+        return result;
     }
 
     std::optional<std::vector<crdt::pb::Element>> ValidatorRegistry::FilterRegistryUpdate(
         const crdt::pb::Element &element )
     {
+        logger_->trace( "{}: entry key={}", __func__, element.key() );
         std::vector<uint8_t> bytes( element.value().begin(), element.value().end() );
         auto                 decoded_update = DeserializeRegistryUpdate( bytes );
         if ( decoded_update.has_error() )
         {
-            logger_->warn( "Failed to parse validator registry update, rejecting: {}", element.key() );
+            logger_->error( "{}: parse failed, rejecting: {}", __func__, element.key() );
             return std::vector<crdt::pb::Element>{};
         }
 
@@ -336,22 +396,24 @@ namespace sgns::blockchain
 
         if ( !VerifyUpdate( update, current_ptr ) )
         {
-            logger_->warn( "Validator registry update failed verification, rejecting: {}", element.key() );
+            logger_->error( "{}: verification failed, rejecting: {}", __func__, element.key() );
             return std::vector<crdt::pb::Element>{};
         }
 
+        logger_->debug( "{}: update accepted", __func__ );
         return std::nullopt;
     }
 
     void ValidatorRegistry::RegistryUpdateReceived( crdt::CRDTCallbackManager::NewDataPair new_data,
                                                     const std::string                     &cid )
     {
+        logger_->trace( "{}: entry cid={}", __func__, cid );
         const auto          &buffer = new_data.second;
         std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
         auto                 decoded = DeserializeRegistryUpdate( bytes );
         if ( decoded.has_error() )
         {
-            logger_->error( "Failed to parse registry update for cache refresh" );
+            logger_->error( "{}: failed to parse registry update for cache refresh", __func__ );
             return;
         }
 
@@ -365,11 +427,13 @@ namespace sgns::blockchain
 
         PersistLocalState( cid );
         NotifyInitialized( true );
+        logger_->info( "{}: cache updated and initialized", __func__ );
     }
 
     outcome::result<std::vector<uint8_t>> ValidatorRegistry::ComputeUpdateSigningBytes(
         const RegistryUpdate &update ) const
     {
+        logger_->trace( "{}: entry validators={}", __func__, update.registry().validators().size() );
         sgns::blockchain::validator::RegistrySigningPayload payload;
         *payload.mutable_registry() = update.registry();
         payload.set_prev_registry_hash( update.prev_registry_hash() );
@@ -377,27 +441,33 @@ namespace sgns::blockchain
         std::string serialized;
         if ( !payload.SerializeToString( &serialized ) )
         {
+            logger_->error( "{}: serialization failed", __func__ );
             return outcome::failure( std::errc::invalid_argument );
         }
 
+        logger_->debug( "{}: payload size={}", __func__, serialized.size() );
         return std::vector<uint8_t>( serialized.begin(), serialized.end() );
     }
 
     bool ValidatorRegistry::VerifyUpdate( const RegistryUpdate &update, const Registry *current_registry ) const
     {
+        logger_->trace( "{}: entry validators={}", __func__, update.registry().validators().size() );
         if ( update.registry().validators().empty() )
         {
+            logger_->error( "{}: empty registry update", __func__ );
             return false;
         }
 
         auto signing_bytes = ComputeUpdateSigningBytes( update );
         if ( signing_bytes.has_error() )
         {
+            logger_->error( "{}: signing bytes computation failed", __func__ );
             return false;
         }
 
         if ( !current_registry )
         {
+            logger_->debug( "{}: verifying genesis update", __func__ );
             if ( update.prev_registry_hash().empty() )
             {
                 for ( const auto &signature : update.signatures() )
@@ -410,10 +480,12 @@ namespace sgns::blockchain
                                                          signature.signature(),
                                                          signing_bytes.value() ) )
                     {
+                        logger_->info( "{}: genesis update verified", __func__ );
                         return true;
                     }
                 }
             }
+            logger_->error( "{}: genesis update verification failed", __func__ );
             return false;
         }
 
@@ -426,11 +498,13 @@ namespace sgns::blockchain
         if ( current_id.empty() || prev_registry_cid != current_id )
         {
             //TODO - Check if the CID checking is necessary, because we could receive out-of-order updates
+            logger_->error( "{}: prev registry CID mismatch", __func__ );
             return false;
         }
 
         if ( update.registry().epoch() <= current_registry->epoch() )
         {
+            logger_->error( "{}: epoch not increasing", __func__ );
             return false;
         }
 
@@ -461,42 +535,48 @@ namespace sgns::blockchain
             accumulated_weight += validator->weight();
             if ( IsQuorum( accumulated_weight, total_weight ) )
             {
+                logger_->info( "{}: quorum reached", __func__ );
                 return true;
             }
         }
 
+        logger_->error( "{}: quorum not reached", __func__ );
         return false;
     }
 
     const ValidatorRegistry::ValidatorEntry *ValidatorRegistry::FindValidator( const Registry    &registry,
                                                                                const std::string &validator_id ) const
     {
+        logger_->trace( "{}: entry id={}", __func__, validator_id.substr( 0, 8 ) );
         for ( const auto &validator : registry.validators() )
         {
             if ( validator.validator_id() == validator_id )
             {
+                logger_->debug( "{}: validator found", __func__ );
                 return &validator;
             }
         }
+        logger_->debug( "{}: validator not found", __func__ );
         return nullptr;
     }
 
     void ValidatorRegistry::InitializeCache()
     {
+        logger_->trace( "{}: entry", __func__ );
         std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
         if ( cache_initialized_ )
         {
-            logger_->error( "Cache already initialized" );
+            logger_->error( "{}: cache already initialized", __func__ );
             return;
         }
-        logger_->trace( "Grabbing Validator Registry from CRDT" );
+        logger_->trace( "{}: grabbing validator registry from CRDT", __func__ );
 
         crdt::HierarchicalKey registry_key{ std::string( RegistryKey() ) };
         auto                  registry_get    = db_->Get( registry_key );
         bool                  content_present = registry_get.has_value();
         if ( !content_present )
         {
-            logger_->error( "Registry content not found during cache init" );
+            logger_->error( "{}: registry content not found during cache init", __func__ );
             return;
         }
         const auto          &buffer = registry_get.value();
@@ -504,12 +584,13 @@ namespace sgns::blockchain
         auto                 decoded = DeserializeRegistryUpdate( bytes );
         if ( !decoded.has_value() )
         {
-            logger_->warn( "Failed to parse registry content during cache init" );
+            logger_->error( "{}: failed to parse registry content during cache init", __func__ );
             return;
         }
 
         cached_update_   = decoded.value();
         cached_registry_ = decoded.value().registry();
+        logger_->debug( "{}: cache populated validators={}", __func__, cached_registry_->validators().size() );
 
         cache_initialized_ = true;
 
@@ -519,13 +600,14 @@ namespace sgns::blockchain
         if ( registry_cid.has_value() )
         {
             cached_registry_id_ = registry_cid.value().toString();
+            logger_->info( "{}: cache initialized with CID {}", __func__, cached_registry_id_ );
             NotifyInitialized( true );
             return;
         }
 
         std::set<CID> heads_to_request;
 
-        logger_->warn( "Registry content found, but CID is missing; requesting heads" );
+        logger_->error( "{}: registry content found but CID missing, requesting heads", __func__ );
 
         auto heads_result = db_->GetCRDTHeadList();
         if ( heads_result.has_value() )
@@ -537,6 +619,7 @@ namespace sgns::blockchain
                 heads_to_request = it->second;
             }
         }
+        logger_->debug( "{}: heads to request={}", __func__, heads_to_request.size() );
 
         lock.unlock();
 
@@ -544,21 +627,30 @@ namespace sgns::blockchain
         {
             RequestHeadCids( heads_to_request );
         }
+        else
+        {
+            logger_->error( "{}: no heads available to request", __func__ );
+        }
     }
 
     void ValidatorRegistry::PersistLocalState( const std::string &cid )
     {
+        logger_->trace( "{}: entry cid={}", __func__, cid );
         sgns::crdt::GlobalDB::Buffer registry_cid_key;
         registry_cid_key.put( std::string( RegistryCidKey() ) );
         sgns::crdt::GlobalDB::Buffer registry_cid;
         registry_cid.put( cid );
         (void)db_->GetDataStore()->put( registry_cid_key, registry_cid );
+        logger_->debug( "{}: persisted CID", __func__ );
     }
 
     void ValidatorRegistry::RequestHeadCids( const std::set<CID> &cids )
     {
+        logger_->trace( "{}: entry count={}", __func__, cids.size() );
+        const char *func = __func__;
         if ( cids.empty() )
         {
+            logger_->error( "{}: empty CID set", __func__ );
             return;
         }
 
@@ -577,6 +669,7 @@ namespace sgns::blockchain
             auto cid_string = cid.toString();
             if ( !cid_string.has_value() )
             {
+                logger_->error( "{}: failed to convert CID to string", __func__ );
                 if ( state->remaining.fetch_sub( 1 ) == 1 && !state->success_reported.load() )
                 {
                     NotifyInitialized( false );
@@ -584,9 +677,10 @@ namespace sgns::blockchain
                 continue;
             }
 
+            logger_->debug( "{}: requesting CID {}", __func__, cid_string.value() );
             request_block_by_cid_(
                 cid_string.value(),
-                [weak_self = weak_from_this(), state]( outcome::result<std::string> result )
+                [weak_self = weak_from_this(), state, func]( outcome::result<std::string> result )
                 {
                     if ( auto self = weak_self.lock() )
                     {
@@ -594,12 +688,14 @@ namespace sgns::blockchain
                         {
                             if ( !state->success_reported.exchange( true ) )
                             {
+                                self->logger_->info( "{}: head request succeeded", func );
                                 self->NotifyInitialized( true );
                             }
                         }
 
                         if ( state->remaining.fetch_sub( 1 ) == 1 && !state->success_reported.load() )
                         {
+                            self->logger_->error( "{}: all head requests failed", func );
                             self->NotifyInitialized( false );
                         }
                     }
@@ -609,9 +705,15 @@ namespace sgns::blockchain
 
     void ValidatorRegistry::NotifyInitialized( bool success )
     {
+        logger_->trace( "{}: entry success={}", __func__, success );
         if ( init_callback_ )
         {
             init_callback_( success );
+            logger_->debug( "{}: callback dispatched", __func__ );
+        }
+        else
+        {
+            logger_->debug( "{}: no callback registered", __func__ );
         }
     }
 }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -10,10 +10,12 @@
 #include <set>
 #include <system_error>
 
+#include <gsl/span>
+
 #include "account/GeniusAccount.hpp"
 #include "base/hexutil.hpp"
+#include "blockchain/impl/proto/ValidatorRegistry.pb.h"
 #include "crypto/hasher/hasher_impl.hpp"
-#include "scale/scale.hpp"
 
 namespace sgns::blockchain
 {
@@ -28,10 +30,29 @@ namespace sgns::blockchain
         , weight_config_( std::move( weight_config ) )
         , genesis_authority_( std::move( genesis_authority ) )
     {
-        if ( quorum_denominator_ == 0 )
+
+    }
+
+    std::shared_ptr<ValidatorRegistry> ValidatorRegistry::New( std::shared_ptr<crdt::GlobalDB> db,
+                                                               uint64_t                        quorum_numerator,
+                                                               uint64_t                        quorum_denominator,
+                                                               WeightConfig                    weight_config,
+                                                               std::string                     genesis_authority )
+    {
+        if ( !db )
         {
-            quorum_denominator_ = 1;
+            return nullptr;
         }
+        if ( quorum_denominator == 0 )
+        {
+            quorum_denominator = 1;
+        }
+        return std::shared_ptr<ValidatorRegistry>(
+            new ValidatorRegistry( std::move( db ),
+                                    quorum_numerator,
+                                    quorum_denominator,
+                                    std::move( weight_config ),
+                                    std::move( genesis_authority ) ) );
     }
 
     uint64_t ValidatorRegistry::ComputeWeight( Role role ) const
@@ -41,16 +62,16 @@ namespace sgns::blockchain
 
         switch ( role )
         {
-            case Role::Genesis:
+            case Role::GENESIS:
                 multiplier = weight_config_.genesis_multiplier_;
                 break;
-            case Role::Full:
+            case Role::FULL:
                 multiplier = weight_config_.full_multiplier_;
                 break;
-            case Role::Sharded:
+            case Role::SHARDED:
                 multiplier = weight_config_.sharded_multiplier_;
                 break;
-            case Role::Regular:
+            case Role::REGULAR:
             default:
                 multiplier = 1;
                 break;
@@ -73,13 +94,13 @@ namespace sgns::blockchain
     uint64_t ValidatorRegistry::TotalWeight( const Registry &registry ) const
     {
         uint64_t total_weight = 0;
-        for ( const auto &entry : registry.validators_ )
+        for ( const auto &entry : registry.validators() )
         {
-            if ( entry.status_ != Status::Active )
+            if ( entry.status() != Status::ACTIVE )
             {
                 continue;
             }
-            total_weight += entry.weight_;
+            total_weight += entry.weight();
         }
         return total_weight;
     }
@@ -103,77 +124,73 @@ namespace sgns::blockchain
         const std::string &genesis_validator_id ) const
     {
         Registry registry;
-        ValidatorEntry entry;
-        entry.validator_id_ = genesis_validator_id;
-        entry.role_          = Role::Genesis;
-        entry.status_        = Status::Active;
-        entry.weight_        = ComputeWeight( entry.role_ );
-
-        registry.validators_.push_back( std::move( entry ) );
+        registry.set_epoch( 0 );
+        auto *entry = registry.add_validators();
+        entry->set_validator_id( genesis_validator_id );
+        entry->set_role( Role::GENESIS );
+        entry->set_status( Status::ACTIVE );
+        entry->set_weight( ComputeWeight( entry->role() ) );
         return registry;
     }
 
-    outcome::result<base::Buffer> ValidatorRegistry::SerializeRegistry( const Registry &registry ) const
+    outcome::result<std::vector<uint8_t>> ValidatorRegistry::SerializeRegistry( const Registry &registry ) const
     {
-        auto encoded = scale::encode( registry );
-        if ( encoded.has_error() )
+        std::string serialized;
+        if ( !registry.SerializeToString( &serialized ) )
         {
-            return outcome::failure( encoded.error() );
+            return outcome::failure( std::errc::invalid_argument );
         }
-        return base::Buffer( std::move( encoded.value() ) );
+        return std::vector<uint8_t>( serialized.begin(), serialized.end() );
     }
 
     outcome::result<ValidatorRegistry::Registry> ValidatorRegistry::DeserializeRegistry(
-        const base::Buffer &buffer ) const
+        const std::vector<uint8_t> &buffer ) const
     {
-        auto decoded = scale::decode<Registry>( gsl::span<const uint8_t>( buffer.data(), buffer.size() ) );
-        if ( decoded.has_error() )
+        Registry proto;
+        if ( !proto.ParseFromArray( buffer.data(), static_cast<int>( buffer.size() ) ) )
         {
-            return outcome::failure( decoded.error() );
+            return outcome::failure( std::errc::invalid_argument );
         }
-        return decoded.value();
+        return proto;
     }
 
-    outcome::result<base::Buffer> ValidatorRegistry::SerializeRegistryUpdate( const RegistryUpdate &update ) const
+    outcome::result<std::vector<uint8_t>> ValidatorRegistry::SerializeRegistryUpdate( const RegistryUpdate &update ) const
     {
-        auto encoded = scale::encode( update );
-        if ( encoded.has_error() )
+        std::string serialized;
+        if ( !update.SerializeToString( &serialized ) )
         {
-            return outcome::failure( encoded.error() );
+            return outcome::failure( std::errc::invalid_argument );
         }
-        return base::Buffer( std::move( encoded.value() ) );
+        return std::vector<uint8_t>( serialized.begin(), serialized.end() );
     }
 
     outcome::result<ValidatorRegistry::RegistryUpdate> ValidatorRegistry::DeserializeRegistryUpdate(
-        const base::Buffer &buffer ) const
+        const std::vector<uint8_t> &buffer ) const
     {
-        auto decoded = scale::decode<RegistryUpdate>( gsl::span<const uint8_t>( buffer.data(), buffer.size() ) );
-        if ( decoded.has_error() )
+        RegistryUpdate proto;
+        if ( !proto.ParseFromArray( buffer.data(), static_cast<int>( buffer.size() ) ) )
         {
-            return outcome::failure( decoded.error() );
+            return outcome::failure( std::errc::invalid_argument );
         }
-        return decoded.value();
+        return proto;
     }
 
     outcome::result<void> ValidatorRegistry::StoreGenesisRegistry(
         const std::string &genesis_validator_id,
         std::function<std::vector<uint8_t>( std::vector<uint8_t> )> sign )
     {
-        if ( !db_ )
-        {
-            return outcome::failure( std::errc::bad_address );
-        }
-
         const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
         const auto                  registry_get = db_->Get( registry_key );
         bool                        registry_empty = true;
 
         if ( registry_get.has_value() )
         {
-            auto decoded_update = DeserializeRegistryUpdate( registry_get.value() );
+            const auto &buffer = registry_get.value();
+            std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
+            auto decoded_update = DeserializeRegistryUpdate( bytes );
             if ( decoded_update.has_value() )
             {
-                registry_empty = decoded_update.value().registry_.validators_.empty();
+                registry_empty = decoded_update.value().registry().validators().empty();
             }
         }
 
@@ -188,8 +205,8 @@ namespace sgns::blockchain
         }
 
         RegistryUpdate update;
-        update.registry_ = CreateGenesisRegistry( genesis_validator_id );
-        update.prev_registry_hash_.clear();
+        *update.mutable_registry() = CreateGenesisRegistry( genesis_validator_id );
+        update.clear_prev_registry_hash();
 
         auto signing_bytes = ComputeUpdateSigningBytes( update );
         if ( signing_bytes.has_error() )
@@ -198,10 +215,10 @@ namespace sgns::blockchain
         }
 
         SignatureEntry signature_entry;
-        signature_entry.validator_id_ = genesis_validator_id;
+        signature_entry.set_validator_id( genesis_validator_id );
         auto signature = sign( signing_bytes.value() );
-        signature_entry.signature_ = std::string( signature.begin(), signature.end() );
-        update.signatures_.push_back( std::move( signature_entry ) );
+        signature_entry.set_signature( signature.data(), signature.size() );
+        *update.add_signatures() = signature_entry;
 
         auto serialized_update = SerializeRegistryUpdate( update );
         if ( serialized_update.has_error() )
@@ -209,8 +226,12 @@ namespace sgns::blockchain
             return outcome::failure( serialized_update.error() );
         }
 
+        base::Buffer update_buffer( gsl::span<const uint8_t>(
+            serialized_update.value().data(),
+            serialized_update.value().size() ) );
+
         auto registry_put = db_->Put( registry_key,
-                                      serialized_update.value(),
+                                      update_buffer,
                                       { std::string( ValidatorTopic() ) } );
         if ( registry_put.has_error() )
         {
@@ -227,16 +248,11 @@ namespace sgns::blockchain
         {
             return outcome::failure( update_result.error() );
         }
-        return update_result.value().registry_;
+        return update_result.value().registry();
     }
 
     outcome::result<ValidatorRegistry::RegistryUpdate> ValidatorRegistry::LoadRegistryUpdate() const
     {
-        if ( !db_ )
-        {
-            return outcome::failure( std::errc::bad_address );
-        }
-
         const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
         auto                        registry_get = db_->Get( registry_key );
         if ( registry_get.has_error() )
@@ -244,16 +260,13 @@ namespace sgns::blockchain
             return outcome::failure( registry_get.error() );
         }
 
-        return DeserializeRegistryUpdate( registry_get.value() );
+        const auto &buffer = registry_get.value();
+        std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
+        return DeserializeRegistryUpdate( bytes );
     }
 
     bool ValidatorRegistry::RegisterFilter()
     {
-        if ( !db_ )
-        {
-            return false;
-        }
-
         const std::string pattern = "/?" + std::string( RegistryKey() );
         auto              weak_self = weak_from_this();
         return db_->RegisterElementFilter(
@@ -271,9 +284,8 @@ namespace sgns::blockchain
     std::optional<std::vector<crdt::pb::Element>> ValidatorRegistry::FilterRegistryUpdate(
         const crdt::pb::Element &element )
     {
-        auto decoded_update = DeserializeRegistryUpdate( base::Buffer{
-            gsl::span<const uint8_t>( reinterpret_cast<const uint8_t *>( element.value().data() ),
-                                      element.value().size() ) } );
+        std::vector<uint8_t> bytes( element.value().begin(), element.value().end() );
+        auto decoded_update = DeserializeRegistryUpdate( bytes );
         if ( decoded_update.has_error() )
         {
             logger_->warn( "Failed to parse validator registry update, rejecting: {}", element.key() );
@@ -288,10 +300,12 @@ namespace sgns::blockchain
             auto                        registry_get = db_->Get( registry_key );
             if ( registry_get.has_value() )
             {
-                auto stored_update = DeserializeRegistryUpdate( registry_get.value() );
+                const auto &buffer = registry_get.value();
+                std::vector<uint8_t> stored_bytes( buffer.data(), buffer.data() + buffer.size() );
+                auto stored_update = DeserializeRegistryUpdate( stored_bytes );
                 if ( stored_update.has_value() )
                 {
-                    current_registry = stored_update.value().registry_;
+                    current_registry = stored_update.value().registry();
                 }
             }
         }
@@ -309,7 +323,17 @@ namespace sgns::blockchain
     outcome::result<std::vector<uint8_t>> ValidatorRegistry::ComputeUpdateSigningBytes(
         const RegistryUpdate &update ) const
     {
-        return scale::encode( update.prev_registry_hash_, update.registry_ );
+        sgns::blockchain::validator::RegistrySigningPayload payload;
+        *payload.mutable_registry() = update.registry();
+        payload.set_prev_registry_hash( update.prev_registry_hash() );
+
+        std::string serialized;
+        if ( !payload.SerializeToString( &serialized ) )
+        {
+            return outcome::failure( std::errc::invalid_argument );
+        }
+
+        return std::vector<uint8_t>( serialized.begin(), serialized.end() );
     }
 
     std::string ValidatorRegistry::ComputeRegistryHash( const Registry &registry ) const
@@ -328,7 +352,7 @@ namespace sgns::blockchain
 
     bool ValidatorRegistry::VerifyUpdate( const RegistryUpdate &update, const Registry *current_registry ) const
     {
-        if ( update.registry_.validators_.empty() )
+        if ( update.registry().validators().empty() )
         {
             return false;
         }
@@ -341,16 +365,16 @@ namespace sgns::blockchain
 
         if ( !current_registry )
         {
-            if ( update.prev_registry_hash_.empty() && !genesis_authority_.empty() )
+            if ( update.prev_registry_hash().empty() && !genesis_authority_.empty() )
             {
-                for ( const auto &signature : update.signatures_ )
+                for ( const auto &signature : update.signatures() )
                 {
-                    if ( signature.validator_id_ != genesis_authority_ )
+                    if ( signature.validator_id() != genesis_authority_ )
                     {
                         continue;
                     }
-                    if ( GeniusAccount::VerifySignature( signature.validator_id_,
-                                                         signature.signature_,
+                    if ( GeniusAccount::VerifySignature( signature.validator_id(),
+                                                         signature.signature(),
                                                          signing_bytes.value() ) )
                     {
                         return true;
@@ -361,12 +385,12 @@ namespace sgns::blockchain
         }
 
         const std::string current_hash = ComputeRegistryHash( *current_registry );
-        if ( current_hash.empty() || update.prev_registry_hash_ != current_hash )
+        if ( current_hash.empty() || update.prev_registry_hash() != current_hash )
         {
             return false;
         }
 
-        if ( update.registry_.epoch_ <= current_registry->epoch_ )
+        if ( update.registry().epoch() <= current_registry->epoch() )
         {
             return false;
         }
@@ -375,27 +399,27 @@ namespace sgns::blockchain
         uint64_t accumulated_weight = 0;
         std::set<std::string> seen;
 
-        for ( const auto &signature : update.signatures_ )
+        for ( const auto &signature : update.signatures() )
         {
-            if ( !seen.insert( signature.validator_id_ ).second )
+            if ( !seen.insert( signature.validator_id() ).second )
             {
                 continue;
             }
 
-            const auto *validator = FindValidator( *current_registry, signature.validator_id_ );
-            if ( !validator || validator->status_ != Status::Active )
+            const auto *validator = FindValidator( *current_registry, signature.validator_id() );
+            if ( !validator || validator->status() != Status::ACTIVE )
             {
                 continue;
             }
 
-            if ( !GeniusAccount::VerifySignature( signature.validator_id_,
-                                                  signature.signature_,
+            if ( !GeniusAccount::VerifySignature( signature.validator_id(),
+                                                  signature.signature(),
                                                   signing_bytes.value() ) )
             {
                 continue;
             }
 
-            accumulated_weight += validator->weight_;
+            accumulated_weight += validator->weight();
             if ( IsQuorum( accumulated_weight, total_weight ) )
             {
                 return true;
@@ -409,9 +433,9 @@ namespace sgns::blockchain
         const Registry &registry,
         const std::string &validator_id ) const
     {
-        for ( const auto &validator : registry.validators_ )
+        for ( const auto &validator : registry.validators() )
         {
-            if ( validator.validator_id_ == validator_id )
+            if ( validator.validator_id() == validator_id )
             {
                 return &validator;
             }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -224,12 +224,9 @@ namespace sgns::blockchain
             return outcome::failure( registry_put.error() );
         }
 
+        if ( registry_put.value().toString().has_value() )
         {
-            std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
-            cached_registry_ = update.registry();
-            cached_update_ = update;
-            cached_registry_hash_ = ComputeRegistryHash( update.registry() );
-            cache_initialized_ = true;
+            PersistLocalState( registry_put.value().toString().value() );
         }
 
         return outcome::success();
@@ -270,7 +267,7 @@ namespace sgns::blockchain
     {
         const std::string pattern   = "/?" + std::string( RegistryKey() );
         auto              weak_self = weak_from_this();
-        return db_->RegisterElementFilter(
+        const bool filter_registered = db_->RegisterElementFilter(
             pattern,
             [weak_self]( const crdt::pb::Element &element ) -> std::optional<std::vector<crdt::pb::Element>>
             {
@@ -280,6 +277,15 @@ namespace sgns::blockchain
                 }
                 return std::nullopt;
             } );
+        const bool callback_registered = db_->RegisterNewElementCallback(
+            pattern,
+            [weak_self]( crdt::CRDTCallbackManager::NewDataPair new_data, const std::string &cid ) {
+                if ( auto strong = weak_self.lock() )
+                {
+                    strong->RegistryUpdateReceived( std::move( new_data ), cid );
+                }
+            } );
+        return filter_registered && callback_registered;
     }
 
     std::optional<std::vector<crdt::pb::Element>> ValidatorRegistry::FilterRegistryUpdate(
@@ -310,15 +316,30 @@ namespace sgns::blockchain
             return std::vector<crdt::pb::Element>{};
         }
 
+        return std::nullopt;
+    }
+
+    void ValidatorRegistry::RegistryUpdateReceived( crdt::CRDTCallbackManager::NewDataPair new_data,
+                                                    const std::string                     &cid )
+    {
+        const auto          &buffer = new_data.second;
+        std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
+        auto                 decoded = DeserializeRegistryUpdate( bytes );
+        if ( decoded.has_error() )
+        {
+            logger_->warn( "Failed to parse registry update for cache refresh" );
+            return;
+        }
+
         {
             std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
-            cached_registry_ = update.registry();
-            cached_update_ = update;
-            cached_registry_hash_ = ComputeRegistryHash( update.registry() );
+            cached_update_ = decoded.value();
+            cached_registry_ = decoded.value().registry();
+            cached_registry_id_ = cid;
             cache_initialized_ = true;
         }
 
-        return std::nullopt;
+        PersistLocalState( cid );
     }
 
     outcome::result<std::vector<uint8_t>> ValidatorRegistry::ComputeUpdateSigningBytes(
@@ -384,8 +405,16 @@ namespace sgns::blockchain
             return false;
         }
 
-        const std::string current_hash = ComputeRegistryHash( *current_registry );
-        if ( current_hash.empty() || update.prev_registry_hash() != current_hash )
+        std::string current_id;
+        {
+            std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
+            current_id = cached_registry_id_;
+        }
+        if ( current_id.empty() )
+        {
+            current_id = ComputeRegistryHash( *current_registry );
+        }
+        if ( current_id.empty() || update.prev_registry_hash() != current_id )
         {
             return false;
         }
@@ -450,6 +479,20 @@ namespace sgns::blockchain
             return;
         }
 
+        sgns::crdt::GlobalDB::Buffer registry_cid_key;
+        registry_cid_key.put( std::string( RegistryCidKey() ) );
+        auto registry_cid = db_->GetDataStore()->get( registry_cid_key );
+        if ( registry_cid.has_value() )
+        {
+            cached_registry_id_ = registry_cid.value().toString();
+        }
+
+        if ( cached_registry_ )
+        {
+            cache_initialized_ = true;
+            return;
+        }
+
         const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
         auto                        registry_get = db_->Get( registry_key );
         if ( registry_get.has_error() )
@@ -470,7 +513,19 @@ namespace sgns::blockchain
 
         cached_update_ = decoded.value();
         cached_registry_ = decoded.value().registry();
-        cached_registry_hash_ = ComputeRegistryHash( decoded.value().registry() );
+        if ( cached_registry_id_.empty() )
+        {
+            cached_registry_id_ = ComputeRegistryHash( decoded.value().registry() );
+        }
         cache_initialized_ = true;
+    }
+
+    void ValidatorRegistry::PersistLocalState( const std::string &cid )
+    {
+        sgns::crdt::GlobalDB::Buffer registry_cid_key;
+        registry_cid_key.put( std::string( RegistryCidKey() ) );
+        sgns::crdt::GlobalDB::Buffer registry_cid;
+        registry_cid.put( cid );
+        (void)db_->GetDataStore()->put( registry_cid_key, registry_cid );
     }
 }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -14,9 +14,7 @@
 #include <gsl/span>
 
 #include "account/GeniusAccount.hpp"
-#include "base/hexutil.hpp"
 #include "blockchain/impl/proto/ValidatorRegistry.pb.h"
-#include "crypto/hasher/hasher_impl.hpp"
 
 namespace sgns::blockchain
 {
@@ -384,19 +382,6 @@ namespace sgns::blockchain
         return std::vector<uint8_t>( serialized.begin(), serialized.end() );
     }
 
-    std::string ValidatorRegistry::ComputeRegistryHash( const Registry &registry ) const
-    {
-        auto encoded = SerializeRegistry( registry );
-        if ( encoded.has_error() )
-        {
-            return {};
-        }
-
-        sgns::crypto::HasherImpl hasher;
-        auto hash = hasher.sha2_256( gsl::span<const uint8_t>( encoded.value().data(), encoded.value().size() ) );
-        return base::hex_lower( gsl::span<const uint8_t>( hash.data(), hash.size() ) );
-    }
-
     bool ValidatorRegistry::VerifyUpdate( const RegistryUpdate &update, const Registry *current_registry ) const
     {
         if ( update.registry().validators().empty() )
@@ -431,16 +416,13 @@ namespace sgns::blockchain
             return false;
         }
 
-        std::string current_id;
+        const std::string prev_registry_cid = update.prev_registry_hash();
+        std::string       current_id;
         {
             std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
             current_id = cached_registry_id_;
         }
-        if ( current_id.empty() )
-        {
-            current_id = ComputeRegistryHash( *current_registry );
-        }
-        if ( current_id.empty() || update.prev_registry_hash() != current_id )
+        if ( current_id.empty() || prev_registry_cid != current_id )
         {
             return false;
         }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -23,14 +23,13 @@ namespace sgns::blockchain
                                           uint64_t                        quorum_numerator,
                                           uint64_t                        quorum_denominator,
                                           WeightConfig                    weight_config,
-                                          std::string                     genesis_authority )
-        : db_( std::move( db ) )
-        , quorum_numerator_( quorum_numerator )
-        , quorum_denominator_( quorum_denominator )
-        , weight_config_( std::move( weight_config ) )
-        , genesis_authority_( std::move( genesis_authority ) )
+                                          std::string                     genesis_authority ) :
+        db_( std::move( db ) ),
+        quorum_numerator_( quorum_numerator ),
+        quorum_denominator_( quorum_denominator ),
+        weight_config_( std::move( weight_config ) ),
+        genesis_authority_( std::move( genesis_authority ) )
     {
-
     }
 
     std::shared_ptr<ValidatorRegistry> ValidatorRegistry::New( std::shared_ptr<crdt::GlobalDB> db,
@@ -47,12 +46,13 @@ namespace sgns::blockchain
         {
             quorum_denominator = 1;
         }
-        return std::shared_ptr<ValidatorRegistry>(
-            new ValidatorRegistry( std::move( db ),
-                                    quorum_numerator,
-                                    quorum_denominator,
-                                    std::move( weight_config ),
-                                    std::move( genesis_authority ) ) );
+        auto instance = std::shared_ptr<ValidatorRegistry>( new ValidatorRegistry( std::move( db ),
+                                                                                   quorum_numerator,
+                                                                                   quorum_denominator,
+                                                                                   std::move( weight_config ),
+                                                                                   std::move( genesis_authority ) ) );
+        instance->InitializeCache();
+        return instance;
     }
 
     uint64_t ValidatorRegistry::ComputeWeight( Role role ) const
@@ -154,7 +154,8 @@ namespace sgns::blockchain
         return proto;
     }
 
-    outcome::result<std::vector<uint8_t>> ValidatorRegistry::SerializeRegistryUpdate( const RegistryUpdate &update ) const
+    outcome::result<std::vector<uint8_t>> ValidatorRegistry::SerializeRegistryUpdate(
+        const RegistryUpdate &update ) const
     {
         std::string serialized;
         if ( !update.SerializeToString( &serialized ) )
@@ -176,27 +177,15 @@ namespace sgns::blockchain
     }
 
     outcome::result<void> ValidatorRegistry::StoreGenesisRegistry(
-        const std::string &genesis_validator_id,
+        const std::string                                          &genesis_validator_id,
         std::function<std::vector<uint8_t>( std::vector<uint8_t> )> sign )
     {
-        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
-        const auto                  registry_get = db_->Get( registry_key );
-        bool                        registry_empty = true;
-
-        if ( registry_get.has_value() )
         {
-            const auto &buffer = registry_get.value();
-            std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
-            auto decoded_update = DeserializeRegistryUpdate( bytes );
-            if ( decoded_update.has_value() )
+            std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
+            if ( cache_initialized_ && cached_registry_ && !cached_registry_->validators().empty() )
             {
-                registry_empty = decoded_update.value().registry().validators().empty();
+                return outcome::success();
             }
-        }
-
-        if ( !registry_empty )
-        {
-            return outcome::success();
         }
 
         if ( !sign )
@@ -226,16 +215,21 @@ namespace sgns::blockchain
             return outcome::failure( serialized_update.error() );
         }
 
-        base::Buffer update_buffer( gsl::span<const uint8_t>(
-            serialized_update.value().data(),
-            serialized_update.value().size() ) );
+        base::Buffer update_buffer(
+            gsl::span<const uint8_t>( serialized_update.value().data(), serialized_update.value().size() ) );
 
-        auto registry_put = db_->Put( registry_key,
-                                      update_buffer,
-                                      { std::string( ValidatorTopic() ) } );
+        auto registry_put = db_->Put( registry_key, update_buffer, { std::string( ValidatorTopic() ) } );
         if ( registry_put.has_error() )
         {
             return outcome::failure( registry_put.error() );
+        }
+
+        {
+            std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
+            cached_registry_ = update.registry();
+            cached_update_ = update;
+            cached_registry_hash_ = ComputeRegistryHash( update.registry() );
+            cache_initialized_ = true;
         }
 
         return outcome::success();
@@ -243,6 +237,14 @@ namespace sgns::blockchain
 
     outcome::result<ValidatorRegistry::Registry> ValidatorRegistry::LoadRegistry() const
     {
+        {
+            std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
+            if ( cached_registry_ )
+            {
+                return cached_registry_.value();
+            }
+        }
+
         auto update_result = LoadRegistryUpdate();
         if ( update_result.has_error() )
         {
@@ -253,21 +255,20 @@ namespace sgns::blockchain
 
     outcome::result<ValidatorRegistry::RegistryUpdate> ValidatorRegistry::LoadRegistryUpdate() const
     {
-        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
-        auto                        registry_get = db_->Get( registry_key );
-        if ( registry_get.has_error() )
         {
-            return outcome::failure( registry_get.error() );
+            std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
+            if ( cached_update_ )
+            {
+                return cached_update_.value();
+            }
         }
 
-        const auto &buffer = registry_get.value();
-        std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
-        return DeserializeRegistryUpdate( bytes );
+        return outcome::failure( std::errc::no_such_file_or_directory );
     }
 
     bool ValidatorRegistry::RegisterFilter()
     {
-        const std::string pattern = "/?" + std::string( RegistryKey() );
+        const std::string pattern   = "/?" + std::string( RegistryKey() );
         auto              weak_self = weak_from_this();
         return db_->RegisterElementFilter(
             pattern,
@@ -285,7 +286,7 @@ namespace sgns::blockchain
         const crdt::pb::Element &element )
     {
         std::vector<uint8_t> bytes( element.value().begin(), element.value().end() );
-        auto decoded_update = DeserializeRegistryUpdate( bytes );
+        auto                 decoded_update = DeserializeRegistryUpdate( bytes );
         if ( decoded_update.has_error() )
         {
             logger_->warn( "Failed to parse validator registry update, rejecting: {}", element.key() );
@@ -293,28 +294,28 @@ namespace sgns::blockchain
         }
 
         RegistryUpdate update = decoded_update.value();
-        std::optional<Registry> current_registry;
-        if ( db_ )
+        const Registry *current_ptr = nullptr;
+
         {
-            const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
-            auto                        registry_get = db_->Get( registry_key );
-            if ( registry_get.has_value() )
+            std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
+            if ( cached_registry_ )
             {
-                const auto &buffer = registry_get.value();
-                std::vector<uint8_t> stored_bytes( buffer.data(), buffer.data() + buffer.size() );
-                auto stored_update = DeserializeRegistryUpdate( stored_bytes );
-                if ( stored_update.has_value() )
-                {
-                    current_registry = stored_update.value().registry();
-                }
+                current_ptr = &cached_registry_.value();
             }
         }
 
-        const Registry *current_ptr = current_registry ? &current_registry.value() : nullptr;
         if ( !VerifyUpdate( update, current_ptr ) )
         {
             logger_->warn( "Validator registry update failed verification, rejecting: {}", element.key() );
             return std::vector<crdt::pb::Element>{};
+        }
+
+        {
+            std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
+            cached_registry_ = update.registry();
+            cached_update_ = update;
+            cached_registry_hash_ = ComputeRegistryHash( update.registry() );
+            cache_initialized_ = true;
         }
 
         return std::nullopt;
@@ -345,8 +346,7 @@ namespace sgns::blockchain
         }
 
         sgns::crypto::HasherImpl hasher;
-        auto hash = hasher.sha2_256( gsl::span<const uint8_t>( encoded.value().data(),
-                                                              encoded.value().size() ) );
+        auto hash = hasher.sha2_256( gsl::span<const uint8_t>( encoded.value().data(), encoded.value().size() ) );
         return base::hex_lower( gsl::span<const uint8_t>( hash.data(), hash.size() ) );
     }
 
@@ -395,8 +395,8 @@ namespace sgns::blockchain
             return false;
         }
 
-        uint64_t total_weight = TotalWeight( *current_registry );
-        uint64_t accumulated_weight = 0;
+        uint64_t              total_weight       = TotalWeight( *current_registry );
+        uint64_t              accumulated_weight = 0;
         std::set<std::string> seen;
 
         for ( const auto &signature : update.signatures() )
@@ -429,9 +429,8 @@ namespace sgns::blockchain
         return false;
     }
 
-    const ValidatorRegistry::ValidatorEntry *ValidatorRegistry::FindValidator(
-        const Registry &registry,
-        const std::string &validator_id ) const
+    const ValidatorRegistry::ValidatorEntry *ValidatorRegistry::FindValidator( const Registry    &registry,
+                                                                               const std::string &validator_id ) const
     {
         for ( const auto &validator : registry.validators() )
         {
@@ -441,5 +440,37 @@ namespace sgns::blockchain
             }
         }
         return nullptr;
+    }
+
+    void ValidatorRegistry::InitializeCache()
+    {
+        std::unique_lock<std::shared_mutex> lock( cache_mutex_ );
+        if ( cache_initialized_ )
+        {
+            return;
+        }
+
+        const crdt::HierarchicalKey registry_key( std::string( RegistryKey() ) );
+        auto                        registry_get = db_->Get( registry_key );
+        if ( registry_get.has_error() )
+        {
+            cache_initialized_ = true;
+            return;
+        }
+
+        const auto          &buffer = registry_get.value();
+        std::vector<uint8_t> bytes( buffer.data(), buffer.data() + buffer.size() );
+        auto                 decoded = DeserializeRegistryUpdate( bytes );
+        if ( decoded.has_error() )
+        {
+            logger_->warn( "Failed to initialize registry cache from CRDT" );
+            cache_initialized_ = true;
+            return;
+        }
+
+        cached_update_ = decoded.value();
+        cached_registry_ = decoded.value().registry();
+        cached_registry_hash_ = ComputeRegistryHash( decoded.value().registry() );
+        cache_initialized_ = true;
     }
 }

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -88,6 +89,7 @@ namespace sgns::blockchain
         bool                                          VerifyUpdate( const RegistryUpdate &update,
                                                                       const Registry *current_registry ) const;
         const ValidatorEntry *FindValidator( const Registry &registry, const std::string &validator_id ) const;
+        void                     InitializeCache();
 
         std::shared_ptr<crdt::GlobalDB> db_;
         uint64_t                        quorum_numerator_;
@@ -95,6 +97,11 @@ namespace sgns::blockchain
         WeightConfig                    weight_config_;
         std::string                     genesis_authority_;
         base::Logger                    logger_ = base::createLogger( "ValidatorRegistry" );
+        mutable std::shared_mutex       cache_mutex_;
+        std::optional<Registry>         cached_registry_;
+        std::optional<RegistryUpdate>   cached_update_;
+        std::string                     cached_registry_hash_;
+        bool                            cache_initialized_ = false;
     };
 
 }

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <shared_mutex>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -21,6 +22,7 @@
 #include "crdt/proto/delta.pb.h"
 #include "outcome/outcome.hpp"
 #include "crdt/globaldb/globaldb.hpp"
+#include "primitives/cid/cid.hpp"
 
 namespace sgns::blockchain
 {
@@ -67,6 +69,9 @@ namespace sgns::blockchain
         outcome::result<std::vector<uint8_t>> SerializeRegistryUpdate( const RegistryUpdate &update ) const;
         outcome::result<RegistryUpdate>       DeserializeRegistryUpdate( const std::vector<uint8_t> &buffer ) const;
 
+        void SetRequestBlockByCidMethod(
+            std::function<void( const std::string &cid,
+                                std::function<void( outcome::result<std::string> )> callback )> method );
         static constexpr std::string_view RegistryKey()
         {
             return "gnus-validator-registry";
@@ -99,6 +104,7 @@ namespace sgns::blockchain
         const ValidatorEntry *FindValidator( const Registry &registry, const std::string &validator_id ) const;
         void                     InitializeCache();
         void                     PersistLocalState( const std::string &cid );
+        void                     RequestHeadCids( const std::set<CID> &cids );
 
         std::shared_ptr<crdt::GlobalDB> db_;
         uint64_t                        quorum_numerator_;
@@ -111,6 +117,8 @@ namespace sgns::blockchain
         std::optional<RegistryUpdate>   cached_update_;
         std::string                     cached_registry_id_;
         bool                            cache_initialized_ = false;
+        std::function<void( const std::string &cid,
+                             std::function<void( outcome::result<std::string> )> callback )> request_block_by_cid_;
     };
 
 }

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -105,7 +105,6 @@ namespace sgns::blockchain
         std::optional<std::vector<crdt::pb::Element>> FilterRegistryUpdate( const crdt::pb::Element &element );
         void RegistryUpdateReceived( crdt::CRDTCallbackManager::NewDataPair new_data, const std::string &cid );
         outcome::result<std::vector<uint8_t>> ComputeUpdateSigningBytes( const RegistryUpdate &update ) const;
-        std::string                           ComputeRegistryHash( const Registry &registry ) const;
         bool                  VerifyUpdate( const RegistryUpdate &update, const Registry *current_registry ) const;
         const ValidatorEntry *FindValidator( const Registry &registry, const std::string &validator_id ) const;
         void                  InitializeCache();

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -50,12 +50,12 @@ namespace sgns::blockchain
         };
 
         static std::shared_ptr<ValidatorRegistry> New( std::shared_ptr<crdt::GlobalDB> db,
-                                                       uint64_t                        quorum_numerator   = 2,
-                                                       uint64_t                        quorum_denominator = 3,
-                                                       WeightConfig                    weight_config      = {},
+                                                       uint64_t                        quorum_numerator,
+                                                       uint64_t                        quorum_denominator,
+                                                       WeightConfig                    weight_config,
                                                        std::string                     genesis_authority,
-                                                       InitCallback                    init_callback = nullptr,
-                                                       BlockRequestMethod              block_request_method );
+                                                       BlockRequestMethod              block_request_method,
+                                                       InitCallback                    init_callback = nullptr );
 
         uint64_t ComputeWeight( Role role ) const;
         uint64_t TotalWeight( const Registry &registry ) const;
@@ -73,10 +73,6 @@ namespace sgns::blockchain
         outcome::result<Registry>             DeserializeRegistry( const std::vector<uint8_t> &buffer ) const;
         outcome::result<std::vector<uint8_t>> SerializeRegistryUpdate( const RegistryUpdate &update ) const;
         outcome::result<RegistryUpdate>       DeserializeRegistryUpdate( const std::vector<uint8_t> &buffer ) const;
-
-        void SetRequestBlockByCidMethod(
-            std::function<void( const std::string &cid, std::function<void( outcome::result<std::string> )> callback )>
-                method );
 
         static constexpr std::string_view RegistryKey()
         {
@@ -99,8 +95,8 @@ namespace sgns::blockchain
                            uint64_t                        quorum_denominator,
                            WeightConfig                    weight_config,
                            std::string                     genesis_authority,
-                           InitCallback                    init_callback,
-                           BlockRequestMethod              block_request_method );
+                           BlockRequestMethod              block_request_method,
+                           InitCallback                    init_callback );
 
         std::optional<std::vector<crdt::pb::Element>> FilterRegistryUpdate( const crdt::pb::Element &element );
         void RegistryUpdateReceived( crdt::CRDTCallbackManager::NewDataPair new_data, const std::string &cid );

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -17,6 +17,7 @@
 #include "base/buffer.hpp"
 #include "base/logger.hpp"
 #include "blockchain/impl/proto/ValidatorRegistry.pb.h"
+#include "crdt/crdt_callback_manager.hpp"
 #include "crdt/proto/delta.pb.h"
 #include "outcome/outcome.hpp"
 #include "crdt/globaldb/globaldb.hpp"
@@ -76,6 +77,11 @@ namespace sgns::blockchain
             return "gnus-validator-registry";
         }
 
+        static constexpr std::string_view RegistryCidKey()
+        {
+            return "gnus-validator-registry-cid";
+        }
+
     private:
         ValidatorRegistry( std::shared_ptr<crdt::GlobalDB> db,
                            uint64_t                        quorum_numerator,
@@ -84,12 +90,15 @@ namespace sgns::blockchain
                            std::string                     genesis_authority );
 
         std::optional<std::vector<crdt::pb::Element>> FilterRegistryUpdate( const crdt::pb::Element &element );
+        void                                          RegistryUpdateReceived( crdt::CRDTCallbackManager::NewDataPair new_data,
+                                                                              const std::string                     &cid );
         outcome::result<std::vector<uint8_t>>         ComputeUpdateSigningBytes( const RegistryUpdate &update ) const;
         std::string                                   ComputeRegistryHash( const Registry &registry ) const;
         bool                                          VerifyUpdate( const RegistryUpdate &update,
                                                                       const Registry *current_registry ) const;
         const ValidatorEntry *FindValidator( const Registry &registry, const std::string &validator_id ) const;
         void                     InitializeCache();
+        void                     PersistLocalState( const std::string &cid );
 
         std::shared_ptr<crdt::GlobalDB> db_;
         uint64_t                        quorum_numerator_;
@@ -100,7 +109,7 @@ namespace sgns::blockchain
         mutable std::shared_mutex       cache_mutex_;
         std::optional<Registry>         cached_registry_;
         std::optional<RegistryUpdate>   cached_update_;
-        std::string                     cached_registry_hash_;
+        std::string                     cached_registry_id_;
         bool                            cache_initialized_ = false;
     };
 

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -31,41 +31,43 @@ namespace sgns::blockchain
     {
     public:
         using ValidatorEntry = validator::ValidatorEntry;
-        using Registry = validator::Registry;
+        using Registry       = validator::Registry;
         using SignatureEntry = validator::SignatureEntry;
         using RegistryUpdate = validator::RegistryUpdate;
-        using Role = validator::Role;
-        using Status = validator::Status;
-        using InitCallback = std::function<void( bool )>;
+        using Role           = validator::Role;
+        using Status         = validator::Status;
+        using InitCallback   = std::function<void( bool )>;
+        using BlockRequestMethod =
+            std::function<void( const std::string &, std::function<void( outcome::result<std::string> )> )>;
 
         struct WeightConfig
         {
-            uint64_t base_weight_       = 1;
-            uint64_t full_multiplier_   = 3;
+            uint64_t base_weight_        = 1;
+            uint64_t full_multiplier_    = 3;
             uint64_t genesis_multiplier_ = 5;
             uint64_t sharded_multiplier_ = 1;
-            uint64_t max_weight_        = 10;
+            uint64_t max_weight_         = 10;
         };
 
         static std::shared_ptr<ValidatorRegistry> New( std::shared_ptr<crdt::GlobalDB> db,
-                                                       uint64_t                        quorum_numerator = 2,
+                                                       uint64_t                        quorum_numerator   = 2,
                                                        uint64_t                        quorum_denominator = 3,
-                                                       WeightConfig                    weight_config = {},
-                                                       std::string                     genesis_authority = {},
-                                                       InitCallback                    init_callback = {} );
+                                                       WeightConfig                    weight_config      = {},
+                                                       std::string                     genesis_authority,
+                                                       InitCallback                    init_callback = nullptr,
+                                                       BlockRequestMethod              block_request_method );
 
         uint64_t ComputeWeight( Role role ) const;
         uint64_t TotalWeight( const Registry &registry ) const;
         uint64_t QuorumThreshold( uint64_t total_weight ) const;
         bool     IsQuorum( uint64_t accumulated_weight, uint64_t total_weight ) const;
 
-        Registry CreateGenesisRegistry( const std::string &genesis_validator_id ) const;
-        outcome::result<void> StoreGenesisRegistry( const std::string &genesis_validator_id,
-                                                    std::function<std::vector<uint8_t>( std::vector<uint8_t> )>
-                                                        sign );
-        outcome::result<Registry> LoadRegistry() const;
+        Registry                        CreateGenesisRegistry( const std::string &genesis_validator_id ) const;
+        outcome::result<void>           StoreGenesisRegistry( const std::string &genesis_validator_id,
+                                                              std::function<std::vector<uint8_t>( std::vector<uint8_t> )> sign );
+        outcome::result<Registry>       LoadRegistry() const;
         outcome::result<RegistryUpdate> LoadRegistryUpdate() const;
-        bool RegisterFilter();
+        bool                            RegisterFilter();
 
         outcome::result<std::vector<uint8_t>> SerializeRegistry( const Registry &registry ) const;
         outcome::result<Registry>             DeserializeRegistry( const std::vector<uint8_t> &buffer ) const;
@@ -73,8 +75,9 @@ namespace sgns::blockchain
         outcome::result<RegistryUpdate>       DeserializeRegistryUpdate( const std::vector<uint8_t> &buffer ) const;
 
         void SetRequestBlockByCidMethod(
-            std::function<void( const std::string &cid,
-                                std::function<void( outcome::result<std::string> )> callback )> method );
+            std::function<void( const std::string &cid, std::function<void( outcome::result<std::string> )> callback )>
+                method );
+
         static constexpr std::string_view RegistryKey()
         {
             return "gnus-validator-registry";
@@ -95,20 +98,20 @@ namespace sgns::blockchain
                            uint64_t                        quorum_numerator,
                            uint64_t                        quorum_denominator,
                            WeightConfig                    weight_config,
-                           std::string                     genesis_authority );
+                           std::string                     genesis_authority,
+                           InitCallback                    init_callback,
+                           BlockRequestMethod              block_request_method );
 
         std::optional<std::vector<crdt::pb::Element>> FilterRegistryUpdate( const crdt::pb::Element &element );
-        void                                          RegistryUpdateReceived( crdt::CRDTCallbackManager::NewDataPair new_data,
-                                                                              const std::string                     &cid );
-        outcome::result<std::vector<uint8_t>>         ComputeUpdateSigningBytes( const RegistryUpdate &update ) const;
-        std::string                                   ComputeRegistryHash( const Registry &registry ) const;
-        bool                                          VerifyUpdate( const RegistryUpdate &update,
-                                                                      const Registry *current_registry ) const;
+        void RegistryUpdateReceived( crdt::CRDTCallbackManager::NewDataPair new_data, const std::string &cid );
+        outcome::result<std::vector<uint8_t>> ComputeUpdateSigningBytes( const RegistryUpdate &update ) const;
+        std::string                           ComputeRegistryHash( const Registry &registry ) const;
+        bool                  VerifyUpdate( const RegistryUpdate &update, const Registry *current_registry ) const;
         const ValidatorEntry *FindValidator( const Registry &registry, const std::string &validator_id ) const;
-        void                     InitializeCache( InitCallback init_callback );
-        void                     NotifyInitialized( bool success );
-        void                     PersistLocalState( const std::string &cid );
-        void                     RequestHeadCids( const std::set<CID> &cids );
+        void                  InitializeCache();
+        void                  NotifyInitialized( bool success );
+        void                  PersistLocalState( const std::string &cid );
+        void                  RequestHeadCids( const std::set<CID> &cids );
 
         std::shared_ptr<crdt::GlobalDB> db_;
         uint64_t                        quorum_numerator_;
@@ -121,12 +124,10 @@ namespace sgns::blockchain
         std::optional<RegistryUpdate>   cached_update_;
         std::string                     cached_registry_id_;
         bool                            cache_initialized_ = false;
-        std::mutex                      init_mutex_;
-        InitCallback                    init_callback_;
-        std::optional<bool>             init_state_;
-        std::set<CID>                   pending_head_requests_;
-        std::function<void( const std::string &cid,
-                             std::function<void( outcome::result<std::string> )> callback )> request_block_by_cid_;
+
+        InitCallback init_callback_;
+        std::function<void( const std::string &cid, std::function<void( outcome::result<std::string> )> callback )>
+            request_block_by_cid_;
     };
 
 }

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -8,66 +8,29 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
-#include <gsl/span>
-
 #include "base/buffer.hpp"
 #include "base/logger.hpp"
+#include "blockchain/impl/proto/ValidatorRegistry.pb.h"
 #include "crdt/proto/delta.pb.h"
 #include "outcome/outcome.hpp"
 #include "crdt/globaldb/globaldb.hpp"
-#include "scale/scale_decoder_stream.hpp"
-#include "scale/scale_encoder_stream.hpp"
 
 namespace sgns::blockchain
 {
     class ValidatorRegistry : public std::enable_shared_from_this<ValidatorRegistry>
     {
     public:
-        enum class Role : uint8_t
-        {
-            Genesis = 0,
-            Full    = 1,
-            Regular = 2,
-            Sharded = 3
-        };
-
-        enum class Status : uint8_t
-        {
-            Active      = 0,
-            Suspended   = 1,
-            Blacklisted = 2
-        };
-
-        struct ValidatorEntry
-        {
-            std::string validator_id_;
-            uint64_t    weight_ = 0;
-            Role        role_   = Role::Regular;
-            Status      status_ = Status::Active;
-        };
-
-        struct Registry
-        {
-            uint64_t                  epoch_ = 0;
-            std::vector<ValidatorEntry> validators_;
-        };
-
-        struct SignatureEntry
-        {
-            std::string validator_id_;
-            std::string signature_;
-        };
-
-        struct RegistryUpdate
-        {
-            Registry                  registry_;
-            std::string               prev_registry_hash_;
-            std::vector<SignatureEntry> signatures_;
-        };
+        using ValidatorEntry = validator::ValidatorEntry;
+        using Registry = validator::Registry;
+        using SignatureEntry = validator::SignatureEntry;
+        using RegistryUpdate = validator::RegistryUpdate;
+        using Role = validator::Role;
+        using Status = validator::Status;
 
         struct WeightConfig
         {
@@ -78,11 +41,11 @@ namespace sgns::blockchain
             uint64_t max_weight_        = 10;
         };
 
-        ValidatorRegistry( std::shared_ptr<crdt::GlobalDB> db,
-                           uint64_t                        quorum_numerator = 2,
-                           uint64_t                        quorum_denominator = 3,
-                           WeightConfig                    weight_config = {},
-                           std::string                     genesis_authority = {} );
+        static std::shared_ptr<ValidatorRegistry> New( std::shared_ptr<crdt::GlobalDB> db,
+                                                       uint64_t                        quorum_numerator = 2,
+                                                       uint64_t                        quorum_denominator = 3,
+                                                       WeightConfig                    weight_config = {},
+                                                       std::string                     genesis_authority = {} );
 
         uint64_t ComputeWeight( Role role ) const;
         uint64_t TotalWeight( const Registry &registry ) const;
@@ -97,10 +60,10 @@ namespace sgns::blockchain
         outcome::result<RegistryUpdate> LoadRegistryUpdate() const;
         bool RegisterFilter();
 
-        outcome::result<base::Buffer> SerializeRegistry( const Registry &registry ) const;
-        outcome::result<Registry>     DeserializeRegistry( const base::Buffer &buffer ) const;
-        outcome::result<base::Buffer> SerializeRegistryUpdate( const RegistryUpdate &update ) const;
-        outcome::result<RegistryUpdate> DeserializeRegistryUpdate( const base::Buffer &buffer ) const;
+        outcome::result<std::vector<uint8_t>> SerializeRegistry( const Registry &registry ) const;
+        outcome::result<Registry>             DeserializeRegistry( const std::vector<uint8_t> &buffer ) const;
+        outcome::result<std::vector<uint8_t>> SerializeRegistryUpdate( const RegistryUpdate &update ) const;
+        outcome::result<RegistryUpdate>       DeserializeRegistryUpdate( const std::vector<uint8_t> &buffer ) const;
 
         static constexpr std::string_view RegistryKey()
         {
@@ -113,6 +76,12 @@ namespace sgns::blockchain
         }
 
     private:
+        ValidatorRegistry( std::shared_ptr<crdt::GlobalDB> db,
+                           uint64_t                        quorum_numerator,
+                           uint64_t                        quorum_denominator,
+                           WeightConfig                    weight_config,
+                           std::string                     genesis_authority );
+
         std::optional<std::vector<crdt::pb::Element>> FilterRegistryUpdate( const crdt::pb::Element &element );
         outcome::result<std::vector<uint8_t>>         ComputeUpdateSigningBytes( const RegistryUpdate &update ) const;
         std::string                                   ComputeRegistryHash( const Registry &registry ) const;
@@ -128,57 +97,4 @@ namespace sgns::blockchain
         base::Logger                    logger_ = base::createLogger( "ValidatorRegistry" );
     };
 
-    template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
-    Stream &operator<<( Stream &s, const ValidatorRegistry::SignatureEntry &entry )
-    {
-        return s << entry.validator_id_ << entry.signature_;
-    }
-
-    template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
-    Stream &operator>>( Stream &s, ValidatorRegistry::SignatureEntry &entry )
-    {
-        return s >> entry.validator_id_ >> entry.signature_;
-    }
-
-    template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
-    Stream &operator<<( Stream &s, const ValidatorRegistry::ValidatorEntry &entry )
-    {
-        return s << entry.validator_id_ << entry.weight_ << static_cast<uint8_t>( entry.role_ )
-                 << static_cast<uint8_t>( entry.status_ );
-    }
-
-    template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
-    Stream &operator>>( Stream &s, ValidatorRegistry::ValidatorEntry &entry )
-    {
-        uint8_t role = 0;
-        uint8_t status = 0;
-        s >> entry.validator_id_ >> entry.weight_ >> role >> status;
-        entry.role_   = static_cast<ValidatorRegistry::Role>( role );
-        entry.status_ = static_cast<ValidatorRegistry::Status>( status );
-        return s;
-    }
-
-    template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
-    Stream &operator<<( Stream &s, const ValidatorRegistry::Registry &registry )
-    {
-        return s << registry.epoch_ << registry.validators_;
-    }
-
-    template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
-    Stream &operator>>( Stream &s, ValidatorRegistry::Registry &registry )
-    {
-        return s >> registry.epoch_ >> registry.validators_;
-    }
-
-    template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
-    Stream &operator<<( Stream &s, const ValidatorRegistry::RegistryUpdate &update )
-    {
-        return s << update.registry_ << update.prev_registry_hash_ << update.signatures_;
-    }
-
-    template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
-    Stream &operator>>( Stream &s, ValidatorRegistry::RegistryUpdate &update )
-    {
-        return s >> update.registry_ >> update.prev_registry_hash_ >> update.signatures_;
-    }
 }

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -1,0 +1,184 @@
+/**
+ * @file       ValidatorRegistry.hpp
+ * @brief      Validator registry and quorum logic for governance.
+ * @date       2025-10-16
+ * @author     Henrique A. Klein (hklein@gnus.ai)
+ */
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gsl/span>
+
+#include "base/buffer.hpp"
+#include "base/logger.hpp"
+#include "crdt/proto/delta.pb.h"
+#include "outcome/outcome.hpp"
+#include "crdt/globaldb/globaldb.hpp"
+#include "scale/scale_decoder_stream.hpp"
+#include "scale/scale_encoder_stream.hpp"
+
+namespace sgns::blockchain
+{
+    class ValidatorRegistry : public std::enable_shared_from_this<ValidatorRegistry>
+    {
+    public:
+        enum class Role : uint8_t
+        {
+            Genesis = 0,
+            Full    = 1,
+            Regular = 2,
+            Sharded = 3
+        };
+
+        enum class Status : uint8_t
+        {
+            Active      = 0,
+            Suspended   = 1,
+            Blacklisted = 2
+        };
+
+        struct ValidatorEntry
+        {
+            std::string validator_id_;
+            uint64_t    weight_ = 0;
+            Role        role_   = Role::Regular;
+            Status      status_ = Status::Active;
+        };
+
+        struct Registry
+        {
+            uint64_t                  epoch_ = 0;
+            std::vector<ValidatorEntry> validators_;
+        };
+
+        struct SignatureEntry
+        {
+            std::string validator_id_;
+            std::string signature_;
+        };
+
+        struct RegistryUpdate
+        {
+            Registry                  registry_;
+            std::string               prev_registry_hash_;
+            std::vector<SignatureEntry> signatures_;
+        };
+
+        struct WeightConfig
+        {
+            uint64_t base_weight_       = 1;
+            uint64_t full_multiplier_   = 3;
+            uint64_t genesis_multiplier_ = 5;
+            uint64_t sharded_multiplier_ = 1;
+            uint64_t max_weight_        = 10;
+        };
+
+        ValidatorRegistry( std::shared_ptr<crdt::GlobalDB> db,
+                           uint64_t                        quorum_numerator = 2,
+                           uint64_t                        quorum_denominator = 3,
+                           WeightConfig                    weight_config = {},
+                           std::string                     genesis_authority = {} );
+
+        uint64_t ComputeWeight( Role role ) const;
+        uint64_t TotalWeight( const Registry &registry ) const;
+        uint64_t QuorumThreshold( uint64_t total_weight ) const;
+        bool     IsQuorum( uint64_t accumulated_weight, uint64_t total_weight ) const;
+
+        Registry CreateGenesisRegistry( const std::string &genesis_validator_id ) const;
+        outcome::result<void> StoreGenesisRegistry( const std::string &genesis_validator_id,
+                                                    std::function<std::vector<uint8_t>( std::vector<uint8_t> )>
+                                                        sign );
+        outcome::result<Registry> LoadRegistry() const;
+        outcome::result<RegistryUpdate> LoadRegistryUpdate() const;
+        bool RegisterFilter();
+
+        outcome::result<base::Buffer> SerializeRegistry( const Registry &registry ) const;
+        outcome::result<Registry>     DeserializeRegistry( const base::Buffer &buffer ) const;
+        outcome::result<base::Buffer> SerializeRegistryUpdate( const RegistryUpdate &update ) const;
+        outcome::result<RegistryUpdate> DeserializeRegistryUpdate( const base::Buffer &buffer ) const;
+
+        static constexpr std::string_view RegistryKey()
+        {
+            return "gnus-validator-registry";
+        }
+
+        static constexpr std::string_view ValidatorTopic()
+        {
+            return "gnus-validator-registry";
+        }
+
+    private:
+        std::optional<std::vector<crdt::pb::Element>> FilterRegistryUpdate( const crdt::pb::Element &element );
+        outcome::result<std::vector<uint8_t>>         ComputeUpdateSigningBytes( const RegistryUpdate &update ) const;
+        std::string                                   ComputeRegistryHash( const Registry &registry ) const;
+        bool                                          VerifyUpdate( const RegistryUpdate &update,
+                                                                      const Registry *current_registry ) const;
+        const ValidatorEntry *FindValidator( const Registry &registry, const std::string &validator_id ) const;
+
+        std::shared_ptr<crdt::GlobalDB> db_;
+        uint64_t                        quorum_numerator_;
+        uint64_t                        quorum_denominator_;
+        WeightConfig                    weight_config_;
+        std::string                     genesis_authority_;
+        base::Logger                    logger_ = base::createLogger( "ValidatorRegistry" );
+    };
+
+    template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
+    Stream &operator<<( Stream &s, const ValidatorRegistry::SignatureEntry &entry )
+    {
+        return s << entry.validator_id_ << entry.signature_;
+    }
+
+    template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
+    Stream &operator>>( Stream &s, ValidatorRegistry::SignatureEntry &entry )
+    {
+        return s >> entry.validator_id_ >> entry.signature_;
+    }
+
+    template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
+    Stream &operator<<( Stream &s, const ValidatorRegistry::ValidatorEntry &entry )
+    {
+        return s << entry.validator_id_ << entry.weight_ << static_cast<uint8_t>( entry.role_ )
+                 << static_cast<uint8_t>( entry.status_ );
+    }
+
+    template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
+    Stream &operator>>( Stream &s, ValidatorRegistry::ValidatorEntry &entry )
+    {
+        uint8_t role = 0;
+        uint8_t status = 0;
+        s >> entry.validator_id_ >> entry.weight_ >> role >> status;
+        entry.role_   = static_cast<ValidatorRegistry::Role>( role );
+        entry.status_ = static_cast<ValidatorRegistry::Status>( status );
+        return s;
+    }
+
+    template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
+    Stream &operator<<( Stream &s, const ValidatorRegistry::Registry &registry )
+    {
+        return s << registry.epoch_ << registry.validators_;
+    }
+
+    template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
+    Stream &operator>>( Stream &s, ValidatorRegistry::Registry &registry )
+    {
+        return s >> registry.epoch_ >> registry.validators_;
+    }
+
+    template <class Stream, typename = std::enable_if_t<Stream::is_encoder_stream>>
+    Stream &operator<<( Stream &s, const ValidatorRegistry::RegistryUpdate &update )
+    {
+        return s << update.registry_ << update.prev_registry_hash_ << update.signatures_;
+    }
+
+    template <class Stream, typename = std::enable_if_t<Stream::is_decoder_stream>>
+    Stream &operator>>( Stream &s, ValidatorRegistry::RegistryUpdate &update )
+    {
+        return s >> update.registry_ >> update.prev_registry_hash_ >> update.signatures_;
+    }
+}

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <set>
@@ -35,6 +36,7 @@ namespace sgns::blockchain
         using RegistryUpdate = validator::RegistryUpdate;
         using Role = validator::Role;
         using Status = validator::Status;
+        using InitCallback = std::function<void( bool )>;
 
         struct WeightConfig
         {
@@ -49,7 +51,8 @@ namespace sgns::blockchain
                                                        uint64_t                        quorum_numerator = 2,
                                                        uint64_t                        quorum_denominator = 3,
                                                        WeightConfig                    weight_config = {},
-                                                       std::string                     genesis_authority = {} );
+                                                       std::string                     genesis_authority = {},
+                                                       InitCallback                    init_callback = {} );
 
         uint64_t ComputeWeight( Role role ) const;
         uint64_t TotalWeight( const Registry &registry ) const;
@@ -102,7 +105,8 @@ namespace sgns::blockchain
         bool                                          VerifyUpdate( const RegistryUpdate &update,
                                                                       const Registry *current_registry ) const;
         const ValidatorEntry *FindValidator( const Registry &registry, const std::string &validator_id ) const;
-        void                     InitializeCache();
+        void                     InitializeCache( InitCallback init_callback );
+        void                     NotifyInitialized( bool success );
         void                     PersistLocalState( const std::string &cid );
         void                     RequestHeadCids( const std::set<CID> &cids );
 
@@ -117,6 +121,10 @@ namespace sgns::blockchain
         std::optional<RegistryUpdate>   cached_update_;
         std::string                     cached_registry_id_;
         bool                            cache_initialized_ = false;
+        std::mutex                      init_mutex_;
+        InitCallback                    init_callback_;
+        std::optional<bool>             init_state_;
+        std::set<CID>                   pending_head_requests_;
         std::function<void( const std::string &cid,
                              std::function<void( outcome::result<std::string> )> callback )> request_block_by_cid_;
     };

--- a/src/blockchain/impl/Blockchain.cpp
+++ b/src/blockchain/impl/Blockchain.cpp
@@ -6,6 +6,7 @@
  */
 #include <chrono>
 #include "blockchain/Blockchain.hpp"
+#include "blockchain/ValidatorRegistry.hpp"
 #include <primitives/cid/cid.hpp>
 
 OUTCOME_CPP_DEFINE_CATEGORY_3( sgns, Blockchain::Error, err )
@@ -33,6 +34,8 @@ OUTCOME_CPP_DEFINE_CATEGORY_3( sgns, Blockchain::Error, err )
             return "Failed to serialize/deserialize account creation block";
         case Error::ACCOUNT_CREATION_BLOCK_INVALID_GENESIS_LINK:
             return "Account creation block not properly linked to genesis";
+        case Error::VALIDATOR_REGISTRY_CREATION_FAILED:
+            return "Couldn't create validator registry";
     }
     return "Unknown error";
 }
@@ -79,8 +82,30 @@ namespace sgns
                 }
                 return std::nullopt;
             } );
-        (void)genesis_filter_initialized;
-        (void)account_creation_filter_initialized;
+
+        instance->validator_registry_ = std::make_shared<blockchain::ValidatorRegistry>(
+            instance->db_,
+            2,
+            3,
+            blockchain::ValidatorRegistry::WeightConfig{},
+            GetAuthorizedFullNodeAddress() );
+        const bool validator_filter_initialized = instance->validator_registry_->RegisterFilter();
+
+        if ( !genesis_filter_initialized )
+        {
+            instance->logger_->error( "[{}] Failed to initialize genesis filter",
+                                      instance->account_->GetAddress().substr( 0, 8 ) );
+        }
+        if ( !account_creation_filter_initialized )
+        {
+            instance->logger_->error( "[{}] Failed to initialize account creation filter",
+                                      instance->account_->GetAddress().substr( 0, 8 ) );
+        }
+        if ( !validator_filter_initialized )
+        {
+            instance->logger_->error( "[{}] Failed to initialize validator registry filter",
+                                      instance->account_->GetAddress().substr( 0, 8 ) );
+        }
 
         (void)instance->db_->RegisterNewElementCallback(
             "/?" + std::string( GENESIS_KEY ),
@@ -195,6 +220,7 @@ namespace sgns
                            account_->GetAddress().substr( 0, 8 ) );
             OUTCOME_TRY( OnGenesisBlockReceived( get_genesis_result.value() ) );
             OUTCOME_TRY( InitGenesisCID() );
+            OUTCOME_TRY( EnsureValidatorRegistry() );
             OUTCOME_TRY( OnAccountCreationBlockReceived( get_account_creation_result.value() ) );
             OUTCOME_TRY( InitAccountCreationCID( account_->GetAddress() ) );
 
@@ -261,6 +287,7 @@ namespace sgns
                 logger_->info( "[{}] Genesis block found locally, verifying", account_->GetAddress().substr( 0, 8 ) );
                 OUTCOME_TRY( OnGenesisBlockReceived( get_genesis_result.value() ) );
                 OUTCOME_TRY( InitGenesisCID() );
+                OUTCOME_TRY( EnsureValidatorRegistry() );
 
                 logger_->info( "[{}] Genesis block verification completed successfully",
                                account_->GetAddress().substr( 0, 8 ) );
@@ -335,6 +362,37 @@ namespace sgns
             return outcome::success();
         }
         return outcome::failure( std::errc::no_such_file_or_directory );
+    }
+
+    outcome::result<void> Blockchain::EnsureValidatorRegistry()
+    {
+        if ( account_->GetAddress() != GetAuthorizedFullNodeAddress() )
+        {
+            return outcome::success();
+        }
+
+        if ( !validator_registry_ )
+        {
+            validator_registry_ = std::make_shared<blockchain::ValidatorRegistry>(
+                db_,
+                2,
+                3,
+                blockchain::ValidatorRegistry::WeightConfig{},
+                GetAuthorizedFullNodeAddress() );
+            (void)validator_registry_->RegisterFilter();
+        }
+
+        auto registry_result = validator_registry_->StoreGenesisRegistry(
+            GetAuthorizedFullNodeAddress(),
+            [this]( std::vector<uint8_t> data ) { return account_->Sign( std::move( data ) ); } );
+        if ( registry_result.has_error() )
+        {
+            logger_->error( "[{}] Failed to ensure validator registry",
+                            account_->GetAddress().substr( 0, 8 ) );
+            return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
+        }
+
+        return outcome::success();
     }
 
     outcome::result<void> Blockchain::InitAccountCreationCID( const std::string &address )
@@ -690,6 +748,28 @@ namespace sgns
 
             return outcome::failure( Error::GENESIS_BLOCK_CREATION_FAILED );
         }
+
+        if ( !validator_registry_ )
+        {
+            validator_registry_ = std::make_shared<blockchain::ValidatorRegistry>(
+                db_,
+                2,
+                3,
+                blockchain::ValidatorRegistry::WeightConfig{},
+                GetAuthorizedFullNodeAddress() );
+            (void)validator_registry_->RegisterFilter();
+        }
+
+        auto registry_result = validator_registry_->StoreGenesisRegistry(
+            GetAuthorizedFullNodeAddress(),
+            [this]( std::vector<uint8_t> data ) { return account_->Sign( std::move( data ) ); } );
+        if ( registry_result.has_error() )
+        {
+            logger_->error( "[{}] Failed to store validator registry in CRDT",
+                            account_->GetAddress().substr( 0, 8 ) );
+            return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
+        }
+        logger_->info( "[{}] Validator registry initialized", account_->GetAddress().substr( 0, 8 ) );
 
         logger_->info( "[{}] Genesis block created and stored successfully", account_->GetAddress().substr( 0, 8 ) );
         return outcome::success();

--- a/src/blockchain/impl/Blockchain.cpp
+++ b/src/blockchain/impl/Blockchain.cpp
@@ -91,6 +91,15 @@ namespace sgns
             3,
             blockchain::ValidatorRegistry::WeightConfig{},
             GetAuthorizedFullNodeAddress(),
+
+            [weak_ptr( std::weak_ptr<Blockchain>(
+                instance ) )]( const std::string &cid, std::function<void( outcome::result<std::string> )> callback )
+            {
+                if ( auto strong = weak_ptr.lock() )
+                {
+                    (void)strong->account_->RequestRegularBlock( 8000, cid, std::move( callback ) );
+                }
+            },
             [weak_ptr( std::weak_ptr<Blockchain>( instance ) )]( bool initialized )
             {
                 if ( auto strong = weak_ptr.lock() )
@@ -98,23 +107,17 @@ namespace sgns
                     strong->validator_registry_initialized_.store( initialized );
                     if ( !initialized )
                     {
-                        strong->logger_->warn( "[{}] Validator registry not initialized yet",
+                        strong->logger_->error( "[{}] Validator registry not initialized yet",
                                                strong->account_->GetAddress().substr( 0, 8 ) );
                     }
                 }
             } );
-        if ( instance->validator_registry_ )
+
+        if ( !instance->validator_registry_ )
         {
-            instance->validator_registry_->SetRequestBlockByCidMethod(
-                [weak_ptr( std::weak_ptr<Blockchain>( instance ) )](
-                    const std::string                                  &cid,
-                    std::function<void( outcome::result<std::string> )> callback )
-                {
-                    if ( auto strong = weak_ptr.lock() )
-                    {
-                        (void)strong->account_->RequestRegularBlock( 8000, cid, std::move( callback ) );
-                    }
-                } );
+            instance->logger_->error( "[{}] Failed to create validator registry",
+                                      instance->account_->GetAddress().substr( 0, 8 ) );
+            return nullptr;
         }
 
         if ( !genesis_filter_initialized )
@@ -408,20 +411,6 @@ namespace sgns
         if ( account_->GetAddress() != GetAuthorizedFullNodeAddress() )
         {
             return outcome::success();
-        }
-
-        if ( !validator_registry_ )
-        {
-            validator_registry_ = blockchain::ValidatorRegistry::New( db_,
-                                                                      2,
-                                                                      3,
-                                                                      blockchain::ValidatorRegistry::WeightConfig{},
-                                                                      GetAuthorizedFullNodeAddress() );
-        }
-        if ( !validator_registry_ )
-        {
-            logger_->error( "[{}] Validator registry not initialized", account_->GetAddress().substr( 0, 8 ) );
-            return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
         }
 
         auto registry_result = validator_registry_->StoreGenesisRegistry(
@@ -788,21 +777,6 @@ namespace sgns
                                { std::string( BLOCKCHAIN_TOPIC ) } );
 
             return outcome::failure( Error::GENESIS_BLOCK_CREATION_FAILED );
-        }
-
-        if ( !validator_registry_ )
-        {
-            validator_registry_ = blockchain::ValidatorRegistry::New( db_,
-                                                                      2,
-                                                                      3,
-                                                                      blockchain::ValidatorRegistry::WeightConfig{},
-                                                                      GetAuthorizedFullNodeAddress() );
-        }
-
-        if ( !validator_registry_ )
-        {
-            logger_->error( "[{}] Validator registry not initialized", account_->GetAddress().substr( 0, 8 ) );
-            return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
         }
 
         auto registry_result = validator_registry_->StoreGenesisRegistry(

--- a/src/blockchain/impl/Blockchain.cpp
+++ b/src/blockchain/impl/Blockchain.cpp
@@ -89,6 +89,19 @@ namespace sgns
             3,
             blockchain::ValidatorRegistry::WeightConfig{},
             GetAuthorizedFullNodeAddress() );
+        if ( instance->validator_registry_ )
+        {
+            instance->validator_registry_->SetRequestBlockByCidMethod(
+                [weak_ptr( std::weak_ptr<Blockchain>( instance ) )](
+                    const std::string &cid,
+                    std::function<void( outcome::result<std::string> )> callback )
+                {
+                    if ( auto strong = weak_ptr.lock() )
+                    {
+                        (void)strong->account_->RequestRegularBlock( 8000, cid, std::move( callback ) );
+                    }
+                } );
+        }
         const bool validator_filter_initialized =
             instance->validator_registry_ ? instance->validator_registry_->RegisterFilter() : false;
 

--- a/src/blockchain/impl/Blockchain.cpp
+++ b/src/blockchain/impl/Blockchain.cpp
@@ -120,6 +120,13 @@ namespace sgns
             return nullptr;
         }
 
+        auto ensure_registry_result = instance->EnsureValidatorRegistry();
+        if ( ensure_registry_result.has_error() )
+        {
+            instance->logger_->error( "[{}] Failed to ensure validator registry during init",
+                                      instance->account_->GetAddress().substr( 0, 8 ) );
+        }
+
         if ( !genesis_filter_initialized )
         {
             instance->logger_->error( "[{}] Failed to initialize genesis filter",

--- a/src/blockchain/impl/Blockchain.cpp
+++ b/src/blockchain/impl/Blockchain.cpp
@@ -107,7 +107,7 @@ namespace sgns
         {
             instance->validator_registry_->SetRequestBlockByCidMethod(
                 [weak_ptr( std::weak_ptr<Blockchain>( instance ) )](
-                    const std::string &cid,
+                    const std::string                                  &cid,
                     std::function<void( outcome::result<std::string> )> callback )
                 {
                     if ( auto strong = weak_ptr.lock() )
@@ -116,8 +116,6 @@ namespace sgns
                     }
                 } );
         }
-        const bool validator_filter_initialized =
-            instance->validator_registry_ ? instance->validator_registry_->RegisterFilter() : false;
 
         if ( !genesis_filter_initialized )
         {
@@ -127,11 +125,6 @@ namespace sgns
         if ( !account_creation_filter_initialized )
         {
             instance->logger_->error( "[{}] Failed to initialize account creation filter",
-                                      instance->account_->GetAddress().substr( 0, 8 ) );
-        }
-        if ( !validator_filter_initialized )
-        {
-            instance->logger_->error( "[{}] Failed to initialize validator registry filter",
                                       instance->account_->GetAddress().substr( 0, 8 ) );
         }
 
@@ -157,11 +150,10 @@ namespace sgns
                 }
             } );
 
-        instance->filters_registered_ =
-            genesis_filter_initialized && account_creation_filter_initialized && validator_filter_initialized;
+        instance->filters_registered_   = genesis_filter_initialized && account_creation_filter_initialized;
         instance->callbacks_registered_ = genesis_callback_registered && account_creation_callback_registered;
-        instance->created_successfully_ =
-            instance->filters_registered_ && instance->callbacks_registered_ && instance->validator_registry_;
+        instance->created_successfully_ = instance->filters_registered_ && instance->callbacks_registered_ &&
+                                          instance->validator_registry_;
         instance->account_->SetGetBlockChainCIDMethod(
             [weak_ptr( std::weak_ptr<Blockchain>(
                 instance ) )]( uint8_t block_index, const std::string &address ) -> outcome::result<std::string>
@@ -420,21 +412,15 @@ namespace sgns
 
         if ( !validator_registry_ )
         {
-            validator_registry_ = blockchain::ValidatorRegistry::New(
-                db_,
-                2,
-                3,
-                blockchain::ValidatorRegistry::WeightConfig{},
-                GetAuthorizedFullNodeAddress() );
-            if ( validator_registry_ )
-            {
-                (void)validator_registry_->RegisterFilter();
-            }
+            validator_registry_ = blockchain::ValidatorRegistry::New( db_,
+                                                                      2,
+                                                                      3,
+                                                                      blockchain::ValidatorRegistry::WeightConfig{},
+                                                                      GetAuthorizedFullNodeAddress() );
         }
         if ( !validator_registry_ )
         {
-            logger_->error( "[{}] Validator registry not initialized",
-                            account_->GetAddress().substr( 0, 8 ) );
+            logger_->error( "[{}] Validator registry not initialized", account_->GetAddress().substr( 0, 8 ) );
             return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
         }
 
@@ -443,8 +429,7 @@ namespace sgns
             [this]( std::vector<uint8_t> data ) { return account_->Sign( std::move( data ) ); } );
         if ( registry_result.has_error() )
         {
-            logger_->error( "[{}] Failed to ensure validator registry",
-                            account_->GetAddress().substr( 0, 8 ) );
+            logger_->error( "[{}] Failed to ensure validator registry", account_->GetAddress().substr( 0, 8 ) );
             return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
         }
 
@@ -807,22 +792,16 @@ namespace sgns
 
         if ( !validator_registry_ )
         {
-            validator_registry_ = blockchain::ValidatorRegistry::New(
-                db_,
-                2,
-                3,
-                blockchain::ValidatorRegistry::WeightConfig{},
-                GetAuthorizedFullNodeAddress() );
-            if ( validator_registry_ )
-            {
-                (void)validator_registry_->RegisterFilter();
-            }
+            validator_registry_ = blockchain::ValidatorRegistry::New( db_,
+                                                                      2,
+                                                                      3,
+                                                                      blockchain::ValidatorRegistry::WeightConfig{},
+                                                                      GetAuthorizedFullNodeAddress() );
         }
 
         if ( !validator_registry_ )
         {
-            logger_->error( "[{}] Validator registry not initialized",
-                            account_->GetAddress().substr( 0, 8 ) );
+            logger_->error( "[{}] Validator registry not initialized", account_->GetAddress().substr( 0, 8 ) );
             return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
         }
 
@@ -831,8 +810,7 @@ namespace sgns
             [this]( std::vector<uint8_t> data ) { return account_->Sign( std::move( data ) ); } );
         if ( registry_result.has_error() )
         {
-            logger_->error( "[{}] Failed to store validator registry in CRDT",
-                            account_->GetAddress().substr( 0, 8 ) );
+            logger_->error( "[{}] Failed to store validator registry in CRDT", account_->GetAddress().substr( 0, 8 ) );
             return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
         }
         logger_->info( "[{}] Validator registry initialized", account_->GetAddress().substr( 0, 8 ) );
@@ -1122,9 +1100,8 @@ namespace sgns
         do
         {
             sgns::blockchain::GenesisBlock new_genesis;
-            if ( !new_genesis.ParseFromArray(
-                     reinterpret_cast<const uint8_t *>( element.value().data() ),
-                     static_cast<int>( element.value().size() ) ) )
+            if ( !new_genesis.ParseFromArray( reinterpret_cast<const uint8_t *>( element.value().data() ),
+                                              static_cast<int>( element.value().size() ) ) )
             {
                 logger_->warn( "[{}] Failed to parse incoming genesis block, rejecting: {}",
                                account_->GetAddress().substr( 0, 8 ),
@@ -1157,9 +1134,8 @@ namespace sgns
             }
 
             sgns::blockchain::GenesisBlock existing_genesis;
-            if ( !existing_genesis.ParseFromArray(
-                     reinterpret_cast<const uint8_t *>( existing_serialized.data() ),
-                     static_cast<int>( existing_serialized.size() ) ) )
+            if ( !existing_genesis.ParseFromArray( reinterpret_cast<const uint8_t *>( existing_serialized.data() ),
+                                                   static_cast<int>( existing_serialized.size() ) ) )
             {
                 logger_->warn( "[{}] Stored genesis block is not parsable, accepting new candidate",
                                account_->GetAddress().substr( 0, 8 ) );
@@ -1199,17 +1175,15 @@ namespace sgns
         return std::nullopt;
     }
 
-    std::optional<std::vector<crdt::pb::Element>> Blockchain::FilterAccountCreation(
-        const crdt::pb::Element &element )
+    std::optional<std::vector<crdt::pb::Element>> Blockchain::FilterAccountCreation( const crdt::pb::Element &element )
     {
         bool reject = false;
 
         do
         {
             sgns::blockchain::AccountCreationBlock new_block;
-            if ( !new_block.ParseFromArray(
-                     reinterpret_cast<const uint8_t *>( element.value().data() ),
-                     static_cast<int>( element.value().size() ) ) )
+            if ( !new_block.ParseFromArray( reinterpret_cast<const uint8_t *>( element.value().data() ),
+                                            static_cast<int>( element.value().size() ) ) )
             {
                 logger_->warn( "[{}] Failed to parse incoming account creation block, rejecting: {}",
                                account_->GetAddress().substr( 0, 8 ),
@@ -1262,9 +1236,8 @@ namespace sgns
             }
 
             sgns::blockchain::AccountCreationBlock existing_block;
-            if ( !existing_block.ParseFromArray(
-                     reinterpret_cast<const uint8_t *>( existing_serialized.data() ),
-                     static_cast<int>( existing_serialized.size() ) ) )
+            if ( !existing_block.ParseFromArray( reinterpret_cast<const uint8_t *>( existing_serialized.data() ),
+                                                 static_cast<int>( existing_serialized.size() ) ) )
             {
                 logger_->warn( "[{}] Stored account creation block for {} is not parsable, accepting new candidate",
                                account_->GetAddress().substr( 0, 8 ),
@@ -1272,8 +1245,8 @@ namespace sgns
                 break;
             }
 
-            const bool existing_genesis_ok =
-                !genesis_known || existing_block.genesis_block_cid() == cids_.genesis_.value();
+            const bool existing_genesis_ok = !genesis_known ||
+                                             existing_block.genesis_block_cid() == cids_.genesis_.value();
             const bool existing_signature_ok = VerifySignature( existing_block );
 
             if ( !( existing_genesis_ok && existing_signature_ok ) )

--- a/src/blockchain/impl/Blockchain.cpp
+++ b/src/blockchain/impl/Blockchain.cpp
@@ -83,13 +83,14 @@ namespace sgns
                 return std::nullopt;
             } );
 
-        instance->validator_registry_ = std::make_shared<blockchain::ValidatorRegistry>(
+        instance->validator_registry_ = blockchain::ValidatorRegistry::New(
             instance->db_,
             2,
             3,
             blockchain::ValidatorRegistry::WeightConfig{},
             GetAuthorizedFullNodeAddress() );
-        const bool validator_filter_initialized = instance->validator_registry_->RegisterFilter();
+        const bool validator_filter_initialized =
+            instance->validator_registry_ ? instance->validator_registry_->RegisterFilter() : false;
 
         if ( !genesis_filter_initialized )
         {
@@ -373,13 +374,22 @@ namespace sgns
 
         if ( !validator_registry_ )
         {
-            validator_registry_ = std::make_shared<blockchain::ValidatorRegistry>(
+            validator_registry_ = blockchain::ValidatorRegistry::New(
                 db_,
                 2,
                 3,
                 blockchain::ValidatorRegistry::WeightConfig{},
                 GetAuthorizedFullNodeAddress() );
-            (void)validator_registry_->RegisterFilter();
+            if ( validator_registry_ )
+            {
+                (void)validator_registry_->RegisterFilter();
+            }
+        }
+        if ( !validator_registry_ )
+        {
+            logger_->error( "[{}] Validator registry not initialized",
+                            account_->GetAddress().substr( 0, 8 ) );
+            return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
         }
 
         auto registry_result = validator_registry_->StoreGenesisRegistry(
@@ -751,13 +761,23 @@ namespace sgns
 
         if ( !validator_registry_ )
         {
-            validator_registry_ = std::make_shared<blockchain::ValidatorRegistry>(
+            validator_registry_ = blockchain::ValidatorRegistry::New(
                 db_,
                 2,
                 3,
                 blockchain::ValidatorRegistry::WeightConfig{},
                 GetAuthorizedFullNodeAddress() );
-            (void)validator_registry_->RegisterFilter();
+            if ( validator_registry_ )
+            {
+                (void)validator_registry_->RegisterFilter();
+            }
+        }
+
+        if ( !validator_registry_ )
+        {
+            logger_->error( "[{}] Validator registry not initialized",
+                            account_->GetAddress().substr( 0, 8 ) );
+            return outcome::failure( Error::VALIDATOR_REGISTRY_CREATION_FAILED );
         }
 
         auto registry_result = validator_registry_->StoreGenesisRegistry(

--- a/src/blockchain/impl/Blockchain.cpp
+++ b/src/blockchain/impl/Blockchain.cpp
@@ -36,6 +36,8 @@ OUTCOME_CPP_DEFINE_CATEGORY_3( sgns, Blockchain::Error, err )
             return "Account creation block not properly linked to genesis";
         case Error::VALIDATOR_REGISTRY_CREATION_FAILED:
             return "Couldn't create validator registry";
+        case Error::BLOCKCHAIN_NOT_INITIALIZED:
+            return "Blockchain not fully initialized";
     }
     return "Unknown error";
 }
@@ -88,7 +90,19 @@ namespace sgns
             2,
             3,
             blockchain::ValidatorRegistry::WeightConfig{},
-            GetAuthorizedFullNodeAddress() );
+            GetAuthorizedFullNodeAddress(),
+            [weak_ptr( std::weak_ptr<Blockchain>( instance ) )]( bool initialized )
+            {
+                if ( auto strong = weak_ptr.lock() )
+                {
+                    strong->validator_registry_initialized_.store( initialized );
+                    if ( !initialized )
+                    {
+                        strong->logger_->warn( "[{}] Validator registry not initialized yet",
+                                               strong->account_->GetAddress().substr( 0, 8 ) );
+                    }
+                }
+            } );
         if ( instance->validator_registry_ )
         {
             instance->validator_registry_->SetRequestBlockByCidMethod(
@@ -121,7 +135,7 @@ namespace sgns
                                       instance->account_->GetAddress().substr( 0, 8 ) );
         }
 
-        (void)instance->db_->RegisterNewElementCallback(
+        const bool genesis_callback_registered = instance->db_->RegisterNewElementCallback(
             "/?" + std::string( GENESIS_KEY ),
             [weak_ptr( std::weak_ptr<Blockchain>( instance ) )]( crdt::CRDTCallbackManager::NewDataPair new_data,
                                                                  const std::string                     &cid )
@@ -132,7 +146,7 @@ namespace sgns
                 }
             } );
 
-        (void)instance->db_->RegisterNewElementCallback(
+        const bool account_creation_callback_registered = instance->db_->RegisterNewElementCallback(
             "/?" + std::string( ACCOUNT_CREATION_KEY_PREFIX ) + ".*",
             [weak_ptr( std::weak_ptr<Blockchain>( instance ) )]( crdt::CRDTCallbackManager::NewDataPair new_data,
                                                                  const std::string                     &cid )
@@ -142,6 +156,12 @@ namespace sgns
                     strong->AccountCreationReceivedCallback( std::move( new_data ), cid );
                 }
             } );
+
+        instance->filters_registered_ =
+            genesis_filter_initialized && account_creation_filter_initialized && validator_filter_initialized;
+        instance->callbacks_registered_ = genesis_callback_registered && account_creation_callback_registered;
+        instance->created_successfully_ =
+            instance->filters_registered_ && instance->callbacks_registered_ && instance->validator_registry_;
         instance->account_->SetGetBlockChainCIDMethod(
             [weak_ptr( std::weak_ptr<Blockchain>(
                 instance ) )]( uint8_t block_index, const std::string &address ) -> outcome::result<std::string>
@@ -212,6 +232,19 @@ namespace sgns
 
     outcome::result<void> Blockchain::Start()
     {
+        if ( !created_successfully_ || !filters_registered_ || !callbacks_registered_ ||
+             !validator_registry_initialized_.load() )
+        {
+            logger_->warn(
+                "[{}] Blockchain start deferred (created: {}, filters: {}, callbacks: {}, validator_registry: {})",
+                account_->GetAddress().substr( 0, 8 ),
+                created_successfully_,
+                filters_registered_,
+                callbacks_registered_,
+                validator_registry_initialized_.load() );
+            return InformBlockchainResult( outcome::failure( Error::BLOCKCHAIN_NOT_INITIALIZED ) );
+        }
+
         logger_->info( "[{}] Starting blockchain with authorized full node: {}",
                        account_->GetAddress().substr( 0, 8 ),
                        GetAuthorizedFullNodeAddress().substr( 0, 8 ) );

--- a/src/blockchain/impl/CMakeLists.txt
+++ b/src/blockchain/impl/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_proto_library(SGBlocksProto proto/SGBlocks.proto)
 add_proto_library(SGBlockchainProto proto/SGBlockchain.proto)
+add_proto_library(ValidatorRegistryProto proto/ValidatorRegistry.proto)
 
 add_library(blockchain_common
     types.cpp
@@ -38,6 +39,7 @@ target_link_libraries(blockchain_genesis
     sgns_genius_account
     PRIVATE
     SGBlockchainProto
+    ValidatorRegistryProto
 )
 
 supergenius_install(blockchain_genesis)

--- a/src/blockchain/impl/CMakeLists.txt
+++ b/src/blockchain/impl/CMakeLists.txt
@@ -23,6 +23,7 @@ supergenius_install(blockchain_common)
 
 add_library(blockchain_genesis
     Blockchain.cpp
+    ../ValidatorRegistry.cpp
 )
 
 target_link_libraries(blockchain_genesis
@@ -31,6 +32,9 @@ target_link_libraries(blockchain_genesis
     crdt_globaldb
     sgns_version
     buffer
+    hasher
+    hexutil
+    logger
     sgns_genius_account
     PRIVATE
     SGBlockchainProto

--- a/src/blockchain/impl/proto/ValidatorRegistry.proto
+++ b/src/blockchain/impl/proto/ValidatorRegistry.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package sgns.blockchain.validator;
+
+message ValidatorEntry {
+  string validator_id = 1;
+  uint64 weight = 2;
+  Role role = 3;
+  Status status = 4;
+}
+
+message Registry {
+  uint64 epoch = 1;
+  repeated ValidatorEntry validators = 2;
+}
+
+enum Role {
+  GENESIS = 0;
+  FULL = 1;
+  REGULAR = 2;
+  SHARDED = 3;
+}
+
+enum Status {
+  ACTIVE = 0;
+  SUSPENDED = 1;
+  BLACKLISTED = 2;
+}
+
+message SignatureEntry {
+  string validator_id = 1;
+  bytes signature = 2;
+}
+
+message RegistryUpdate {
+  Registry registry = 1;
+  string prev_registry_hash = 2;
+  repeated SignatureEntry signatures = 3;
+}
+
+message RegistrySigningPayload {
+  Registry registry = 1;
+  string prev_registry_hash = 2;
+}


### PR DESCRIPTION
This registry enables WQC for consensus.

### Feats
- Validator Registry with global scope.
- Genesis creator register itself as the genesis validator registry with 5 as its weight.
- Registry is only updated if the signatures of the new registry reaches the quorum of the current registry.
- Only Genesis registry created (before allowing blockchain to boot).
- No need for new version because if the registry is missing it's created by the genesis creator.
- Request CID content implemented. Broadcast message "who has this CID" to be able to graphsync to it.
