### PR TITLE
Dev fetch utxos

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -564,7 +564,7 @@ jobs:
 
       - name: Run tests (Linux)
         working-directory: ${{ github.workspace }}/SuperGenius/${{ env.BUILD_DIRECTORY }}
-        if: ${{ matrix.build-type == 'Release' && matrix.target == 'Linux' }}
+        if: ${{ matrix.target == 'Linux' }}
         shell: bash
         run: |
           dbus-run-session -- bash -c '\
@@ -575,4 +575,4 @@ jobs:
             lock-on-idle=false
             lock-after=false" > ~/.local/share/keyrings/login.keyring && \
             eval $(printf "\n" | gnome-keyring-daemon --unlock --components=secrets) && \
-            ctest . -j -C ${{ matrix.build-type }}'
+            ctest . --verbose -j -C ${{ matrix.build-type }}'

--- a/src/account/AccountMessenger.cpp
+++ b/src/account/AccountMessenger.cpp
@@ -9,6 +9,7 @@
 #include <boost/format.hpp>
 #include <future>
 #include <algorithm>
+#include <type_traits>
 #include "AccountMessenger.hpp"
 #include "base/sgns_version.hpp"
 #include "crypto/hasher/hasher_impl.hpp"
@@ -212,6 +213,9 @@ namespace sgns
                 case accountComm::AccountMessage::kBlockCidRequest:
                     HandleBlockCidRequest( acc_msg.block_cid_request() );
                     break;
+                case accountComm::AccountMessage::kTransactionRequest:
+                    HandleTransactionRequest( acc_msg.transaction_request() );
+                    break;
                 case accountComm::AccountMessage::kUtxoRequest:
                     HandleUTXORequest( acc_msg.utxo_request() );
                     break;
@@ -255,6 +259,9 @@ namespace sgns
                     break;
                 case accountComm::AccountMessage::kUtxoResponse:
                     HandleUTXOResponse( acc_msg.utxo_response() );
+                    break;
+                case accountComm::AccountMessage::kTransactionRequest:
+                    logger_->error( "{}: Unexpected response received ", __func__ );
                     break;
                 case accountComm::AccountMessage::kUtxoRequest:
                     logger_->error( "{}: Unexpected response received ", __func__ );
@@ -346,11 +353,28 @@ namespace sgns
         return outcome::success();
     }
 
-    outcome::result<std::set<std::string>> AccountMessenger::RequestUTXOs( uint64_t           timeout_ms,
-                                                                           const std::string &address,
-                                                                           uint64_t           silent_time_ms )
+    outcome::result<void> AccountMessenger::RequestTransaction(
+        uint64_t                                            timeout_ms,
+        std::string                                         tx_hash,
+        std::function<void( outcome::result<std::string> )> callback )
     {
-        auto promise = std::make_shared<std::promise<outcome::result<std::set<std::string>>>>();
+        EnqueueTask( { RequestType::Transaction,
+                       timeout_ms,
+                       150,
+                       0,
+                       std::move( tx_hash ),
+                       std::string{},
+                       std::move( callback ),
+                       nullptr,
+                       nullptr } );
+        return outcome::success();
+    }
+
+    outcome::result<std::unordered_set<std::string>> AccountMessenger::RequestUTXOs( uint64_t           timeout_ms,
+                                                                                     const std::string &address,
+                                                                                     uint64_t           silent_time_ms )
+    {
+        auto promise = std::make_shared<std::promise<outcome::result<std::unordered_set<std::string>>>>();
         auto future  = promise->get_future();
 
         EnqueueTask( { RequestType::UTXO,
@@ -424,6 +448,36 @@ namespace sgns
         return SendAccountMessage( envelope, { requests_topic_ } );
     }
 
+    outcome::result<void> AccountMessenger::RequestBlockByHash( uint64_t req_id, const std::string &tx_hash )
+    {
+        accountComm::TransactionRequest req;
+        req.set_requester_address( address_ );
+        req.set_request_id( req_id );
+        req.set_timestamp(
+            std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
+                .count() );
+        req.set_tx_hash( tx_hash );
+        logger_->debug( "[{}] Requesting transaction {} with req_id {}", address_.substr( 0, 8 ), tx_hash, req_id );
+
+        std::string encoded;
+        if ( !req.SerializeToString( &encoded ) )
+        {
+            return outcome::failure( Error::PROTO_SERIALIZATION );
+        }
+
+        std::vector<uint8_t> serialized_vec( encoded.begin(), encoded.end() );
+        OUTCOME_TRY( auto &&signature, methods_.sign_( serialized_vec ) );
+
+        accountComm::SignedTransactionRequest signed_req;
+        *signed_req.mutable_data() = req;
+        signed_req.set_signature( signature.data(), signature.size() );
+
+        accountComm::AccountMessage envelope;
+        *envelope.mutable_transaction_request() = signed_req;
+
+        return SendAccountMessage( envelope, { requests_topic_ } );
+    }
+
     outcome::result<void> AccountMessenger::RequestUTXO( uint64_t req_id, const std::string &address )
     {
         accountComm::UTXORequest req;
@@ -478,32 +532,151 @@ namespace sgns
             return;
         }
 
-        auto cid_result = methods_.get_block_cid_( static_cast<uint8_t>( req.block_index() ), req.requester_address() );
-        bool have_cid   = !cid_result.has_error();
+        HandleBlockLikeRequest( BlockIndexRequest{ static_cast<uint8_t>( req.block_index() ) },
+                                req.requester_address(),
+                                req.request_id() );
+    }
+
+    void AccountMessenger::HandleBlockCidRequest( const accountComm::SignedBlockCidRequest &signed_req )
+    {
+        const auto &req = signed_req.data();
+
+        logger_->debug( "[{}] Received a Block-by-CID request req_id {} cid {}",
+                        address_.substr( 0, 8 ),
+                        req.request_id(),
+                        req.cid() );
+
+        std::string serialized;
+        if ( !req.SerializeToString( &serialized ) )
+        {
+            logger_->error( "Failed to serialize BlockCidRequest for signature check" );
+            return;
+        }
+        std::vector<uint8_t> serialized_vec( serialized.begin(), serialized.end() );
+        auto                 verify_signature_result = methods_.verify_signature_( req.requester_address(),
+                                                                   signed_req.signature(),
+                                                                   serialized_vec );
+        if ( verify_signature_result.has_error() || !verify_signature_result.value() )
+        {
+            logger_->error( "Invalid signature on BlockCidRequest from {}", req.requester_address() );
+            return;
+        }
+
+        HandleBlockLikeRequest( BlockCidRequest{ req.cid() }, req.requester_address(), req.request_id() );
+    }
+
+    void AccountMessenger::HandleTransactionRequest( const accountComm::SignedTransactionRequest &signed_req )
+    {
+        const auto &req = signed_req.data();
+
+        logger_->debug( "[{}] Received a Transaction request req_id {} hash {}",
+                        address_.substr( 0, 8 ),
+                        req.request_id(),
+                        req.tx_hash() );
+
+        std::string serialized;
+        if ( !req.SerializeToString( &serialized ) )
+        {
+            logger_->error( "Failed to serialize TransactionRequest for signature check" );
+            return;
+        }
+        std::vector<uint8_t> serialized_vec( serialized.begin(), serialized.end() );
+        auto                 verify_signature_result = methods_.verify_signature_( req.requester_address(),
+                                                                   signed_req.signature(),
+                                                                   serialized_vec );
+        if ( verify_signature_result.has_error() || !verify_signature_result.value() )
+        {
+            logger_->error( "Invalid signature on TransactionRequest from {}", req.requester_address() );
+            return;
+        }
+
+        HandleBlockLikeRequest( TransactionHashRequest{ req.tx_hash() }, req.requester_address(), req.request_id() );
+    }
+
+    void AccountMessenger::HandleBlockLikeRequest( const BlockQuery  &query,
+                                                   const std::string &requester_address,
+                                                   uint64_t           request_id )
+    {
+        bool        have_cid = false;
+        std::string cid;
+        std::string label;
+        std::string target;
+
+        std::visit(
+            [&]( const auto &q )
+            {
+                using T = std::decay_t<decltype( q )>;
+                if constexpr ( std::is_same_v<T, BlockIndexRequest> )
+                {
+                    label           = "block";
+                    target          = std::to_string( q.block_index );
+                    auto cid_result = methods_.get_block_cid_( q.block_index, requester_address );
+                    have_cid        = !cid_result.has_error();
+                    if ( have_cid )
+                    {
+                        cid = cid_result.value();
+                    }
+                }
+                else if constexpr ( std::is_same_v<T, BlockCidRequest> )
+                {
+                    label  = "block CID";
+                    target = q.cid;
+                    if ( methods_.has_block_cid_ )
+                    {
+                        auto has_cid_result = methods_.has_block_cid_( q.cid );
+                        have_cid            = has_cid_result.has_value() && has_cid_result.value();
+                        if ( have_cid )
+                        {
+                            cid = q.cid;
+                        }
+                    }
+                    else
+                    {
+                        logger_->error( "No has_block_cid_ method configured" );
+                    }
+                }
+                else
+                {
+                    label  = "transaction";
+                    target = q.tx_hash;
+                    if ( methods_.get_transaction_cid_ )
+                    {
+                        auto tx_cid_result = methods_.get_transaction_cid_( q.tx_hash );
+                        have_cid           = tx_cid_result.has_value();
+                        if ( have_cid )
+                        {
+                            cid = tx_cid_result.value();
+                        }
+                    }
+                    else
+                    {
+                        logger_->error( "No get_transaction_cid_ method configured" );
+                    }
+                }
+            },
+            query );
 
         if ( !have_cid )
         {
-            logger_->debug( "[{}] I don't have the block index {}, will send empty BlockResponse",
+            logger_->debug( "[{}] I don't have {} {}, will send empty BlockResponse",
                             address_.substr( 0, 8 ),
-                            req.block_index() );
+                            label,
+                            target );
         }
 
         accountComm::BlockResponse resp;
         resp.set_responder_address( address_ );
-        resp.set_requester_address( req.requester_address() );
-        resp.set_request_id( req.request_id() );
+        resp.set_requester_address( requester_address );
+        resp.set_request_id( request_id );
         resp.set_timestamp(
             std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
                 .count() );
-        logger_->debug( "[{}] Preparing BlockResponse for req_id {} with requester address {}",
-                        address_.substr( 0, 8 ),
-                        req.request_id(),
-                        req.requester_address() );
+        logger_->debug( "[{}] Preparing BlockResponse for {} req_id {}", address_.substr( 0, 8 ), label, request_id );
 
         if ( have_cid )
         {
             auto *info = resp.add_blocks();
-            info->set_cid( cid_result.value() );
+            info->set_cid( cid );
 
             auto peer_info = pubsub_->GetHost()->getPeerInfo();
             info->set_peer_id( std::string( peer_info.id.toVector().begin(), peer_info.id.toVector().end() ) );
@@ -534,119 +707,6 @@ namespace sgns
         }
 
         std::vector<uint8_t> resp_bytes( resp_serialized.begin(), resp_serialized.end() );
-
-        auto signature_res = methods_.sign_( resp_bytes );
-        if ( signature_res.has_error() )
-        {
-            logger_->error( "Failed to sign BlockResponse" );
-            return;
-        }
-
-        accountComm::SignedBlockResponse signed_resp;
-        *signed_resp.mutable_data() = resp;
-        auto signature              = signature_res.value();
-        signed_resp.set_signature( signature.data(), signature.size() );
-
-        accountComm::AccountMessage msg;
-        *msg.mutable_block_response() = signed_resp;
-
-        auto account_topic = req.requester_address() + std::string( ACCOUNT_COMM ) +
-                             sgns::version::GetNetAndVersionAppendix();
-
-        auto send_ret = SendAccountMessage( msg, { account_topic } );
-        if ( send_ret.has_error() )
-        {
-            logger_->error( "[{}] Failed to send BlockResponse for req_id {}",
-                            address_.substr( 0, 8 ),
-                            req.request_id() );
-        }
-        else
-        {
-            logger_->debug( "[{}] Sent BlockResponse ({} block entries) to {} (req_id {})",
-                            address_.substr( 0, 8 ),
-                            resp.blocks_size(),
-                            req.requester_address().substr( 0, 8 ),
-                            req.request_id() );
-        }
-    }
-
-    void AccountMessenger::HandleBlockCidRequest( const accountComm::SignedBlockCidRequest &signed_req )
-    {
-        const auto &req = signed_req.data();
-
-        logger_->debug( "[{}] Received a Block-by-CID request req_id {} cid {}",
-                        address_.substr( 0, 8 ),
-                        req.request_id(),
-                        req.cid() );
-
-        std::string serialized;
-        if ( !req.SerializeToString( &serialized ) )
-        {
-            logger_->error( "Failed to serialize BlockCidRequest for signature check" );
-            return;
-        }
-        std::vector<uint8_t> serialized_vec( serialized.begin(), serialized.end() );
-        auto                 verify_signature_result = methods_.verify_signature_( req.requester_address(),
-                                                                   signed_req.signature(),
-                                                                   serialized_vec );
-        if ( verify_signature_result.has_error() || !verify_signature_result.value() )
-        {
-            logger_->error( "Invalid signature on BlockCidRequest from {}", req.requester_address() );
-            return;
-        }
-
-        bool have_cid = false;
-        if ( methods_.has_block_cid_ )
-        {
-            auto has_cid_result = methods_.has_block_cid_( req.cid() );
-            have_cid            = has_cid_result.has_value() && has_cid_result.value();
-        }
-        else
-        {
-            logger_->error( "No has_block_cid_ method configured" );
-        }
-
-        accountComm::BlockResponse resp;
-        resp.set_responder_address( address_ );
-        resp.set_requester_address( req.requester_address() );
-        resp.set_request_id( req.request_id() );
-        resp.set_timestamp(
-            std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
-                .count() );
-        logger_->debug( "[{}] Preparing BlockResponse for req_id {} with requester address {}",
-                        address_.substr( 0, 8 ),
-                        req.request_id(),
-                        req.requester_address() );
-
-        if ( have_cid )
-        {
-            auto *info = resp.add_blocks();
-            info->set_cid( req.cid() );
-
-            auto peer_info = pubsub_->GetHost()->getPeerInfo();
-            info->set_peer_id( std::string( peer_info.id.toVector().begin(), peer_info.id.toVector().end() ) );
-
-            auto pubsubObserved = pubsub_->GetHost()->getObservedAddressesReal();
-            for ( auto &addr : pubsubObserved )
-            {
-                info->add_addresses( addr.getStringAddress() );
-                logger_->debug( "Address Broadcast: {}", addr.getStringAddress() );
-            }
-            for ( auto &addr : peer_info.addresses )
-            {
-                info->add_addresses( addr.getStringAddress() );
-                logger_->debug( "Address Broadcast: {}", addr.getStringAddress() );
-            }
-        }
-
-        std::string resp_serialized;
-        if ( !resp.SerializeToString( &resp_serialized ) )
-        {
-            logger_->error( "Failed to serialize BlockResponse" );
-            return;
-        }
-
-        std::vector<uint8_t> resp_bytes( resp_serialized.begin(), resp_serialized.end() );
         auto                 signature_res = methods_.sign_( resp_bytes );
         if ( signature_res.has_error() )
         {
@@ -662,23 +722,21 @@ namespace sgns
         accountComm::AccountMessage msg;
         *msg.mutable_block_response() = signed_resp;
 
-        auto account_topic = req.requester_address() + std::string( ACCOUNT_COMM ) +
+        auto account_topic = requester_address + std::string( ACCOUNT_COMM ) +
                              sgns::version::GetNetAndVersionAppendix();
 
         auto send_ret = SendAccountMessage( msg, { account_topic } );
         if ( send_ret.has_error() )
         {
-            logger_->error( "[{}] Failed to send BlockResponse for req_id {}",
-                            address_.substr( 0, 8 ),
-                            req.request_id() );
+            logger_->error( "[{}] Failed to send BlockResponse for req_id {}", address_.substr( 0, 8 ), request_id );
         }
         else
         {
             logger_->debug( "[{}] Sent BlockResponse ({} block entries) to {} (req_id {})",
                             address_.substr( 0, 8 ),
                             resp.blocks_size(),
-                            req.requester_address().substr( 0, 8 ),
-                            req.request_id() );
+                            requester_address.substr( 0, 8 ),
+                            request_id );
         }
     }
 
@@ -837,35 +895,9 @@ namespace sgns
                     break;
                 }
                 case RequestType::Genesis:
-                {
-                    auto res = PerformBlockRequest( task.timeout_ms, task.block_index );
-                    if ( task.callback )
-                    {
-                        if ( res.has_error() )
-                        {
-                            task.callback( outcome::failure( res.error() ) );
-                        }
-                        else
-                        {
-                            const auto &cids = res.value();
-                            if ( cids.empty() )
-                            {
-                                task.callback( outcome::failure( boost::system::error_code{} ) );
-                            }
-                            else
-                            {
-                                for ( const auto &cid : cids )
-                                {
-                                    task.callback( outcome::success( cid ) );
-                                }
-                            }
-                        }
-                    }
-                    break;
-                }
                 case RequestType::AccountCreation:
                 {
-                    auto res = PerformBlockRequest( task.timeout_ms, task.block_index );
+                    auto res = PerformBlockRequest( task.timeout_ms, BlockIndexRequest{ task.block_index } );
                     if ( task.callback )
                     {
                         if ( res.has_error() )
@@ -892,7 +924,34 @@ namespace sgns
                 }
                 case RequestType::BlockByCid:
                 {
-                    auto res = PerformBlockCidRequest( task.timeout_ms, task.cid );
+                    auto res = PerformBlockRequest( task.timeout_ms, BlockCidRequest{ task.cid } );
+                    if ( task.callback )
+                    {
+                        if ( res.has_error() )
+                        {
+                            task.callback( outcome::failure( res.error() ) );
+                        }
+                        else
+                        {
+                            const auto &cids = res.value();
+                            if ( cids.empty() )
+                            {
+                                task.callback( outcome::failure( boost::system::error_code{} ) );
+                            }
+                            else
+                            {
+                                for ( const auto &cid : cids )
+                                {
+                                    task.callback( outcome::success( cid ) );
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+                case RequestType::Transaction:
+                {
+                    auto res = PerformBlockRequest( task.timeout_ms, TransactionHashRequest{ task.cid } );
                     if ( task.callback )
                     {
                         if ( res.has_error() )
@@ -1057,8 +1116,8 @@ namespace sgns
         return max_nonce;
     }
 
-    outcome::result<std::set<std::string>> AccountMessenger::PerformBlockRequest( uint64_t timeout_ms,
-                                                                                  uint8_t  block_index )
+    outcome::result<std::set<std::string>> AccountMessenger::PerformBlockRequest( uint64_t          timeout_ms,
+                                                                                  const BlockQuery &query )
     {
         std::mt19937_64 gen( rd_() );
         uint64_t        random_value = gen();
@@ -1071,9 +1130,41 @@ namespace sgns
         uint64_t req_id = 0;
         std::memcpy( &req_id, hash.data(), sizeof( req_id ) );
 
-        logger_->debug( "[{}] Requesting block {} with req_id {} and timeout {}",
+        std::string label;
+        std::string target;
+        auto        send_request = [&]( uint64_t id ) -> outcome::result<void>
+        {
+            return std::visit(
+                [&]( const auto &q ) -> outcome::result<void>
+                {
+                    using T = std::decay_t<decltype( q )>;
+                    if constexpr ( std::is_same_v<T, BlockIndexRequest> )
+                    {
+                        label  = "block";
+                        target = std::to_string( q.block_index );
+                        return RequestBlock( id, q.block_index );
+                    }
+                    else if constexpr ( std::is_same_v<T, BlockCidRequest> )
+                    {
+                        label  = "block CID";
+                        target = q.cid;
+                        return RequestBlockByCid( id, q.cid );
+                    }
+                    else
+                    {
+                        label  = "transaction";
+                        target = q.tx_hash;
+                        return RequestBlockByHash( id, q.tx_hash );
+                    }
+                },
+                query );
+        };
+
+        auto request_result = send_request( req_id );
+        logger_->debug( "[{}] Requesting {} {} with req_id {} and timeout {}",
                         address_.substr( 0, 8 ),
-                        block_index,
+                        label,
+                        target,
                         req_id,
                         timeout_ms );
 
@@ -1083,10 +1174,9 @@ namespace sgns
             block_first_response_time_.erase( req_id );
         }
 
-        auto request_result = RequestBlock( req_id, block_index );
         if ( request_result.has_error() )
         {
-            logger_->error( "[{}] Failed to request block {}", address_.substr( 0, 8 ), block_index );
+            logger_->error( "[{}] Failed to request {} {}", address_.substr( 0, 8 ), label, target );
             return request_result.error();
         }
 
@@ -1098,8 +1188,6 @@ namespace sgns
 
         while ( true )
         {
-            const auto now = std::chrono::steady_clock::now();
-
             {
                 std::lock_guard lock( block_responses_mutex_ );
                 auto            it = block_responses_.find( req_id );
@@ -1155,107 +1243,9 @@ namespace sgns
         return outcome::success( cids );
     }
 
-    outcome::result<std::set<std::string>> AccountMessenger::PerformBlockCidRequest( uint64_t           timeout_ms,
-                                                                                     const std::string &cid )
-    {
-        std::mt19937_64 gen( rd_() );
-        uint64_t        random_value = gen();
-
-        std::string              to_hash = address_ + std::to_string( random_value );
-        sgns::crypto::HasherImpl hasher;
-        auto                     hash = hasher.sha2_256(
-            gsl::span<const uint8_t>( reinterpret_cast<const uint8_t *>( to_hash.data() ), to_hash.size() ) );
-
-        uint64_t req_id = 0;
-        std::memcpy( &req_id, hash.data(), sizeof( req_id ) );
-
-        logger_->debug( "[{}] Requesting block CID {} with req_id {} and timeout {}",
-                        address_.substr( 0, 8 ),
-                        cid,
-                        req_id,
-                        timeout_ms );
-
-        {
-            std::lock_guard lock( block_responses_mutex_ );
-            block_responses_.erase( req_id );
-            block_first_response_time_.erase( req_id );
-        }
-
-        auto request_result = RequestBlockByCid( req_id, cid );
-        if ( request_result.has_error() )
-        {
-            logger_->error( "[{}] Failed to request block CID {}", address_.substr( 0, 8 ), cid );
-            return request_result.error();
-        }
-
-        const auto start_time   = std::chrono::steady_clock::now();
-        const auto full_timeout = std::chrono::milliseconds( timeout_ms );
-        const auto silent_time  = std::chrono::milliseconds( 150 );
-
-        bool first_seen = false;
-
-        while ( true )
-        {
-            const auto now = std::chrono::steady_clock::now();
-
-            {
-                std::lock_guard lock( block_responses_mutex_ );
-                auto            it = block_responses_.find( req_id );
-                if ( it != block_responses_.end() )
-                {
-                    if ( !first_seen )
-                    {
-                        first_seen                         = true;
-                        block_first_response_time_[req_id] = std::chrono::steady_clock::now();
-                    }
-                    else
-                    {
-                        auto elapsed = std::chrono::steady_clock::now() - block_first_response_time_[req_id];
-                        if ( elapsed >= silent_time )
-                        {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if ( std::chrono::steady_clock::now() - start_time >= full_timeout )
-            {
-                logger_->debug( "[{}] Timeout: no BlockResponse received for req_id {}",
-                                address_.substr( 0, 8 ),
-                                req_id );
-                return outcome::failure( Error::GENESIS_REQUEST_ERROR );
-            }
-
-            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
-        }
-
-        std::set<std::string> cids;
-        bool                  any_response = false;
-        {
-            std::lock_guard lock( block_responses_mutex_ );
-            auto            it = block_responses_.find( req_id );
-            if ( it != block_responses_.end() )
-            {
-                any_response = true;
-                cids         = it->second;
-            }
-            block_responses_.erase( req_id );
-            block_first_response_time_.erase( req_id );
-        }
-
-        if ( !any_response )
-        {
-            logger_->warn( "[{}] No responses recorded for req_id {}", address_.substr( 0, 8 ), req_id );
-            return outcome::failure( Error::GENESIS_REQUEST_ERROR );
-        }
-
-        return outcome::success( cids );
-    }
-
-    outcome::result<std::set<std::string>> AccountMessenger::PerformUTXORequest( uint64_t           timeout_ms,
-                                                                                 const std::string &address,
-                                                                                 uint64_t           silent_time_ms )
+    outcome::result<std::unordered_set<std::string>> AccountMessenger::PerformUTXORequest( uint64_t timeout_ms,
+                                                                                           const std::string &address,
+                                                                                           uint64_t silent_time_ms )
     {
         std::mt19937_64 gen( rd_() );
         uint64_t        random_value = gen();
@@ -1350,7 +1340,7 @@ namespace sgns
             uint64_t                 total_weight{ 0 };
             uint64_t                 count{ 0 };
             bool                     has_utxos{ false };
-            std::vector<std::string> utxos;
+            std::vector<std::string> utxos; // canonical sorted list
         };
 
         auto make_key = []( bool has_utxos, const std::vector<std::string> &utxos ) -> std::string
@@ -1380,12 +1370,7 @@ namespace sgns
         bool any_validator = false;
         for ( auto &resp : responses )
         {
-            if ( resp.has_utxos )
-            {
-                std::sort( resp.utxos.begin(), resp.utxos.end() );
-                resp.utxos.erase( std::unique( resp.utxos.begin(), resp.utxos.end() ), resp.utxos.end() );
-            }
-            else
+            if ( !resp.has_utxos )
             {
                 resp.utxos.clear();
             }
@@ -1418,12 +1403,24 @@ namespace sgns
             }
 
             const uint64_t weight = any_validator ? entry.validator_weight.value() : 1;
-            const auto     key    = make_key( entry.data.has_utxos, entry.data.utxos );
-            auto          &vote   = votes[key];
+
+            std::vector<std::string> canonical_utxos;
+            if ( entry.data.has_utxos )
+            {
+                canonical_utxos.reserve( entry.data.utxos.size() );
+                for ( const auto &u : entry.data.utxos )
+                {
+                    canonical_utxos.push_back( u );
+                }
+                std::sort( canonical_utxos.begin(), canonical_utxos.end() );
+            }
+
+            const auto key  = make_key( entry.data.has_utxos, canonical_utxos );
+            auto      &vote = votes[key];
             if ( vote.count == 0 )
             {
                 vote.has_utxos = entry.data.has_utxos;
-                vote.utxos     = entry.data.utxos;
+                vote.utxos     = canonical_utxos;
             }
             vote.total_weight += weight;
             vote.count        += 1;
@@ -1452,7 +1449,7 @@ namespace sgns
             }
         }
 
-        std::set<std::string> result;
+        std::unordered_set<std::string> result;
         if ( best_vote.has_utxos )
         {
             result.insert( best_vote.utxos.begin(), best_vote.utxos.end() );
@@ -1721,10 +1718,9 @@ namespace sgns
         UTXOResponseData entry;
         entry.responder_address = resp.responder_address();
         entry.has_utxos         = resp.has_utxos();
-        entry.utxos.reserve( resp.utxos_size() );
         for ( const auto &utxo : resp.utxos() )
         {
-            entry.utxos.emplace_back( utxo );
+            entry.utxos.insert( utxo );
         }
 
         std::lock_guard lock( utxo_responses_mutex_ );

--- a/src/account/AccountMessenger.cpp
+++ b/src/account/AccountMessenger.cpp
@@ -1343,17 +1343,12 @@ namespace sgns
             std::vector<std::string> utxos; // canonical sorted list
         };
 
-        auto make_key = []( bool has_utxos, const std::vector<std::string> &utxos ) -> std::string
+        auto make_key = []( const std::vector<std::string> &utxos ) -> std::string
         {
-            if ( !has_utxos )
-            {
-                return "none";
-            }
             std::string key;
             for ( const auto &u : utxos )
             {
                 key.append( u );
-                key.push_back( '\x1f' );
             }
             return key;
         };
@@ -1404,22 +1399,24 @@ namespace sgns
 
             const uint64_t weight = any_validator ? entry.validator_weight.value() : 1;
 
-            std::vector<std::string> canonical_utxos;
-            if ( entry.data.has_utxos )
+            if ( !entry.data.has_utxos )
             {
-                canonical_utxos.reserve( entry.data.utxos.size() );
-                for ( const auto &u : entry.data.utxos )
-                {
-                    canonical_utxos.push_back( u );
-                }
-                std::sort( canonical_utxos.begin(), canonical_utxos.end() );
+                continue;
             }
 
-            const auto key  = make_key( entry.data.has_utxos, canonical_utxos );
+            std::vector<std::string> canonical_utxos;
+            canonical_utxos.reserve( entry.data.utxos.size() );
+            for ( const auto &u : entry.data.utxos )
+            {
+                canonical_utxos.push_back( u );
+            }
+            std::sort( canonical_utxos.begin(), canonical_utxos.end() );
+
+            const auto key  = make_key( canonical_utxos );
             auto      &vote = votes[key];
             if ( vote.count == 0 )
             {
-                vote.has_utxos = entry.data.has_utxos;
+                vote.has_utxos = true;
                 vote.utxos     = canonical_utxos;
             }
             vote.total_weight += weight;

--- a/src/account/AccountMessenger.cpp
+++ b/src/account/AccountMessenger.cpp
@@ -8,6 +8,7 @@
 #include <random>
 #include <boost/format.hpp>
 #include <future>
+#include <algorithm>
 #include "AccountMessenger.hpp"
 #include "base/sgns_version.hpp"
 #include "crypto/hasher/hasher_impl.hpp"
@@ -32,6 +33,8 @@ OUTCOME_CPP_DEFINE_CATEGORY_3( sgns, AccountMessenger::Error, e )
             return "Response received but without nonce data";
         case AccountCommError::GENESIS_REQUEST_ERROR:
             return "Genesis request failed";
+        case AccountCommError::UTXO_REQUEST_ERROR:
+            return "UTXO request failed";
     }
     return "Unknown error";
 }
@@ -209,8 +212,12 @@ namespace sgns
                 case accountComm::AccountMessage::kBlockCidRequest:
                     HandleBlockCidRequest( acc_msg.block_cid_request() );
                     break;
+                case accountComm::AccountMessage::kUtxoRequest:
+                    HandleUTXORequest( acc_msg.utxo_request() );
+                    break;
                 case accountComm::AccountMessage::kNonceResponse:
                 case accountComm::AccountMessage::kBlockResponse:
+                case accountComm::AccountMessage::kUtxoResponse:
                     logger_->error( "{}: Unexpected response received ", __func__ );
                     break;
                 default:
@@ -244,6 +251,12 @@ namespace sgns
                     HandleBlockResponse( acc_msg.block_response() );
                     break;
                 case accountComm::AccountMessage::kBlockCidRequest:
+                    logger_->error( "{}: Unexpected response received ", __func__ );
+                    break;
+                case accountComm::AccountMessage::kUtxoResponse:
+                    HandleUTXOResponse( acc_msg.utxo_response() );
+                    break;
+                case accountComm::AccountMessage::kUtxoRequest:
                     logger_->error( "{}: Unexpected response received ", __func__ );
                     break;
                 default:
@@ -287,26 +300,70 @@ namespace sgns
         auto promise = std::make_shared<std::promise<outcome::result<uint64_t>>>();
         auto future  = promise->get_future();
 
-        EnqueueTask(
-            { RequestType::Nonce, timeout_ms, silent_time_ms, 0, std::string{}, nullptr, std::move( promise ) } );
+        EnqueueTask( { RequestType::Nonce,
+                       timeout_ms,
+                       silent_time_ms,
+                       0,
+                       std::string{},
+                       std::string{},
+                       nullptr,
+                       std::move( promise ),
+                       nullptr } );
 
         return future.get();
     }
 
     outcome::result<void> AccountMessenger::RequestGenesis(
-        uint64_t timeout_ms, std::function<void( outcome::result<std::string> )> callback )
+        uint64_t                                            timeout_ms,
+        std::function<void( outcome::result<std::string> )> callback )
     {
-        EnqueueTask( { RequestType::Genesis, timeout_ms, 150, 0, std::string{}, std::move( callback ), nullptr } );
+        EnqueueTask( { RequestType::Genesis,
+                       timeout_ms,
+                       150,
+                       0,
+                       std::string{},
+                       std::string{},
+                       std::move( callback ),
+                       nullptr,
+                       nullptr } );
         return outcome::success();
     }
 
-    outcome::result<void> AccountMessenger::RequestRegularBlock( uint64_t                                            timeout_ms,
-                                                                 std::string                                         cid,
-                                                                 std::function<void( outcome::result<std::string> )> callback )
+    outcome::result<void> AccountMessenger::RequestRegularBlock(
+        uint64_t                                            timeout_ms,
+        std::string                                         cid,
+        std::function<void( outcome::result<std::string> )> callback )
     {
-        EnqueueTask(
-            { RequestType::BlockByCid, timeout_ms, 150, 0, std::move( cid ), std::move( callback ), nullptr } );
+        EnqueueTask( { RequestType::BlockByCid,
+                       timeout_ms,
+                       150,
+                       0,
+                       std::move( cid ),
+                       std::string{},
+                       std::move( callback ),
+                       nullptr,
+                       nullptr } );
         return outcome::success();
+    }
+
+    outcome::result<std::set<std::string>> AccountMessenger::RequestUTXOs( uint64_t           timeout_ms,
+                                                                           const std::string &address,
+                                                                           uint64_t           silent_time_ms )
+    {
+        auto promise = std::make_shared<std::promise<outcome::result<std::set<std::string>>>>();
+        auto future  = promise->get_future();
+
+        EnqueueTask( { RequestType::UTXO,
+                       timeout_ms,
+                       silent_time_ms,
+                       0,
+                       std::string{},
+                       address,
+                       nullptr,
+                       nullptr,
+                       std::move( promise ) } );
+
+        return future.get();
     }
 
     outcome::result<void> AccountMessenger::RequestBlock( uint64_t req_id, uint8_t block_index )
@@ -347,9 +404,7 @@ namespace sgns
             std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
                 .count() );
         req.set_cid( cid );
-        logger_->debug( "[{}] Requesting block by CID {} with req_id {}",
-                        address_.substr( 0, 8 ),
-                        cid, req_id );
+        logger_->debug( "[{}] Requesting block by CID {} with req_id {}", address_.substr( 0, 8 ), cid, req_id );
         std::string encoded;
         if ( !req.SerializeToString( &encoded ) )
         {
@@ -365,6 +420,35 @@ namespace sgns
 
         accountComm::AccountMessage envelope;
         *envelope.mutable_block_cid_request() = signed_req;
+
+        return SendAccountMessage( envelope, { requests_topic_ } );
+    }
+
+    outcome::result<void> AccountMessenger::RequestUTXO( uint64_t req_id, const std::string &address )
+    {
+        accountComm::UTXORequest req;
+        req.set_requester_address( address_ );
+        req.set_target_address( address );
+        req.set_request_id( req_id );
+        req.set_timestamp(
+            std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
+                .count() );
+
+        std::string encoded;
+        if ( !req.SerializeToString( &encoded ) )
+        {
+            return outcome::failure( Error::PROTO_SERIALIZATION );
+        }
+
+        std::vector<uint8_t> serialized_vec( encoded.begin(), encoded.end() );
+        OUTCOME_TRY( auto &&signature, methods_.sign_( serialized_vec ) );
+
+        accountComm::SignedUTXORequest signed_req;
+        *signed_req.mutable_data() = req;
+        signed_req.set_signature( signature.data(), signature.size() );
+
+        accountComm::AccountMessage envelope;
+        *envelope.mutable_utxo_request() = signed_req;
 
         return SendAccountMessage( envelope, { requests_topic_ } );
     }
@@ -515,7 +599,7 @@ namespace sgns
         if ( methods_.has_block_cid_ )
         {
             auto has_cid_result = methods_.has_block_cid_( req.cid() );
-            have_cid = has_cid_result.has_value() && has_cid_result.value();
+            have_cid            = has_cid_result.has_value() && has_cid_result.value();
         }
         else
         {
@@ -692,10 +776,18 @@ namespace sgns
     }
 
     outcome::result<void> AccountMessenger::RequestAccountCreation(
-        uint64_t timeout_ms, std::function<void( outcome::result<std::string> )> callback )
+        uint64_t                                            timeout_ms,
+        std::function<void( outcome::result<std::string> )> callback )
     {
-        EnqueueTask(
-            { RequestType::AccountCreation, timeout_ms, 150, 1, std::string{}, std::move( callback ), nullptr } );
+        EnqueueTask( { RequestType::AccountCreation,
+                       timeout_ms,
+                       150,
+                       1,
+                       std::string{},
+                       std::string{},
+                       std::move( callback ),
+                       nullptr,
+                       nullptr } );
         return outcome::success();
     }
 
@@ -825,6 +917,15 @@ namespace sgns
                     }
                     break;
                 }
+                case RequestType::UTXO:
+                {
+                    auto res = PerformUTXORequest( task.timeout_ms, task.utxo_address, task.silent_time_ms );
+                    if ( task.utxo_promise )
+                    {
+                        task.utxo_promise->set_value( res );
+                    }
+                    break;
+                }
                 default:
                     break;
             }
@@ -867,9 +968,9 @@ namespace sgns
 
         OUTCOME_TRY( RequestNonce( req_id ) );
 
-        const auto start_time        = std::chrono::steady_clock::now();
-        const auto full_timeout      = std::chrono::milliseconds( timeout_ms );
-        const auto silent_time       = std::chrono::milliseconds( silent_time_ms );
+        const auto start_time   = std::chrono::steady_clock::now();
+        const auto full_timeout = std::chrono::milliseconds( timeout_ms );
+        const auto silent_time  = std::chrono::milliseconds( silent_time_ms );
 
         bool first_seen = false;
 
@@ -989,9 +1090,9 @@ namespace sgns
             return request_result.error();
         }
 
-        const auto start_time        = std::chrono::steady_clock::now();
-        const auto full_timeout      = std::chrono::milliseconds( timeout_ms );
-        const auto silent_time       = std::chrono::milliseconds( 150 );
+        const auto start_time   = std::chrono::steady_clock::now();
+        const auto full_timeout = std::chrono::milliseconds( timeout_ms );
+        const auto silent_time  = std::chrono::milliseconds( 150 );
 
         bool first_seen = false;
 
@@ -1019,7 +1120,6 @@ namespace sgns
                     }
                 }
             }
-
 
             if ( std::chrono::steady_clock::now() - start_time >= full_timeout )
             {
@@ -1055,8 +1155,8 @@ namespace sgns
         return outcome::success( cids );
     }
 
-    outcome::result<std::set<std::string>> AccountMessenger::PerformBlockCidRequest( uint64_t timeout_ms,
-                                                                                      const std::string &cid )
+    outcome::result<std::set<std::string>> AccountMessenger::PerformBlockCidRequest( uint64_t           timeout_ms,
+                                                                                     const std::string &cid )
     {
         std::mt19937_64 gen( rd_() );
         uint64_t        random_value = gen();
@@ -1084,15 +1184,13 @@ namespace sgns
         auto request_result = RequestBlockByCid( req_id, cid );
         if ( request_result.has_error() )
         {
-            logger_->error( "[{}] Failed to request block CID {}",
-                            address_.substr( 0, 8 ),
-                            cid );
+            logger_->error( "[{}] Failed to request block CID {}", address_.substr( 0, 8 ), cid );
             return request_result.error();
         }
 
-        const auto start_time        = std::chrono::steady_clock::now();
-        const auto full_timeout      = std::chrono::milliseconds( timeout_ms );
-        const auto silent_time       = std::chrono::milliseconds( 150 );
+        const auto start_time   = std::chrono::steady_clock::now();
+        const auto full_timeout = std::chrono::milliseconds( timeout_ms );
+        const auto silent_time  = std::chrono::milliseconds( 150 );
 
         bool first_seen = false;
 
@@ -1153,6 +1251,214 @@ namespace sgns
         }
 
         return outcome::success( cids );
+    }
+
+    outcome::result<std::set<std::string>> AccountMessenger::PerformUTXORequest( uint64_t           timeout_ms,
+                                                                                 const std::string &address,
+                                                                                 uint64_t           silent_time_ms )
+    {
+        std::mt19937_64 gen( rd_() );
+        uint64_t        random_value = gen();
+
+        std::string              to_hash = address_ + std::to_string( random_value );
+        sgns::crypto::HasherImpl hasher;
+        auto                     hash = hasher.sha2_256(
+            gsl::span<const uint8_t>( reinterpret_cast<const uint8_t *>( to_hash.data() ), to_hash.size() ) );
+
+        uint64_t req_id = 0;
+        std::memcpy( &req_id, hash.data(), sizeof( req_id ) );
+
+        logger_->debug( "[{}] Requesting UTXOs for {} with req_id {} and timeout {}",
+                        address_.substr( 0, 8 ),
+                        address.substr( 0, 8 ),
+                        req_id,
+                        timeout_ms );
+
+        {
+            std::lock_guard lock( utxo_responses_mutex_ );
+            utxo_responses_.erase( req_id );
+            utxo_first_response_time_.erase( req_id );
+        }
+
+        auto request_result = RequestUTXO( req_id, address );
+        if ( request_result.has_error() )
+        {
+            logger_->error( "[{}] Failed to request UTXOs for {}", address_.substr( 0, 8 ), address.substr( 0, 8 ) );
+            return request_result.error();
+        }
+
+        const auto start_time   = std::chrono::steady_clock::now();
+        const auto full_timeout = std::chrono::milliseconds( timeout_ms );
+        const auto silent_time  = std::chrono::milliseconds( silent_time_ms );
+
+        bool first_seen = false;
+
+        while ( true )
+        {
+            {
+                std::lock_guard lock( utxo_responses_mutex_ );
+                auto            it = utxo_responses_.find( req_id );
+                if ( it != utxo_responses_.end() && !it->second.empty() )
+                {
+                    if ( !first_seen )
+                    {
+                        first_seen                        = true;
+                        utxo_first_response_time_[req_id] = std::chrono::steady_clock::now();
+                    }
+                    else
+                    {
+                        auto elapsed = std::chrono::steady_clock::now() - utxo_first_response_time_[req_id];
+                        if ( elapsed >= silent_time )
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if ( std::chrono::steady_clock::now() - start_time >= full_timeout )
+            {
+                logger_->debug( "[{}] Timeout: no UTXOResponse received for req_id {}",
+                                address_.substr( 0, 8 ),
+                                req_id );
+                return outcome::failure( Error::NO_RESPONSE_RECEIVED );
+            }
+
+            std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+        }
+
+        std::vector<UTXOResponseData> responses;
+        {
+            std::lock_guard lock( utxo_responses_mutex_ );
+            auto            it = utxo_responses_.find( req_id );
+            if ( it != utxo_responses_.end() )
+            {
+                responses = std::move( it->second );
+            }
+            utxo_responses_.erase( req_id );
+            utxo_first_response_time_.erase( req_id );
+        }
+
+        if ( responses.empty() )
+        {
+            logger_->warn( "[{}] No UTXO responses recorded for req_id {}", address_.substr( 0, 8 ), req_id );
+            return outcome::failure( Error::NO_RESPONSE_RECEIVED );
+        }
+
+        struct Vote
+        {
+            uint64_t                 total_weight{ 0 };
+            uint64_t                 count{ 0 };
+            bool                     has_utxos{ false };
+            std::vector<std::string> utxos;
+        };
+
+        auto make_key = []( bool has_utxos, const std::vector<std::string> &utxos ) -> std::string
+        {
+            if ( !has_utxos )
+            {
+                return "none";
+            }
+            std::string key;
+            for ( const auto &u : utxos )
+            {
+                key.append( u );
+                key.push_back( '\x1f' );
+            }
+            return key;
+        };
+
+        struct WeightedResponse
+        {
+            UTXOResponseData        data;
+            std::optional<uint64_t> validator_weight;
+        };
+
+        std::vector<WeightedResponse> weighted;
+        weighted.reserve( responses.size() );
+
+        bool any_validator = false;
+        for ( auto &resp : responses )
+        {
+            if ( resp.has_utxos )
+            {
+                std::sort( resp.utxos.begin(), resp.utxos.end() );
+                resp.utxos.erase( std::unique( resp.utxos.begin(), resp.utxos.end() ), resp.utxos.end() );
+            }
+            else
+            {
+                resp.utxos.clear();
+            }
+
+            std::optional<uint64_t> weight;
+            if ( methods_.get_validator_weight_ )
+            {
+                auto weight_res = methods_.get_validator_weight_( resp.responder_address );
+                if ( weight_res.has_value() )
+                {
+                    weight = weight_res.value();
+                }
+            }
+
+            if ( weight.has_value() && weight.value() > 0 )
+            {
+                any_validator = true;
+            }
+
+            weighted.push_back( { std::move( resp ), weight } );
+        }
+
+        std::unordered_map<std::string, Vote> votes;
+        for ( const auto &entry : weighted )
+        {
+            const bool is_validator = entry.validator_weight.has_value() && entry.validator_weight.value() > 0;
+            if ( any_validator && !is_validator )
+            {
+                continue;
+            }
+
+            const uint64_t weight = any_validator ? entry.validator_weight.value() : 1;
+            const auto     key    = make_key( entry.data.has_utxos, entry.data.utxos );
+            auto          &vote   = votes[key];
+            if ( vote.count == 0 )
+            {
+                vote.has_utxos = entry.data.has_utxos;
+                vote.utxos     = entry.data.utxos;
+            }
+            vote.total_weight += weight;
+            vote.count        += 1;
+        }
+
+        if ( votes.empty() )
+        {
+            logger_->warn( "[{}] No eligible UTXO responses after applying validator preference",
+                           address_.substr( 0, 8 ) );
+            return outcome::failure( Error::NO_RESPONSE_RECEIVED );
+        }
+
+        std::string best_key;
+        Vote        best_vote;
+        bool        first = true;
+
+        for ( const auto &[key, vote] : votes )
+        {
+            if ( first || vote.total_weight > best_vote.total_weight ||
+                 ( vote.total_weight == best_vote.total_weight && vote.count > best_vote.count ) ||
+                 ( vote.total_weight == best_vote.total_weight && vote.count == best_vote.count && key < best_key ) )
+            {
+                best_key  = key;
+                best_vote = vote;
+                first     = false;
+            }
+        }
+
+        std::set<std::string> result;
+        if ( best_vote.has_utxos )
+        {
+            result.insert( best_vote.utxos.begin(), best_vote.utxos.end() );
+        }
+
+        return outcome::success( result );
     }
 
     void AccountMessenger::HandleNonceRequest( const accountComm::SignedNonceRequest &signed_req )
@@ -1297,6 +1603,137 @@ namespace sgns
             // Track addresses that responded with no nonce
             no_nonce_responses_[resp.request_id()].insert( resp.responder_address() );
         }
+    }
+
+    void AccountMessenger::HandleUTXORequest( const accountComm::SignedUTXORequest &signed_req )
+    {
+        const auto &req = signed_req.data();
+
+        logger_->debug( "[{}] Received a UTXO request req_id {} for {}",
+                        address_.substr( 0, 8 ),
+                        req.request_id(),
+                        req.target_address().substr( 0, 8 ) );
+
+        std::string serialized;
+        if ( !req.SerializeToString( &serialized ) )
+        {
+            logger_->error( "Failed to serialize UTXORequest for signature check" );
+            return;
+        }
+
+        std::vector<uint8_t> serialized_vec( serialized.begin(), serialized.end() );
+        auto                 verify_signature_result = methods_.verify_signature_( req.requester_address(),
+                                                                   signed_req.signature(),
+                                                                   serialized_vec );
+        if ( verify_signature_result.has_error() || !verify_signature_result.value() )
+        {
+            logger_->error( "Invalid signature on UTXORequest from {}", req.requester_address() );
+            return;
+        }
+
+        accountComm::UTXOResponse resp;
+        resp.set_responder_address( address_ );
+        resp.set_requester_address( req.requester_address() );
+        resp.set_target_address( req.target_address() );
+        resp.set_request_id( req.request_id() );
+        resp.set_timestamp(
+            std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::system_clock::now().time_since_epoch() )
+                .count() );
+
+        bool have_utxos = false;
+
+        auto utxos_res = methods_.get_utxos_( req.target_address() );
+        if ( utxos_res.has_value() )
+        {
+            auto utxos = utxos_res.value();
+            for ( auto &utxo : utxos )
+            {
+                resp.add_utxos( std::move( utxo ) );
+            }
+            have_utxos = !utxos.empty();
+        }
+
+        resp.set_has_utxos( have_utxos );
+
+        std::string resp_serialized;
+        if ( !resp.SerializeToString( &resp_serialized ) )
+        {
+            logger_->error( "Failed to serialize UTXOResponse" );
+            return;
+        }
+
+        std::vector<uint8_t> resp_bytes( resp_serialized.begin(), resp_serialized.end() );
+        auto                 signature_res = methods_.sign_( resp_bytes );
+        if ( signature_res.has_error() )
+        {
+            logger_->error( "Failed to sign UTXOResponse" );
+            return;
+        }
+
+        accountComm::SignedUTXOResponse signed_resp;
+        *signed_resp.mutable_data() = resp;
+        auto signature              = signature_res.value();
+        signed_resp.set_signature( signature.data(), signature.size() );
+
+        accountComm::AccountMessage msg;
+        *msg.mutable_utxo_response() = signed_resp;
+
+        auto account_topic = req.requester_address() + std::string( ACCOUNT_COMM ) +
+                             sgns::version::GetNetAndVersionAppendix();
+
+        auto send_ret = SendAccountMessage( msg, { account_topic } );
+        if ( send_ret.has_error() )
+        {
+            logger_->error( "[{}] Failed to send UTXOResponse for req_id {}",
+                            address_.substr( 0, 8 ),
+                            req.request_id() );
+        }
+    }
+
+    void AccountMessenger::HandleUTXOResponse( const accountComm::SignedUTXOResponse &signed_resp )
+    {
+        const auto &resp = signed_resp.data();
+
+        logger_->debug( "[{}] Received a UTXO response from {} (has_utxos={}, count={}) and req_id {}",
+                        address_.substr( 0, 8 ),
+                        resp.responder_address().substr( 0, 8 ),
+                        resp.has_utxos(),
+                        resp.utxos_size(),
+                        resp.request_id() );
+
+        std::string serialized;
+        if ( !resp.SerializeToString( &serialized ) )
+        {
+            logger_->error( "Failed to serialize UTXOResponse for signature check" );
+            return;
+        }
+
+        std::vector<uint8_t> data_vec( serialized.begin(), serialized.end() );
+        auto                 verify_signature_result = methods_.verify_signature_( resp.responder_address(),
+                                                                   signed_resp.signature(),
+                                                                   data_vec );
+        if ( verify_signature_result.has_error() || !verify_signature_result.value() )
+        {
+            logger_->error( "Invalid signature on UTXOResponse from {}", resp.responder_address() );
+            return;
+        }
+
+        UTXOResponseData entry;
+        entry.responder_address = resp.responder_address();
+        entry.has_utxos         = resp.has_utxos();
+        entry.utxos.reserve( resp.utxos_size() );
+        for ( const auto &utxo : resp.utxos() )
+        {
+            entry.utxos.emplace_back( utxo );
+        }
+
+        std::lock_guard lock( utxo_responses_mutex_ );
+        auto           &list_ref = utxo_responses_[resp.request_id()];
+        if ( list_ref.empty() )
+        {
+            utxo_first_response_time_[resp.request_id()] = std::chrono::steady_clock::now();
+        }
+        list_ref.push_back( std::move( entry ) );
     }
 
     void AccountMessenger::HandleHeadRequest( const accountComm::SignedHeadRequest &signed_req )

--- a/src/account/AccountMessenger.hpp
+++ b/src/account/AccountMessenger.hpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <chrono>
+#include <variant>
 #include <set>
 #include <optional>
 
@@ -74,8 +75,10 @@ namespace sgns
             std::function<outcome::result<std::vector<std::string>>( const std::string &address )> get_utxos_;
 
             /// @brief Get validator weight for an address (empty if not a validator)
-            std::function<outcome::result<std::optional<uint64_t>>( const std::string &address )>
-                get_validator_weight_;
+            std::function<outcome::result<std::optional<uint64_t>>( const std::string &address )> get_validator_weight_;
+
+            /// @brief Get transaction CID by hash
+            std::function<outcome::result<std::string>( const std::string &tx_hash )> get_transaction_cid_;
         };
 
         // Global block response handler type
@@ -113,9 +116,8 @@ namespace sgns
          * @param[in]   callback Function to be called for each CID found (empty string if none)
          * @return      success if at least one response arrives before timeout, error otherwise
          */
-        outcome::result<void> RequestGenesis(
-            uint64_t timeout_ms,
-            std::function<void( outcome::result<std::string> )> callback = nullptr );
+        outcome::result<void> RequestGenesis( uint64_t                                            timeout_ms,
+                                              std::function<void( outcome::result<std::string> )> callback = nullptr );
 
         /**
          * @brief       Request account creation from the network and invoke callback with found CIDs
@@ -123,9 +125,8 @@ namespace sgns
          * @param[in]   callback Function to be called for each CID found (signature: void(std::string))
          * @return      success on scheduled request, error otherwise
          */
-        outcome::result<void> RequestAccountCreation(
-            uint64_t timeout_ms,
-            std::function<void( outcome::result<std::string> )> callback );
+        outcome::result<void> RequestAccountCreation( uint64_t                                            timeout_ms,
+                                                      std::function<void( outcome::result<std::string> )> callback );
 
         /**
          * @brief       Request a block by CID from the network (retries until timeout)
@@ -134,9 +135,22 @@ namespace sgns
          * @param[in]   callback Callback invoked with the CID result (or error)
          * @return      success on scheduled request, error otherwise
          */
-        outcome::result<void> RequestRegularBlock( uint64_t                                            timeout_ms,
-                                                   std::string                                         cid,
-                                                   std::function<void( outcome::result<std::string> )> callback = nullptr );
+        outcome::result<void> RequestRegularBlock(
+            uint64_t                                            timeout_ms,
+            std::string                                         cid,
+            std::function<void( outcome::result<std::string> )> callback = nullptr );
+
+        /**
+         * @brief       Request a transaction by hash from the network (retries until timeout)
+         * @param[in]   timeout_ms Total timeout in milliseconds to wait for responses
+         * @param[in]   tx_hash Transaction hash to request
+         * @param[in]   callback Callback invoked with the CID result (or error)
+         * @return      success on scheduled request, error otherwise
+         */
+        outcome::result<void> RequestTransaction(
+            uint64_t                                            timeout_ms,
+            std::string                                         tx_hash,
+            std::function<void( outcome::result<std::string> )> callback = nullptr );
 
         /**
          * @brief       Request UTXOs for a specific address and return the selected response
@@ -145,9 +159,9 @@ namespace sgns
          * @param[in]   silent_time_ms Time to wait for subsequent responses after first one
          * @return      Set of UTXO strings based on selection criteria, or error otherwise
          */
-        outcome::result<std::set<std::string>> RequestUTXOs( uint64_t           timeout_ms,
-                                                             const std::string &address,
-                                                             uint64_t           silent_time_ms = 150 );
+        outcome::result<std::unordered_set<std::string>> RequestUTXOs( uint64_t           timeout_ms,
+                                                                       const std::string &address,
+                                                                       uint64_t           silent_time_ms = 150 );
 
         /**
          * @brief       Register global block response handler
@@ -184,6 +198,23 @@ namespace sgns
         /// Basis of the global requests topic
         static constexpr std::string_view REQUESTS_COMM = "SGNUS.BC.Requests.comm";
 
+        struct BlockIndexRequest
+        {
+            uint8_t block_index{ 0 };
+        };
+
+        struct BlockCidRequest
+        {
+            std::string cid;
+        };
+
+        struct TransactionHashRequest
+        {
+            std::string tx_hash;
+        };
+
+        using BlockQuery = std::variant<BlockIndexRequest, BlockCidRequest, TransactionHashRequest>;
+
         const std::string                          address_;            ///< Own address
         const std::string                          account_comm_topic_; ///< Account receiving topic
         const std::string                          requests_topic_;     ///< Global requests topic
@@ -209,14 +240,14 @@ namespace sgns
 
         struct UTXOResponseData
         {
-            std::string              responder_address;
-            std::vector<std::string> utxos;
-            bool                     has_utxos{ false };
+            std::string                     responder_address;
+            std::unordered_set<std::string> utxos;
+            bool                            has_utxos{ false };
         };
 
-        std::unordered_map<uint64_t, std::vector<UTXOResponseData>> utxo_responses_;
+        std::unordered_map<uint64_t, std::vector<UTXOResponseData>>         utxo_responses_;
         std::unordered_map<uint64_t, std::chrono::steady_clock::time_point> utxo_first_response_time_;
-        std::mutex utxo_responses_mutex_;
+        std::mutex                                                          utxo_responses_mutex_;
 
         InterfaceMethods methods_; ///< Interface methods
 
@@ -231,42 +262,42 @@ namespace sgns
         std::mutex         head_handler_mutex_;
 
         // Worker thread state
-        enum class RequestType: std::uint8_t
+        enum class RequestType : std::uint8_t
         {
             Nonce,
             Genesis,
             AccountCreation,
             BlockByCid,
-            UTXO
+            UTXO,
+            Transaction
         };
 
         struct RequestTask
         {
-            RequestType                                         type;
-            uint64_t                                            timeout_ms;
-            uint64_t                                            silent_time_ms{ 150 };
-            uint8_t                                             block_index{ 0 };
-            std::string                                         cid;
-            std::string                                         utxo_address;
-            std::function<void( outcome::result<std::string> )> callback;
-            std::shared_ptr<std::promise<outcome::result<uint64_t>>> nonce_promise;
-            std::shared_ptr<std::promise<outcome::result<std::set<std::string>>>> utxo_promise;
+            RequestType                                                                     type;
+            uint64_t                                                                        timeout_ms;
+            uint64_t                                                                        silent_time_ms{ 150 };
+            uint8_t                                                                         block_index{ 0 };
+            std::string                                                                     cid;
+            std::string                                                                     utxo_address;
+            std::function<void( outcome::result<std::string> )>                             callback;
+            std::shared_ptr<std::promise<outcome::result<uint64_t>>>                        nonce_promise;
+            std::shared_ptr<std::promise<outcome::result<std::unordered_set<std::string>>>> utxo_promise;
         };
 
-        std::thread                     worker_thread_;
-        std::mutex                      queue_mutex_;
-        std::condition_variable         queue_cv_;
-        std::queue<RequestTask>         request_queue_;
-        std::atomic<bool>               stop_worker_{ false };
+        std::thread             worker_thread_;
+        std::mutex              queue_mutex_;
+        std::condition_variable queue_cv_;
+        std::queue<RequestTask> request_queue_;
+        std::atomic<bool>       stop_worker_{ false };
 
-        void WorkerLoop();
-        void EnqueueTask( RequestTask task );
-        outcome::result<uint64_t> PerformNonceRequest( uint64_t timeout_ms, uint64_t silent_time_ms );
-        outcome::result<std::set<std::string>> PerformBlockRequest( uint64_t timeout_ms, uint8_t block_index );
-        outcome::result<std::set<std::string>> PerformBlockCidRequest( uint64_t timeout_ms, const std::string &cid );
-        outcome::result<std::set<std::string>> PerformUTXORequest( uint64_t           timeout_ms,
-                                                                   const std::string &address,
-                                                                   uint64_t           silent_time_ms );
+        void                                   WorkerLoop();
+        void                                   EnqueueTask( RequestTask task );
+        outcome::result<uint64_t>              PerformNonceRequest( uint64_t timeout_ms, uint64_t silent_time_ms );
+        outcome::result<std::set<std::string>> PerformBlockRequest( uint64_t timeout_ms, const BlockQuery &query );
+        outcome::result<std::unordered_set<std::string>> PerformUTXORequest( uint64_t           timeout_ms,
+                                                                             const std::string &address,
+                                                                             uint64_t           silent_time_ms );
 
         /**
          * @brief       Private constructor of the Account Messenger 
@@ -297,6 +328,7 @@ namespace sgns
          * @param[in]   cid CID to request
          */
         outcome::result<void> RequestBlockByCid( uint64_t req_id, const std::string &cid );
+        outcome::result<void> RequestBlockByHash( uint64_t req_id, const std::string &tx_hash );
         outcome::result<void> RequestUTXO( uint64_t req_id, const std::string &address );
 
         /**
@@ -344,6 +376,10 @@ namespace sgns
          * @param[in]   resp The proto block response package
          */
         void HandleBlockResponse( const accountComm::SignedBlockResponse &resp );
+        void HandleTransactionRequest( const accountComm::SignedTransactionRequest &req );
+        void HandleBlockLikeRequest( const BlockQuery  &query,
+                                     const std::string &requester_address,
+                                     uint64_t           request_id );
 
         /**
          * @brief       Handles the Head request package (calls registered handler)

--- a/src/account/AccountMessenger.hpp
+++ b/src/account/AccountMessenger.hpp
@@ -18,6 +18,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <chrono>
+#include <set>
+#include <optional>
 
 #include <boost/optional.hpp>
 
@@ -43,6 +45,7 @@ namespace sgns
             NO_RESPONSE_RECEIVED,      ///< No response received from network
             RESPONSE_WITHOUT_NONCE,    ///< Response received but without nonce data
             GENESIS_REQUEST_ERROR,     ///< Genesis request failed
+            UTXO_REQUEST_ERROR,        ///< UTXO request failed
         };
 
         /**
@@ -66,6 +69,13 @@ namespace sgns
 
             /// @brief Check if a CID is locally available
             std::function<outcome::result<bool>( const std::string &cid )> has_block_cid_;
+
+            /// @brief Get local UTXOs as a list of strings for a given address
+            std::function<outcome::result<std::vector<std::string>>( const std::string &address )> get_utxos_;
+
+            /// @brief Get validator weight for an address (empty if not a validator)
+            std::function<outcome::result<std::optional<uint64_t>>( const std::string &address )>
+                get_validator_weight_;
         };
 
         // Global block response handler type
@@ -129,6 +139,17 @@ namespace sgns
                                                    std::function<void( outcome::result<std::string> )> callback = nullptr );
 
         /**
+         * @brief       Request UTXOs for a specific address and return the selected response
+         * @param[in]   timeout_ms Total timeout in milliseconds to wait for responses
+         * @param[in]   address Address to request UTXOs for
+         * @param[in]   silent_time_ms Time to wait for subsequent responses after first one
+         * @return      Set of UTXO strings based on selection criteria, or error otherwise
+         */
+        outcome::result<std::set<std::string>> RequestUTXOs( uint64_t           timeout_ms,
+                                                             const std::string &address,
+                                                             uint64_t           silent_time_ms = 150 );
+
+        /**
          * @brief       Register global block response handler
          * @param[in]   handler Function to call for all block responses
          */
@@ -186,6 +207,17 @@ namespace sgns
                    block_first_response_time_; ///< Timestamp of the first block response
         std::mutex block_responses_mutex_;     ///< Mutex protecting block_responses_
 
+        struct UTXOResponseData
+        {
+            std::string              responder_address;
+            std::vector<std::string> utxos;
+            bool                     has_utxos{ false };
+        };
+
+        std::unordered_map<uint64_t, std::vector<UTXOResponseData>> utxo_responses_;
+        std::unordered_map<uint64_t, std::chrono::steady_clock::time_point> utxo_first_response_time_;
+        std::mutex utxo_responses_mutex_;
+
         InterfaceMethods methods_; ///< Interface methods
 
         std::random_device rd_; ///< Random device for request IDs
@@ -204,7 +236,8 @@ namespace sgns
             Nonce,
             Genesis,
             AccountCreation,
-            BlockByCid
+            BlockByCid,
+            UTXO
         };
 
         struct RequestTask
@@ -214,8 +247,10 @@ namespace sgns
             uint64_t                                            silent_time_ms{ 150 };
             uint8_t                                             block_index{ 0 };
             std::string                                         cid;
+            std::string                                         utxo_address;
             std::function<void( outcome::result<std::string> )> callback;
             std::shared_ptr<std::promise<outcome::result<uint64_t>>> nonce_promise;
+            std::shared_ptr<std::promise<outcome::result<std::set<std::string>>>> utxo_promise;
         };
 
         std::thread                     worker_thread_;
@@ -229,6 +264,9 @@ namespace sgns
         outcome::result<uint64_t> PerformNonceRequest( uint64_t timeout_ms, uint64_t silent_time_ms );
         outcome::result<std::set<std::string>> PerformBlockRequest( uint64_t timeout_ms, uint8_t block_index );
         outcome::result<std::set<std::string>> PerformBlockCidRequest( uint64_t timeout_ms, const std::string &cid );
+        outcome::result<std::set<std::string>> PerformUTXORequest( uint64_t           timeout_ms,
+                                                                   const std::string &address,
+                                                                   uint64_t           silent_time_ms );
 
         /**
          * @brief       Private constructor of the Account Messenger 
@@ -259,6 +297,7 @@ namespace sgns
          * @param[in]   cid CID to request
          */
         outcome::result<void> RequestBlockByCid( uint64_t req_id, const std::string &cid );
+        outcome::result<void> RequestUTXO( uint64_t req_id, const std::string &address );
 
         /**
          * @brief       Callback of pubsub message when a response was received
@@ -311,6 +350,18 @@ namespace sgns
          * @param[in]   req The proto head request package
          */
         void HandleHeadRequest( const accountComm::SignedHeadRequest &req );
+
+        /**
+         * @brief       Handles the UTXO request package
+         * @param[in]   req The proto UTXO request package
+         */
+        void HandleUTXORequest( const accountComm::SignedUTXORequest &req );
+
+        /**
+         * @brief       Handles the UTXO response package
+         * @param[in]   resp The proto UTXO response package
+         */
+        void HandleUTXOResponse( const accountComm::SignedUTXOResponse &resp );
 
         /// The logger instance
         base::Logger logger_ = sgns::base::createLogger( "AccountMessenger" );

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -336,6 +336,38 @@ namespace sgns
 
             return outcome::failure( std::errc::owner_dead );
         };
+        methods.get_utxos_ =
+            [weakptr( weak_from_this() )]( const std::string &address ) -> outcome::result<std::vector<std::string>>
+        {
+            if ( auto self = weakptr.lock() )
+            {
+                std::lock_guard lock( self->get_cids_mutex_ );
+                if ( self->get_utxos_method_ )
+                {
+                    return self->get_utxos_method_( address );
+                }
+
+                return outcome::failure( AccountMessenger::Error::UTXO_REQUEST_ERROR );
+            }
+
+            return outcome::failure( std::errc::owner_dead );
+        };
+        methods.get_validator_weight_ =
+            [weakptr( weak_from_this() )]( const std::string &address ) -> outcome::result<std::optional<uint64_t>>
+        {
+            if ( auto self = weakptr.lock() )
+            {
+                std::lock_guard lock( self->get_cids_mutex_ );
+                if ( self->get_validator_weight_method_ )
+                {
+                    return self->get_validator_weight_method_( address );
+                }
+
+                return outcome::failure( AccountMessenger::Error::UTXO_REQUEST_ERROR );
+            }
+
+            return outcome::failure( std::errc::owner_dead );
+        };
         messenger_ = AccountMessenger::New( eth_keypair_->GetEntirePubValue(),
                                             std::move( pubsub ),
                                             std::move( methods ) );
@@ -766,6 +798,19 @@ namespace sgns
         return messenger_->RequestRegularBlock( timeout_ms, cid, std::move( callback ) );
     }
 
+    outcome::result<std::set<std::string>> GeniusAccount::RequestUTXOs( uint64_t           timeout_ms,
+                                                                        const std::string &address,
+                                                                        uint64_t           silent_time_ms ) const
+    {
+        if ( !messenger_ )
+        {
+            return outcome::failure( std::errc::no_such_device );
+        }
+        genius_account_logger()->debug( "Requesting UTXOs for {}", address.substr( 0, 8 ) );
+
+        return messenger_->RequestUTXOs( timeout_ms, address, silent_time_ms );
+    }
+
     void GeniusAccount::SetGetBlockChainCIDMethod(
         std::function<outcome::result<std::string>( uint8_t, const std::string & )> method )
     {
@@ -789,5 +834,31 @@ namespace sgns
     {
         std::lock_guard lock( get_cids_mutex_ );
         has_cid_method_ = nullptr;
+    }
+
+    void GeniusAccount::SetGetUTXOsMethod(
+        std::function<outcome::result<std::vector<std::string>>( const std::string & )> method )
+    {
+        std::lock_guard lock( get_cids_mutex_ );
+        get_utxos_method_ = std::move( method );
+    }
+
+    void GeniusAccount::ClearGetUTXOsMethod()
+    {
+        std::lock_guard lock( get_cids_mutex_ );
+        get_utxos_method_ = nullptr;
+    }
+
+    void GeniusAccount::SetGetValidatorWeightMethod(
+        std::function<outcome::result<std::optional<uint64_t>>( const std::string & )> method )
+    {
+        std::lock_guard lock( get_cids_mutex_ );
+        get_validator_weight_method_ = std::move( method );
+    }
+
+    void GeniusAccount::ClearGetValidatorWeightMethod()
+    {
+        std::lock_guard lock( get_cids_mutex_ );
+        get_validator_weight_method_ = nullptr;
     }
 }

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -396,9 +396,11 @@ namespace sgns
         return ret;
     }
 
-    bool GeniusAccount::ConfigureMessengerHandlers( std::shared_ptr<crdt::GlobalDB> global_db )
+    bool GeniusAccount::ConfigureDatabaseDependencies( std::shared_ptr<crdt::GlobalDB> global_db )
     {
         bool ret = false;
+
+        SetNonceStore( global_db->GetDataStore() );
         if ( messenger_ )
         {
             messenger_->RegisterBlockResponseHandler(

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -368,6 +368,22 @@ namespace sgns
 
             return outcome::failure( std::errc::owner_dead );
         };
+        methods.get_transaction_cid_ =
+            [weakptr( weak_from_this() )]( const std::string &tx_hash ) -> outcome::result<std::string>
+        {
+            if ( auto self = weakptr.lock() )
+            {
+                std::lock_guard lock( self->get_cids_mutex_ );
+                if ( self->get_transaction_cid_method_ )
+                {
+                    return self->get_transaction_cid_method_( tx_hash );
+                }
+
+                return outcome::failure( AccountMessenger::Error::GENESIS_REQUEST_ERROR );
+            }
+
+            return outcome::failure( std::errc::owner_dead );
+        };
         messenger_ = AccountMessenger::New( eth_keypair_->GetEntirePubValue(),
                                             std::move( pubsub ),
                                             std::move( methods ) );
@@ -537,8 +553,8 @@ namespace sgns
 
     void GeniusAccount::SetPeerConfirmedNonce( uint64_t nonce, const std::string &address )
     {
-        std::lock_guard lock( nonce_mutex_ );
-        auto            current_confirmed_nonce = confirmed_nonces_[address];
+        std::unique_lock lock( nonce_mutex_ );
+        auto             current_confirmed_nonce = confirmed_nonces_[address];
         genius_account_logger()->debug( "Setting the max value between {} and {} as a confirmed nonce for address {}",
                                         current_confirmed_nonce,
                                         nonce,
@@ -559,6 +575,9 @@ namespace sgns
                 it = pending_nonces_.erase( it );
             }
         }
+
+        lock.unlock();
+        PersistConfirmedNonce( address, updated_nonce );
     }
 
     void GeniusAccount::RollBackPeerConfirmedNonce( uint64_t nonce, const std::string &address )
@@ -798,9 +817,23 @@ namespace sgns
         return messenger_->RequestRegularBlock( timeout_ms, cid, std::move( callback ) );
     }
 
-    outcome::result<std::set<std::string>> GeniusAccount::RequestUTXOs( uint64_t           timeout_ms,
-                                                                        const std::string &address,
-                                                                        uint64_t           silent_time_ms ) const
+    outcome::result<void> GeniusAccount::RequestTransaction(
+        uint64_t                                            timeout_ms,
+        const std::string                                  &tx_hash,
+        std::function<void( outcome::result<std::string> )> callback ) const
+    {
+        if ( !messenger_ )
+        {
+            return outcome::failure( std::errc::no_such_device );
+        }
+        genius_account_logger()->debug( "Requesting transaction {}", tx_hash.substr( 0, 8 ) );
+
+        return messenger_->RequestTransaction( timeout_ms, tx_hash, std::move( callback ) );
+    }
+
+    outcome::result<std::unordered_set<std::string>> GeniusAccount::RequestUTXOs( uint64_t           timeout_ms,
+                                                                                  const std::string &address,
+                                                                                  uint64_t silent_time_ms ) const
     {
         if ( !messenger_ )
         {
@@ -860,5 +893,95 @@ namespace sgns
     {
         std::lock_guard lock( get_cids_mutex_ );
         get_validator_weight_method_ = nullptr;
+    }
+
+    void GeniusAccount::SetGetTransactionCIDMethod(
+        std::function<outcome::result<std::string>( const std::string & )> method )
+    {
+        std::lock_guard lock( get_cids_mutex_ );
+        get_transaction_cid_method_ = std::move( method );
+    }
+
+    void GeniusAccount::ClearGetTransactionCIDMethod()
+    {
+        std::lock_guard lock( get_cids_mutex_ );
+        get_transaction_cid_method_ = nullptr;
+    }
+
+    void GeniusAccount::SetNonceStore( std::shared_ptr<storage::rocksdb> db )
+    {
+        nonce_db_ = std::move( db );
+        LoadConfirmedNonces();
+    }
+
+    void GeniusAccount::LoadConfirmedNonces()
+    {
+        if ( !nonce_db_ )
+        {
+            return;
+        }
+
+        base::Buffer prefix;
+        prefix.put( std::string( NONCE_KEY_PREFIX ) );
+        auto query_res = nonce_db_->query( prefix );
+        if ( query_res.has_error() )
+        {
+            return;
+        }
+
+        std::unordered_map<std::string, uint64_t> loaded;
+        uint64_t                                  max_local = 0;
+        bool                                      has_local = false;
+
+        for ( const auto &[key_buf, val_buf] : query_res.value() )
+        {
+            const auto key = std::string( key_buf.toString() );
+
+            if ( key.rfind( std::string( NONCE_KEY_PREFIX ) ) != 0 )
+            {
+                continue;
+            }
+
+            auto address = key.substr( std::string( NONCE_KEY_PREFIX ).size() );
+            try
+            {
+                uint64_t nonce  = std::stoull( std::string( val_buf.toString() ) );
+                loaded[address] = nonce;
+            }
+            catch ( const std::exception & )
+            {
+            }
+        }
+
+        std::lock_guard lock( nonce_mutex_ );
+        for ( const auto &[address, nonce] : loaded )
+        {
+            confirmed_nonces_[address] = nonce;
+        }
+
+        if ( has_local )
+        {
+            local_confirmed_nonce_ = max_local;
+        }
+    }
+
+    void GeniusAccount::PersistConfirmedNonce( const std::string &address, uint64_t nonce )
+    {
+        if ( !nonce_db_ )
+        {
+            return;
+        }
+
+        base::Buffer key;
+
+        key.put( std::string( NONCE_KEY_PREFIX ) + address );
+
+        base::Buffer value;
+        value.put( std::to_string( nonce ) );
+        auto put_res = nonce_db_->put( key, value );
+        if ( put_res.has_error() )
+        {
+            genius_account_logger()->error( "Failed to persist nonce for {}", address.substr( 0, 8 ) );
+        }
     }
 }

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -989,6 +989,8 @@ namespace sgns
             }
             catch ( const std::exception & )
             {
+                genius_account_logger()->error( "Failed to parse nonce for {}: ", address.substr( 0, 8 ),
+                                                val_buf.toString() );
             }
         }
 

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -702,7 +702,7 @@ namespace sgns
             genius_account_logger()->debug( "Nonce replied with value {}", result.value() );
             return result.value();
         }
-        else if ( result.error() == AccountMessenger::Error::RESPONSE_WITHOUT_NONCE )
+        if ( result.error() == AccountMessenger::Error::RESPONSE_WITHOUT_NONCE )
         {
             genius_account_logger()->debug( "Network didn't answer nonce request" );
             return outcome::success( std::nullopt );

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -461,6 +461,20 @@ namespace sgns
         return ret;
     }
 
+    void GeniusAccount::DeconfigureDatabaseDependencies()
+    {
+        SetNonceStore( nullptr );
+
+        if ( messenger_ )
+        {
+            messenger_->ClearBlockResponseHandler();
+            messenger_->ClearHeadRequestHandler();
+        }
+
+        ClearHasBlockCidMethod();
+        genius_account_logger()->debug( "Cleared database dependency handlers" );
+    }
+
     GeniusAccount::GeniusAccount( TokenID token_id, std::shared_ptr<ISecureStorage> storage, bool full_node ) :
         token( token_id ),
         storage_( std::move( storage ) ),

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -674,6 +674,29 @@ namespace sgns
         return GetPeerNonce( eth_keypair_->GetEntirePubValue() );
     }
 
+    outcome::result<std::optional<uint64_t>> GeniusAccount::FetchNetworkNonce( uint64_t timeout_ms ) const
+    {
+        if ( !messenger_ )
+        {
+            return outcome::failure( std::errc::no_such_device );
+        }
+        genius_account_logger()->debug( "Fetching nonce from the network with timeout {} ms", timeout_ms );
+
+        auto result = messenger_->GetLatestNonce( timeout_ms );
+        if ( result.has_value() )
+        {
+            genius_account_logger()->debug( "Nonce replied with value {}", result.value() );
+            return result.value();
+        }
+        else if ( result.error() == AccountMessenger::Error::RESPONSE_WITHOUT_NONCE )
+        {
+            genius_account_logger()->debug( "Network didn't answer nonce request" );
+            return outcome::success( std::nullopt );
+        }
+
+        return outcome::failure( result.error() );
+    }
+
     outcome::result<uint64_t> GeniusAccount::GetConfirmedNonce( uint64_t timeout_ms ) const
     {
         if ( !messenger_ )

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -47,7 +47,7 @@ namespace sgns
         class GlobalDB;
     }
     class AccountMessenger;
-    class GeniusNode;
+    class TransactionManager;
 
     class GeniusAccount : public std::enable_shared_from_this<GeniusAccount>
     {
@@ -106,7 +106,7 @@ namespace sgns
          * @param[in]   global_db GlobalDB instance used to store fetched block CIDs.
          * @return      true if successfully configured, false otherwise.
          */
-        bool ConfigureMessengerHandlers( std::shared_ptr<crdt::GlobalDB> global_db );
+        bool ConfigureDatabaseDependencies( std::shared_ptr<crdt::GlobalDB> global_db );
 
         /**
          * @brief       Destroy the Genius Account object
@@ -249,7 +249,7 @@ namespace sgns
 
     protected:
         friend class Blockchain;
-        friend class GeniusNode;
+        friend class TransactionManager;
         void SetGetBlockChainCIDMethod(
             std::function<outcome::result<std::string>( uint8_t, const std::string & )> method );
         void ClearGetBlockChainCIDMethod();

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -45,6 +45,7 @@ namespace sgns
         class GlobalDB;
     }
     class AccountMessenger;
+    class GeniusNode;
 
     class GeniusAccount : public std::enable_shared_from_this<GeniusAccount>
     {
@@ -218,6 +219,16 @@ namespace sgns
             const std::string                                  &cid,
             std::function<void( outcome::result<std::string> )> callback = nullptr ) const;
         /**
+         * @brief       Request UTXOs for a specific address and return the selected response
+         * @param[in]   timeout_ms Total timeout in milliseconds to wait for responses
+         * @param[in]   address Address to request UTXOs for
+         * @param[in]   silent_time_ms Time to wait for subsequent responses after first one
+         * @return      Set of UTXO strings based on selection criteria, or error otherwise
+         */
+        outcome::result<std::set<std::string>> RequestUTXOs( uint64_t           timeout_ms,
+                                                             const std::string &address,
+                                                             uint64_t           silent_time_ms = 150 ) const;
+        /**
          * @brief       Request heads broadcast for specific topics
          * @param[in]   topics Vector of topic names to request heads for
          * @return      outcome::success if request was sent, error otherwise
@@ -232,11 +243,18 @@ namespace sgns
 
     protected:
         friend class Blockchain;
+        friend class GeniusNode;
         void SetGetBlockChainCIDMethod(
             std::function<outcome::result<std::string>( uint8_t, const std::string & )> method );
         void ClearGetBlockChainCIDMethod();
         void SetHasBlockCidMethod( std::function<outcome::result<bool>( const std::string & )> method );
         void ClearHasBlockCidMethod();
+        void SetGetUTXOsMethod(
+            std::function<outcome::result<std::vector<std::string>>( const std::string & )> method );
+        void ClearGetUTXOsMethod();
+        void SetGetValidatorWeightMethod(
+            std::function<outcome::result<std::optional<uint64_t>>( const std::string & )> method );
+        void ClearGetValidatorWeightMethod();
 
     private:
         static constexpr size_t SIGNATURE_EXP_SIZE = 64; ///< Expected size of the signature in bytes
@@ -271,6 +289,10 @@ namespace sgns
         std::function<outcome::result<std::string>( uint8_t, const std::string & )>
             get_cids_method_; ///< Function to get blockchain CIDs
         std::function<outcome::result<bool>( const std::string & )> has_cid_method_; ///< Function to check CID presence
+        std::function<outcome::result<std::vector<std::string>>( const std::string & )>
+            get_utxos_method_; ///< Function to get UTXOs for an address
+        std::function<outcome::result<std::optional<uint64_t>>( const std::string & )>
+            get_validator_weight_method_; ///< Function to get validator weight for an address
 
         uint64_t GetNextNonceLocked() const;
 

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -109,6 +109,11 @@ namespace sgns
         bool ConfigureDatabaseDependencies( std::shared_ptr<crdt::GlobalDB> global_db );
 
         /**
+         * @brief       Clears handlers and methods set by ConfigureDatabaseDependencies.
+         */
+        void DeconfigureDatabaseDependencies();
+
+        /**
          * @brief       Destroy the Genius Account object
          */
         ~GeniusAccount();

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -193,6 +193,13 @@ namespace sgns
         outcome::result<uint64_t> GetConfirmedNonce( uint64_t timeout_ms ) const;
 
         /**
+         * @brief       Fetch the latest nonce from the network without relying on cached values
+         * @param[in]   timeout_ms Timeout in miliseconds to get the confirmed nonce
+         * @return      Error if no response received, optional nonce if success
+         */
+        outcome::result<std::optional<uint64_t>> FetchNetworkNonce( uint64_t timeout_ms ) const;
+
+        /**
          * @brief       Get the next available nonce without reserving it
          * @return      The nonce that would be assigned to the next transaction
          */
@@ -261,8 +268,7 @@ namespace sgns
         void SetGetValidatorWeightMethod(
             std::function<outcome::result<std::optional<uint64_t>>( const std::string & )> method );
         void ClearGetValidatorWeightMethod();
-        void SetGetTransactionCIDMethod(
-            std::function<outcome::result<std::string>( const std::string & )> method );
+        void SetGetTransactionCIDMethod( std::function<outcome::result<std::string>( const std::string & )> method );
         void ClearGetTransactionCIDMethod();
         void SetNonceStore( std::shared_ptr<storage::rocksdb> db );
 
@@ -304,11 +310,10 @@ namespace sgns
         std::function<outcome::result<std::optional<uint64_t>>( const std::string & )>
             get_validator_weight_method_; ///< Function to get validator weight for an address
         std::function<outcome::result<std::string>( const std::string & )>
-            get_transaction_cid_method_; ///< Function to get transaction CID by hash
-        std::shared_ptr<storage::rocksdb> nonce_db_; ///< RocksDB for nonce persistence
+                                          get_transaction_cid_method_; ///< Function to get transaction CID by hash
+        std::shared_ptr<storage::rocksdb> nonce_db_;                   ///< RocksDB for nonce persistence
 
         static constexpr std::string_view NONCE_KEY_PREFIX = "gnus-confirmed-nonce-";
-        
 
         void LoadConfirmedNonces();
         void PersistConfirmedNonce( const std::string &address, uint64_t nonce );

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -17,6 +17,8 @@
 #include <functional>
 #include <optional>
 #include <set>
+#include <storage/rocksdb/rocksdb.hpp>
+#include <string_view>
 
 #include <boost/multiprecision/cpp_int.hpp>
 
@@ -218,6 +220,10 @@ namespace sgns
             uint64_t                                            timeout_ms,
             const std::string                                  &cid,
             std::function<void( outcome::result<std::string> )> callback = nullptr ) const;
+        outcome::result<void> RequestTransaction(
+            uint64_t                                            timeout_ms,
+            const std::string                                  &tx_hash,
+            std::function<void( outcome::result<std::string> )> callback = nullptr ) const;
         /**
          * @brief       Request UTXOs for a specific address and return the selected response
          * @param[in]   timeout_ms Total timeout in milliseconds to wait for responses
@@ -225,9 +231,9 @@ namespace sgns
          * @param[in]   silent_time_ms Time to wait for subsequent responses after first one
          * @return      Set of UTXO strings based on selection criteria, or error otherwise
          */
-        outcome::result<std::set<std::string>> RequestUTXOs( uint64_t           timeout_ms,
-                                                             const std::string &address,
-                                                             uint64_t           silent_time_ms = 150 ) const;
+        outcome::result<std::unordered_set<std::string>> RequestUTXOs( uint64_t           timeout_ms,
+                                                                       const std::string &address,
+                                                                       uint64_t           silent_time_ms = 150 ) const;
         /**
          * @brief       Request heads broadcast for specific topics
          * @param[in]   topics Vector of topic names to request heads for
@@ -255,6 +261,10 @@ namespace sgns
         void SetGetValidatorWeightMethod(
             std::function<outcome::result<std::optional<uint64_t>>( const std::string & )> method );
         void ClearGetValidatorWeightMethod();
+        void SetGetTransactionCIDMethod(
+            std::function<outcome::result<std::string>( const std::string & )> method );
+        void ClearGetTransactionCIDMethod();
+        void SetNonceStore( std::shared_ptr<storage::rocksdb> db );
 
     private:
         static constexpr size_t SIGNATURE_EXP_SIZE = 64; ///< Expected size of the signature in bytes
@@ -293,6 +303,15 @@ namespace sgns
             get_utxos_method_; ///< Function to get UTXOs for an address
         std::function<outcome::result<std::optional<uint64_t>>( const std::string & )>
             get_validator_weight_method_; ///< Function to get validator weight for an address
+        std::function<outcome::result<std::string>( const std::string & )>
+            get_transaction_cid_method_; ///< Function to get transaction CID by hash
+        std::shared_ptr<storage::rocksdb> nonce_db_; ///< RocksDB for nonce persistence
+
+        static constexpr std::string_view NONCE_KEY_PREFIX = "gnus-confirmed-nonce-";
+        
+
+        void LoadConfirmedNonces();
+        void PersistConfirmedNonce( const std::string &address, uint64_t nonce );
 
         uint64_t GetNextNonceLocked() const;
 

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -416,6 +416,19 @@ namespace sgns
                                                                 std::make_shared<crypto::HasherImpl>(),
                                                                 is_full_node_ );
 
+                account_->SetNonceStore( tx_globaldb_->GetDataStore() );
+
+                account_->SetGetTransactionCIDMethod(
+                    [weak_tm = std::weak_ptr<TransactionManager>( transaction_manager_ )]( const std::string &tx_hash )
+                        -> outcome::result<std::string>
+                    {
+                        if ( auto tm = weak_tm.lock() )
+                        {
+                            return tm->GetTransactionCID( tx_hash );
+                        }
+                        return outcome::failure( std::errc::owner_dead );
+                    } );
+
                 transaction_manager_->RegisterStateChangeCallback(
                     [weak_self = weak_from_this()]( TransactionManager::State old_state,
                                                     TransactionManager::State new_state )

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -395,6 +395,20 @@ namespace sgns
 
             case NodeState::INITIALIZING_TRANSACTIONS:
             {
+                account_->SetGetUTXOsMethod(
+                    [this]( const std::string &address ) -> outcome::result<std::vector<std::string>>
+                    {
+                        std::vector<std::string> results;
+                        auto                     utxos = utxo_manager_.GetUTXOs( address );
+                        results.reserve( utxos.size() );
+
+                        for ( const auto &utxo : utxos )
+                        {
+                            results.push_back( utxo.GetTxID().toReadableString() );
+                        }
+                        return results;
+                    } );
+
                 transaction_manager_ = TransactionManager::New( tx_globaldb_,
                                                                 io_,
                                                                 utxo_manager_,

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -364,6 +364,7 @@ namespace sgns
                                     strong->node_logger_->error( "Error starting blockchain: {}",
                                                                  result.error().message() );
                                     strong->node_logger_->info( "Scheduling blockchain retry after failure" );
+                                    strong->account_->RequestHeads({std::string(blockchain::ValidatorRegistry::ValidatorTopic())});
                                     strong->ScheduleBlockchainRetry();
                                     return;
                                 }

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -384,7 +384,22 @@ namespace sgns
                                     strong->blockchain_->SetFullNodeMode();
                                 }
 
-                                strong->StateTransition( NodeState::INITIALIZING_TRANSACTIONS );
+                                // Move transaction initialization off the AccountMessenger worker thread.
+                                boost::asio::post( *strong->io_, [weak_self]()
+                                {
+                                    if ( auto strong = weak_self.lock() )
+                                    {
+                                        auto current_state = strong->state_.load();
+                                        if ( current_state != NodeState::INITIALIZING_BLOCKCHAIN )
+                                        {
+                                            strong->node_logger_->debug(
+                                                "Skipping transaction initialization, unexpected state: {}",
+                                                NodeStateToString( current_state ) );
+                                            return;
+                                        }
+                                        strong->StateTransition( NodeState::INITIALIZING_TRANSACTIONS );
+                                    }
+                                } );
                             }
                         } );
                 }
@@ -506,8 +521,8 @@ namespace sgns
         auto loggerUPNP           = ConfigureLogger( "UPNP", logdir, spdlog::level::err );
         auto loggerProcessingNode = ConfigureLogger( "ProcessingNode", logdir, spdlog::level::err );
         auto loggerGossipPubsub   = ConfigureLogger( "GossipPubSub", logdir, spdlog::level::err );
-        auto loggerAccountMessenger = ConfigureLogger( "AccountMessenger", logdir, spdlog::level::err );
-        auto loggerGeniusAccount    = ConfigureLogger( "GeniusAccount", logdir, spdlog::level::err );
+        auto loggerAccountMessenger = ConfigureLogger( "AccountMessenger", logdir, spdlog::level::debug );
+        auto loggerGeniusAccount    = ConfigureLogger( "GeniusAccount", logdir, spdlog::level::debug );
         auto loggerKeyPair          = ConfigureLogger( "KeyPairFileStorage", logdir, spdlog::level::err );
         auto loggerBlockchain       = ConfigureLogger( "Blockchain", logdir, spdlog::level::trace );
         auto loggerValidator        = ConfigureLogger( "ValidatorRegistry", logdir, spdlog::level::debug );

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -287,7 +287,7 @@ namespace sgns
                     node_logger_->error( "GlobalDB initialization error" );
                     return;
                 }
-                account_->ConfigureMessengerHandlers( tx_globaldb_ );
+                account_->ConfigureDatabaseDependencies( tx_globaldb_ );
                 tx_globaldb_->AddListenTopic( processing_channel_topic_ );
                 StateTransition( NodeState::INITIALIZING_PROCESSING );
                 break;
@@ -410,39 +410,12 @@ namespace sgns
 
             case NodeState::INITIALIZING_TRANSACTIONS:
             {
-                account_->SetGetUTXOsMethod(
-                    [this]( const std::string &address ) -> outcome::result<std::vector<std::string>>
-                    {
-                        std::vector<std::string> results;
-                        auto                     utxos = utxo_manager_.GetUTXOs( address );
-                        results.reserve( utxos.size() );
-
-                        for ( const auto &utxo : utxos )
-                        {
-                            results.push_back( utxo.GetTxID().toReadableString() );
-                        }
-                        return results;
-                    } );
-
                 transaction_manager_ = TransactionManager::New( tx_globaldb_,
                                                                 io_,
                                                                 utxo_manager_,
                                                                 account_,
                                                                 std::make_shared<crypto::HasherImpl>(),
                                                                 is_full_node_ );
-
-                account_->SetNonceStore( tx_globaldb_->GetDataStore() );
-
-                account_->SetGetTransactionCIDMethod(
-                    [weak_tm = std::weak_ptr<TransactionManager>( transaction_manager_ )]( const std::string &tx_hash )
-                        -> outcome::result<std::string>
-                    {
-                        if ( auto tm = weak_tm.lock() )
-                        {
-                            return tm->GetTransactionCID( tx_hash );
-                        }
-                        return outcome::failure( std::errc::owner_dead );
-                    } );
 
                 transaction_manager_->RegisterStateChangeCallback(
                     [weak_self = weak_from_this()]( TransactionManager::State old_state,

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -475,7 +475,7 @@ namespace sgns
         // Debug mode
         node_logger_              = ConfigureLogger( "SuperGeniusNode", logdir, spdlog::level::debug );
         auto loggerGeniusNode     = ConfigureLogger( "GeniusNode", logdir, spdlog::level::debug );
-        auto loggerGlobalDB       = ConfigureLogger( "GlobalDB", logdir, spdlog::level::err );
+        auto loggerGlobalDB       = ConfigureLogger( "GlobalDB", logdir, spdlog::level::debug );
         auto loggerDAGSyncer      = ConfigureLogger( "GraphsyncDAGSyncer", logdir, spdlog::level::err );
         auto loggerGraphsync      = ConfigureLogger( "graphsync", logdir, spdlog::level::err );
         auto loggerBroadcaster    = ConfigureLogger( "PubSubBroadcasterExt", logdir, spdlog::level::err );

--- a/src/account/Migration3_4_0To3_5_0.cpp
+++ b/src/account/Migration3_4_0To3_5_0.cpp
@@ -137,7 +137,8 @@ namespace sgns
                         if ( result.has_error() )
                         {
                             strong->logger_->error( "Error starting blockchain: {}", result.error().message() );
-                            strong->account_->RequestHeads({std::string(sgns::blockchain::ValidatorRegistry::ValidatorTopic())});
+                            strong->account_->RequestHeads(
+                                { std::string( sgns::blockchain::ValidatorRegistry::ValidatorTopic() ) } );
                             strong->blockchain_status_.store( Status::ST_ERROR );
                             return;
                         }
@@ -233,7 +234,7 @@ namespace sgns
             return outcome::failure( MigrationManager::Error::BLOCKCHAIN_INIT_FAILED );
         }
 
-        auto                  crdt_transaction_ = db_3_5_0_->BeginTransaction();
+        auto                            crdt_transaction_ = db_3_5_0_->BeginTransaction();
         std::unordered_set<std::string> topics_;
 
         topics_.emplace( std::string( TransactionManager::GNUS_FULL_NODES_TOPIC ) );
@@ -481,6 +482,7 @@ namespace sgns
 
     outcome::result<void> Migration3_4_0To3_5_0::ShutDown()
     {
+        account_->DeconfigureDatabaseDependencies();
         db_3_4_0_.reset();
         db_3_5_0_.reset();
         blockchain_.reset();

--- a/src/account/Migration3_4_0To3_5_0.cpp
+++ b/src/account/Migration3_4_0To3_5_0.cpp
@@ -119,7 +119,7 @@ namespace sgns
 
         logger_->info( "Starting migration from {} to {}", FromVersion(), ToVersion() );
 
-        account_->ConfigureMessengerHandlers( db_3_5_0_ );
+        account_->ConfigureDatabaseDependencies( db_3_5_0_ );
 
         db_3_5_0_->Start();
         //init blockchain

--- a/src/account/Migration3_4_0To3_5_0.cpp
+++ b/src/account/Migration3_4_0To3_5_0.cpp
@@ -13,9 +13,11 @@
 #include "account/TransactionManager.hpp"
 #include "account/MigrationManager.hpp"
 #include "account/TransferTransaction.hpp"
+#include "blockchain/ValidatorRegistry.hpp"
 
 namespace sgns
 {
+
     namespace
     {
         std::string BuildLegacyTransactionPath_3_5_0( const IGeniusTransactions &tx )
@@ -135,6 +137,7 @@ namespace sgns
                         if ( result.has_error() )
                         {
                             strong->logger_->error( "Error starting blockchain: {}", result.error().message() );
+                            strong->account_->RequestHeads({std::string(sgns::blockchain::ValidatorRegistry::ValidatorTopic())});
                             strong->blockchain_status_.store( Status::ST_ERROR );
                             return;
                         }

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -98,6 +98,35 @@ namespace sgns
                 } );
         }
 
+        instance->account_m->SetGetUTXOsMethod(
+            [weak_ptr( std::weak_ptr<TransactionManager>( instance ) )](
+                const std::string &address ) -> outcome::result<std::vector<std::string>>
+            {
+                if ( auto strong = weak_ptr.lock() )
+                {
+                    std::vector<std::string> results;
+                    auto                     utxos = strong->utxo_manager_.GetUTXOs( address );
+                    results.reserve( utxos.size() );
+
+                    for ( const auto &utxo : utxos )
+                    {
+                        results.push_back( utxo.GetTxID().toReadableString() );
+                    }
+                    return results;
+                }
+                return outcome::failure( std::errc::owner_dead );
+            } );
+        instance->account_m->SetGetTransactionCIDMethod(
+            [weak_ptr( std::weak_ptr<TransactionManager>( instance ) )](
+                const std::string &tx_hash ) -> outcome::result<std::string>
+            {
+                if ( auto strong = weak_ptr.lock() )
+                {
+                    return strong->GetTransactionCID( tx_hash );
+                }
+                return outcome::failure( std::errc::owner_dead );
+            } );
+
         return instance;
     }
 
@@ -1549,7 +1578,9 @@ namespace sgns
         auto utxo_result = utxo_manager_.LoadUTXOs( globaldb_m->GetDataStore() );
         if ( utxo_result.has_error() )
         {
-            m_logger->error( "[{} - full: {}] Failed to load UTXOs from storage", account_m->GetAddress().substr( 0, 8 ), full_node_m );
+            m_logger->error( "[{} - full: {}] Failed to load UTXOs from storage",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m );
         }
 
         const bool has_local_utxos    = utxo_result.has_value() && utxo_result.value();
@@ -1558,7 +1589,9 @@ namespace sgns
         std::unordered_set<std::string> network_hashes;
         bool                            has_network_utxos = false;
 
-        m_logger->debug( "[{} - full: {}] Requesting UTXOs from network during init", account_m->GetAddress().substr( 0, 8 ), full_node_m );
+        m_logger->debug( "[{} - full: {}] Requesting UTXOs from network during init",
+                         account_m->GetAddress().substr( 0, 8 ),
+                         full_node_m );
         auto network_utxos = account_m->RequestUTXOs( 8000, account_m->GetAddress() );
         if ( network_utxos.has_value() && !network_utxos.value().empty() )
         {
@@ -1578,7 +1611,9 @@ namespace sgns
 
         if ( !has_local_utxos && !has_network_utxos )
         {
-            m_logger->info( "[{} - full: {}] No local or network UTXOs found, querying transactions to mount UTXOs", account_m->GetAddress().substr( 0, 8 ), full_node_m );
+            m_logger->info( "[{} - full: {}] No local or network UTXOs found, querying transactions to mount UTXOs",
+                            account_m->GetAddress().substr( 0, 8 ),
+                            full_node_m );
             QueryTransactions();
             return;
         }
@@ -1672,12 +1707,12 @@ namespace sgns
 
     void TransactionManager::InitTransactions()
     {
-        size_t missing_count = 0;
+        size_t                          missing_count = 0;
         std::unordered_set<std::string> missing_tx_hashes_copy;
         {
             std::lock_guard missing_lock( missing_tx_mutex_ );
             missing_tx_hashes_copy = missing_tx_hashes_;
-            missing_count = missing_tx_hashes_.size();
+            missing_count          = missing_tx_hashes_.size();
         }
 
         if ( missing_count == 0 )
@@ -1691,13 +1726,13 @@ namespace sgns
                         full_node_m,
                         missing_count );
 
-        for (const auto &tx_hash : missing_tx_hashes_copy )
+        for ( const auto &tx_hash : missing_tx_hashes_copy )
         {
             m_logger->debug( "[{} - full: {}] Requesting transaction with hash {}",
                              account_m->GetAddress().substr( 0, 8 ),
                              full_node_m,
                              tx_hash );
-            auto request_result = account_m->RequestTransaction( 5000,tx_hash );
+            auto request_result = account_m->RequestTransaction( 5000, tx_hash );
             if ( request_result.has_error() )
             {
                 m_logger->error( "[{} - full: {}] Failed to request transaction with hash {}",

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -8,6 +8,7 @@
 
 #include <utility>
 #include <thread>
+#include <system_error>
 
 #include <boost/asio/post.hpp>
 #include <openssl/err.h>
@@ -80,7 +81,7 @@ namespace sgns
                 {
                     if ( auto strong = weak_ptr.lock() )
                     {
-                        strong->NewElementCallback( std::move( new_data ) );
+                        strong->NewElementCallback( std::move( new_data ), cid );
                     }
                 } );
             (void)instance->globaldb_m->RegisterDeletedElementCallback(
@@ -2470,6 +2471,7 @@ namespace sgns
                              key );
             return outcome::failure( boost::system::error_code{} );
         }
+
         m_logger->debug( "[{} - full: {}] Checking if we already have this transaction {}",
                          account_m->GetAddress().substr( 0, 8 ),
                          full_node_m,
@@ -2541,6 +2543,39 @@ namespace sgns
         }
     }
 
+    outcome::result<void> TransactionManager::StoreTransactionCID( const std::string &key,
+                                                                   const std::string &cid )
+    {
+        if ( cid.empty() )
+        {
+            return outcome::success();
+        }
+
+        auto datastore = globaldb_m ? globaldb_m->GetDataStore() : nullptr;
+        if ( !datastore )
+        {
+            m_logger->error( "[{} - full: {}] RocksDB datastore unavailable, cannot store CID for tx {}",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m,
+                             key );
+            return outcome::failure( std::errc::bad_file_descriptor );
+        }
+
+        crdt::GlobalDB::Buffer key_buffer;
+        key_buffer.put( key );
+
+        crdt::GlobalDB::Buffer value_buffer;
+        value_buffer.put( cid );
+
+        auto put_result = datastore->put( key_buffer, value_buffer );
+        if ( put_result.has_error() )
+        {
+            return outcome::failure( put_result.error() );
+        }
+
+        return outcome::success();
+    }
+
     void TransactionManager::ProcessNewData( crdt::CRDTCallbackManager::NewDataPair new_data )
     {
         m_logger->debug( "[{} - full: {}] Processing new data with key {}",
@@ -2573,17 +2608,28 @@ namespace sgns
         }
     }
 
-    void TransactionManager::NewElementCallback( crdt::CRDTCallbackManager::NewDataPair new_data )
+    void TransactionManager::NewElementCallback( crdt::CRDTCallbackManager::NewDataPair new_data, std::string cid )
     {
+        auto store_cid_res = StoreTransactionCID( new_data.first, cid );
+        if ( store_cid_res.has_error() )
+        {
+            m_logger->error( "[{} - full: {}] Failed to store CID for key {}: {}",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m,
+                             new_data.first,
+                             store_cid_res.error().message() );
+        }
+
+        auto key = new_data.first;
         {
             std::lock_guard queue_lock( new_data_queue_mutex_ );
-            new_data_queue_.push( new_data );
+            new_data_queue_.push( std::move( new_data ) );
         }
 
         m_logger->debug( "[{} - full: {}] CRDT new data queued, {} - (queue size: {})",
                          account_m->GetAddress().substr( 0, 8 ),
                          full_node_m,
-                         new_data.first,
+                         key,
                          new_data_queue_.size() );
 
         // Notify the condition variable to wake up the main loop

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -173,65 +173,7 @@ namespace sgns
             return;
         }
 
-        auto utxo_result = utxo_manager_.LoadUTXOs( globaldb_m->GetDataStore() );
-        if ( utxo_result.has_error() )
-        {
-            m_logger->error( "Failed to load UTXOs from storage" );
-        }
-        if ( utxo_result.has_error() || !utxo_result.value() )
-        {
-            m_logger->info( "Loading transactions to mount UTXOs" );
-            QueryTransactions();
-        }
-        else
-        {
-            auto utxo_map           = utxo_manager_.GetAllUTXOs();
-            auto monitored_networks = GetMonitoredNetworkIDs();
-
-            for ( const auto &[address, utxo_data_vector] : utxo_map )
-            {
-                m_logger->debug( "[{} - full: {}] Loaded {} UTXOs for address {}",
-                                 account_m->GetAddress().substr( 0, 8 ),
-                                 full_node_m,
-                                 utxo_data_vector.size(),
-                                 address.substr( 0, 8 ) );
-                for ( auto &utxo_data : utxo_data_vector )
-                {
-                    auto &[utxo_state, utxo] = utxo_data;
-                    m_logger->debug( "[{} - full: {}] UTXO - state: {}, tx_hash: {}, index: {}, amount: {}",
-                                     account_m->GetAddress().substr( 0, 8 ),
-                                     full_node_m,
-                                     static_cast<uint8_t>( utxo_state ),
-                                     utxo.GetTxID().toReadableString(),
-                                     utxo.GetOutputIdx(),
-                                     utxo.GetAmount() );
-
-                    if ( utxo_state != UTXOManager::UTXOState::UTXO_READY )
-                    {
-                        m_logger->debug( "[{} - full: {}] Skipping UTXO in state {} for tx {}",
-                                         account_m->GetAddress().substr( 0, 8 ),
-                                         full_node_m,
-                                         static_cast<uint8_t>( utxo_state ),
-                                         utxo.GetTxID().toReadableString() );
-                        continue;
-                    }
-
-                    for ( auto network_id : monitored_networks )
-                    {
-                        auto tx_path        = GetTransactionPath( network_id, utxo.GetTxID().toReadableString() );
-                        auto process_result = FetchAndProcessTransaction( tx_path );
-                        if ( !process_result.has_error() )
-                        {
-                            m_logger->debug( "[{} - full: {}] Processed transaction in {}",
-                                             account_m->GetAddress().substr( 0, 8 ),
-                                             full_node_m,
-                                             tx_path );
-                            break;
-                        }
-                    }
-                }
-            }
-        }
+        InitializeUTXOs();
 
         // First kick: keep self alive during the first dispatch only
         boost::asio::post( *ctx_m, [self = shared_from_this()]() { self->TickOnce(); } );
@@ -294,7 +236,7 @@ namespace sgns
         switch ( GetState() )
         {
             case State::INITIALIZING:
-                InitNonce( 8000 );
+                InitTransactions();
                 if ( GetState() == State::READY )
                 {
                     m_logger->debug( "[{} - full: {}] Transaction Manager is now READY - starting regular updates",
@@ -1136,8 +1078,14 @@ namespace sgns
     {
         {
             std::shared_lock tx_lock( tx_mutex_m );
-            if ( tx_processed_m.find( tx_key ) != tx_processed_m.end() )
+            auto             tracked = tx_processed_m.find( tx_key );
+            if ( tracked != tx_processed_m.end() )
             {
+                if ( tracked->second.tx )
+                {
+                    std::lock_guard missing_lock( missing_tx_mutex_ );
+                    missing_tx_hashes_.erase( tracked->second.tx->GetHash() );
+                }
                 m_logger->trace( "[{} - full: {}] Transaction already processed: {}",
                                  account_m->GetAddress().substr( 0, 8 ),
                                  full_node_m,
@@ -1201,6 +1149,11 @@ namespace sgns
             std::unique_lock tx_lock( tx_mutex_m );
             tx_processed_m[tx_key] = TrackedTx{ transaction, TransactionStatus::CONFIRMED, nonce };
         }
+        {
+            std::lock_guard missing_lock( missing_tx_mutex_ );
+            missing_tx_hashes_.erase( transaction->GetHash() );
+        }
+
         return outcome::success();
     }
 
@@ -1582,56 +1535,101 @@ namespace sgns
         return retval; // Will be INVALID if not seen within timeout
     }
 
-    void TransactionManager::InitNonce( uint64_t timeout_ms )
+    void TransactionManager::InitializeUTXOs()
     {
-        m_logger->debug( "[{} - full: {}] Trying to get confirmed nonce",
-                         account_m->GetAddress().substr( 0, 8 ),
-                         full_node_m );
-
-        auto nonce_result = account_m->GetConfirmedNonce( NONCE_REQUEST_TIMEOUT_MS );
-        if ( nonce_result.has_value() )
         {
-            auto network_confirmed_nonce = nonce_result.value();
-            m_logger->debug( "[{} - full: {}] Nonce from the network received {}",
+            std::lock_guard missing_lock( missing_tx_mutex_ );
+            missing_tx_hashes_.clear();
+        }
+
+        auto utxo_result = utxo_manager_.LoadUTXOs( globaldb_m->GetDataStore() );
+        if ( utxo_result.has_error() )
+        {
+            m_logger->error( "Failed to load UTXOs from storage" );
+        }
+        if ( utxo_result.has_error() || !utxo_result.value() )
+        {
+            m_logger->info( "Loading transactions to mount UTXOs" );
+            QueryTransactions();
+            return;
+        }
+
+        auto utxo_map           = utxo_manager_.GetAllUTXOs();
+        auto monitored_networks = GetMonitoredNetworkIDs();
+
+        for ( const auto &[address, utxo_data_vector] : utxo_map )
+        {
+            m_logger->debug( "[{} - full: {}] Loaded {} UTXOs for address {}",
                              account_m->GetAddress().substr( 0, 8 ),
                              full_node_m,
-                             network_confirmed_nonce );
-            bool synced = true;
-            for ( uint64_t i = 1; i <= network_confirmed_nonce; ++i )
+                             utxo_data_vector.size(),
+                             address.substr( 0, 8 ) );
+            for ( auto &utxo_data : utxo_data_vector )
             {
-                if ( auto tx = GetTransactionByNonceAndAddress( i, account_m->GetAddress() ); !tx )
+                auto &[utxo_state, utxo] = utxo_data;
+                const auto tx_hash       = utxo.GetTxID().toReadableString();
+                m_logger->debug( "[{} - full: {}] UTXO - state: {}, tx_hash: {}, index: {}, amount: {}",
+                                 account_m->GetAddress().substr( 0, 8 ),
+                                 full_node_m,
+                                 static_cast<uint8_t>( utxo_state ),
+                                 tx_hash,
+                                 utxo.GetOutputIdx(),
+                                 utxo.GetAmount() );
+
+                if ( utxo_state != UTXOManager::UTXOState::UTXO_READY )
                 {
-                    synced = false;
-                    m_logger->debug( "[{} - full: {}] Missing transaction with nonce {}",
+                    m_logger->debug( "[{} - full: {}] Skipping UTXO in state {} for tx {}",
                                      account_m->GetAddress().substr( 0, 8 ),
                                      full_node_m,
-                                     i );
-                    break;
+                                     static_cast<uint8_t>( utxo_state ),
+                                     tx_hash );
+                    continue;
+                }
+
+                bool processed = false;
+                for ( auto network_id : monitored_networks )
+                {
+                    auto tx_path        = GetTransactionPath( network_id, tx_hash );
+                    auto process_result = FetchAndProcessTransaction( tx_path );
+                    if ( !process_result.has_error() )
+                    {
+                        m_logger->debug( "[{} - full: {}] Processed transaction in {}",
+                                         account_m->GetAddress().substr( 0, 8 ),
+                                         full_node_m,
+                                         tx_path );
+                        processed = true;
+                        break;
+                    }
+                }
+
+                if ( !processed )
+                {
+                    std::lock_guard missing_lock( missing_tx_mutex_ );
+                    missing_tx_hashes_.insert( tx_hash );
                 }
             }
-            if ( synced )
-            {
-                ChangeState( State::READY );
-            }
-            else
-            {
-                // We're missing transactions - request heads to help sync faster
-                uint64_t gap = network_confirmed_nonce - account_m->GetProposedNonce() + 1;
-                m_logger->info( "[{} - full: {}] Missing transactions during init, gap: {}",
-                                account_m->GetAddress().substr( 0, 8 ),
-                                full_node_m,
-                                gap );
-                RequestRelevantHeads();
-            }
         }
-        else
+    }
+
+    void TransactionManager::InitTransactions()
+    {
+        size_t missing_count = 0;
         {
-            //TODO - Have the full node respond it doesn't have it to check for connectivity
-            m_logger->debug( "[{} - full: {}] No node from the network, assume we are updated",
-                             account_m->GetAddress().substr( 0, 8 ),
-                             full_node_m );
-            ChangeState( State::READY );
+            std::lock_guard missing_lock( missing_tx_mutex_ );
+            missing_count = missing_tx_hashes_.size();
         }
+
+        if ( missing_count == 0 )
+        {
+            ChangeState( State::READY );
+            return;
+        }
+
+        m_logger->info( "[{} - full: {}] Missing {} transactions during init",
+                        account_m->GetAddress().substr( 0, 8 ),
+                        full_node_m,
+                        missing_count );
+        RequestRelevantHeads();
     }
 
     void TransactionManager::SyncNonce()

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -1723,6 +1723,8 @@ namespace sgns
             }
             return;
         }
+        // TODO - Remove this once we remove the passive heads processing or we want transactions we are not subscribed here
+        return;
 
         m_logger->info( "[{} - full: {}] Missing {} transactions during init",
                         account_m->GetAddress().substr( 0, 8 ),

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -1717,7 +1717,10 @@ namespace sgns
 
         if ( missing_count == 0 )
         {
-            ChangeState( State::READY );
+            if ( CheckNonce() )
+            {
+                ChangeState( State::READY );
+            }
             return;
         }
 
@@ -1726,13 +1729,26 @@ namespace sgns
                         full_node_m,
                         missing_count );
 
+        auto now = std::chrono::steady_clock::now();
+        if ( last_init_tx_request_time_ != std::chrono::steady_clock::time_point{} &&
+             now - last_init_tx_request_time_ < std::chrono::milliseconds( k_init_tx_request_cooldown_ms ) )
+        {
+            m_logger->debug( "[{} - full: {}] Skipping tx requests (init cooldown)",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m );
+            return;
+        }
+        last_init_tx_request_time_ = now;
+
+        const auto request_timeout = std::chrono::milliseconds( k_init_tx_request_cooldown_ms );
         for ( const auto &tx_hash : missing_tx_hashes_copy )
         {
-            m_logger->debug( "[{} - full: {}] Requesting transaction with hash {}",
+            m_logger->debug( "[{} - full: {}] Requesting transaction with hash {} (this: {})",
                              account_m->GetAddress().substr( 0, 8 ),
                              full_node_m,
-                             tx_hash );
-            auto request_result = account_m->RequestTransaction( 5000, tx_hash );
+                             tx_hash,
+                             reinterpret_cast<uint64_t>( this ) );
+            auto request_result = account_m->RequestTransaction( request_timeout.count(), tx_hash );
             if ( request_result.has_error() )
             {
                 m_logger->error( "[{} - full: {}] Failed to request transaction with hash {}",
@@ -1740,7 +1756,76 @@ namespace sgns
                                  full_node_m,
                                  tx_hash );
             }
+            else
+            {
+                m_logger->debug( "[{} - full: {}] Successfully requested transaction with hash {}",
+                                 account_m->GetAddress().substr( 0, 8 ),
+                                 full_node_m,
+                                 tx_hash );
+            }
         }
+    }
+
+    bool TransactionManager::CheckNonce() const
+    {
+        m_logger->debug( "[{} - full: {}] Checking if my local confirmed nonce is in sync with the network",
+                         account_m->GetAddress().substr( 0, 8 ),
+                         full_node_m );
+
+        auto nonce_from_network_result = account_m->FetchNetworkNonce( NONCE_REQUEST_TIMEOUT_MS );
+        if ( nonce_from_network_result.has_error() )
+        {
+            m_logger->error( "[{} - full: {}] Failed to fetch network nonce: {}",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m,
+                             nonce_from_network_result.error().message() );
+            if ( full_node_m )
+            {
+                m_logger->debug(
+                    "[{} - full: {}] Network nonce fetch failed, but we have a full node configured. Allowing for it to boot",
+                    account_m->GetAddress().substr( 0, 8 ),
+                    full_node_m );
+                return true;
+            }
+            return false;
+        }
+        auto maybe_nonce = nonce_from_network_result.value();
+        if ( !maybe_nonce.has_value() )
+        {
+            m_logger->error( "[{} - full: {}] Network doesn't have nonce info, trusting local nonce",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m );
+            return true;
+        }
+
+        auto network_nonce      = maybe_nonce.value();
+        auto local_nonce_result = account_m->GetPeerNonce( account_m->GetAddress() );
+        if ( local_nonce_result.has_error() )
+        {
+            m_logger->debug( "[{} - full: {}] No local nonce found. Network nonce exists: {}",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m,
+                             network_nonce );
+            return false;
+        }
+        auto local_nonce = local_nonce_result.value();
+
+        if ( network_nonce > local_nonce )
+        {
+            m_logger->error( "[{} - full: {}] Nonce mismatch - Network: {}, Local: {}",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m,
+                             network_nonce,
+                             local_nonce );
+
+            return false;
+        }
+        m_logger->debug( "[{} - full: {}] Nonce is in sync with the network - Network: {}, Local: {}",
+                         account_m->GetAddress().substr( 0, 8 ),
+                         full_node_m,
+                         network_nonce,
+                         local_nonce );
+        return true;
     }
 
     void TransactionManager::SyncNonce()
@@ -2626,6 +2711,11 @@ namespace sgns
         OUTCOME_TRY( ParseTransaction( new_tx ) );
 
         const auto nonce = new_tx->dag_st.nonce();
+
+        {
+            std::lock_guard missing_lock( missing_tx_mutex_ );
+            missing_tx_hashes_.erase( new_tx->GetHash() );
+        }
 
         account_m->SetPeerConfirmedNonce( nonce, new_tx->dag_st.source_addr() );
 

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -1558,20 +1558,22 @@ namespace sgns
         std::unordered_set<std::string> network_hashes;
         bool                            has_network_utxos = false;
 
-        if ( !has_local_utxos )
+        m_logger->debug( "[{} - full: {}] Requesting UTXOs from network during init", account_m->GetAddress().substr( 0, 8 ), full_node_m );
+        auto network_utxos = account_m->RequestUTXOs( 8000, account_m->GetAddress() );
+        if ( network_utxos.has_value() && !network_utxos.value().empty() )
         {
-            m_logger->debug( "[{} - full: {}] No local UTXOs found, requesting from network", account_m->GetAddress().substr( 0, 8 ), full_node_m );
-            auto network_utxos = account_m->RequestUTXOs( 8000, account_m->GetAddress() );
-            if ( network_utxos.has_value() && !network_utxos.value().empty() )
-            {
-                network_hashes    = network_utxos.value();
-                has_network_utxos = true;
-                m_logger->debug( "[{} - full: {}] Received {} UTXOs from network", account_m->GetAddress().substr( 0, 8 ), full_node_m, network_hashes.size() );
-            }
-            else
-            {
-                m_logger->debug( "[{} - full: {}] No UTXO response received from network during init", account_m->GetAddress().substr( 0, 8 ), full_node_m );
-            }
+            network_hashes    = network_utxos.value();
+            has_network_utxos = true;
+            m_logger->debug( "[{} - full: {}] Received {} UTXOs from network",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m,
+                             network_hashes.size() );
+        }
+        else
+        {
+            m_logger->debug( "[{} - full: {}] No UTXO response received from network during init",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m );
         }
 
         if ( !has_local_utxos && !has_network_utxos )
@@ -1637,31 +1639,33 @@ namespace sgns
                     }
                 }
             }
-            return;
         }
 
-        for ( const auto &tx_hash : network_hashes )
+        if ( has_network_utxos )
         {
-            bool processed = false;
-            for ( auto network_id : monitored_networks )
+            for ( const auto &tx_hash : network_hashes )
             {
-                auto tx_path        = GetTransactionPath( network_id, tx_hash );
-                auto process_result = FetchAndProcessTransaction( tx_path );
-                if ( !process_result.has_error() )
+                bool processed = false;
+                for ( auto network_id : monitored_networks )
                 {
-                    m_logger->debug( "[{} - full: {}] Processed transaction in {}",
-                                     account_m->GetAddress().substr( 0, 8 ),
-                                     full_node_m,
-                                     tx_path );
-                    processed = true;
-                    break;
+                    auto tx_path        = GetTransactionPath( network_id, tx_hash );
+                    auto process_result = FetchAndProcessTransaction( tx_path );
+                    if ( !process_result.has_error() )
+                    {
+                        m_logger->debug( "[{} - full: {}] Processed transaction in {}",
+                                         account_m->GetAddress().substr( 0, 8 ),
+                                         full_node_m,
+                                         tx_path );
+                        processed = true;
+                        break;
+                    }
                 }
-            }
 
-            if ( !processed )
-            {
-                std::lock_guard missing_lock( missing_tx_mutex_ );
-                missing_tx_hashes_.insert( tx_hash );
+                if ( !processed )
+                {
+                    std::lock_guard missing_lock( missing_tx_mutex_ );
+                    missing_tx_hashes_.insert( tx_hash );
+                }
             }
         }
     }

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -149,7 +149,7 @@ namespace sgns
             return;
         }
 
-        m_logger->info( "[{} - full: {}] Initializing values by reading whole blockchain",
+        m_logger->info( "[{} - full: {}] Starting Transaction Manager",
                         account_m->GetAddress().substr( 0, 8 ),
                         full_node_m );
 
@@ -1544,11 +1544,12 @@ namespace sgns
             std::lock_guard missing_lock( missing_tx_mutex_ );
             missing_tx_hashes_.clear();
         }
+        m_logger->debug( "[{} - full: {}] Initializing UTXOs", account_m->GetAddress().substr( 0, 8 ), full_node_m );
 
         auto utxo_result = utxo_manager_.LoadUTXOs( globaldb_m->GetDataStore() );
         if ( utxo_result.has_error() )
         {
-            m_logger->error( "Failed to load UTXOs from storage" );
+            m_logger->error( "[{} - full: {}] Failed to load UTXOs from storage", account_m->GetAddress().substr( 0, 8 ), full_node_m );
         }
 
         const bool has_local_utxos    = utxo_result.has_value() && utxo_result.value();
@@ -1559,21 +1560,23 @@ namespace sgns
 
         if ( !has_local_utxos )
         {
+            m_logger->debug( "[{} - full: {}] No local UTXOs found, requesting from network", account_m->GetAddress().substr( 0, 8 ), full_node_m );
             auto network_utxos = account_m->RequestUTXOs( 8000, account_m->GetAddress() );
             if ( network_utxos.has_value() && !network_utxos.value().empty() )
             {
                 network_hashes    = network_utxos.value();
                 has_network_utxos = true;
+                m_logger->debug( "[{} - full: {}] Received {} UTXOs from network", account_m->GetAddress().substr( 0, 8 ), full_node_m, network_hashes.size() );
             }
             else
             {
-                m_logger->debug( "No UTXO response received from network during init" );
+                m_logger->debug( "[{} - full: {}] No UTXO response received from network during init", account_m->GetAddress().substr( 0, 8 ), full_node_m );
             }
         }
 
         if ( !has_local_utxos && !has_network_utxos )
         {
-            m_logger->info( "Loading transactions to mount UTXOs" );
+            m_logger->info( "[{} - full: {}] No local or network UTXOs found, querying transactions to mount UTXOs", account_m->GetAddress().substr( 0, 8 ), full_node_m );
             QueryTransactions();
             return;
         }
@@ -1666,8 +1669,10 @@ namespace sgns
     void TransactionManager::InitTransactions()
     {
         size_t missing_count = 0;
+        std::unordered_set<std::string> missing_tx_hashes_copy;
         {
             std::lock_guard missing_lock( missing_tx_mutex_ );
+            missing_tx_hashes_copy = missing_tx_hashes_;
             missing_count = missing_tx_hashes_.size();
         }
 
@@ -1681,7 +1686,22 @@ namespace sgns
                         account_m->GetAddress().substr( 0, 8 ),
                         full_node_m,
                         missing_count );
-        RequestRelevantHeads();
+
+        for (const auto &tx_hash : missing_tx_hashes_copy )
+        {
+            m_logger->debug( "[{} - full: {}] Requesting transaction with hash {}",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m,
+                             tx_hash );
+            auto request_result = account_m->RequestTransaction( 5000,tx_hash );
+            if ( request_result.has_error() )
+            {
+                m_logger->error( "[{} - full: {}] Failed to request transaction with hash {}",
+                                 account_m->GetAddress().substr( 0, 8 ),
+                                 full_node_m,
+                                 tx_hash );
+            }
+        }
     }
 
     void TransactionManager::SyncNonce()

--- a/src/account/TransactionManager.cpp
+++ b/src/account/TransactionManager.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <thread>
 #include <system_error>
+#include <set>
+#include <unordered_set>
 
 #include <boost/asio/post.hpp>
 #include <openssl/err.h>
@@ -1548,66 +1550,115 @@ namespace sgns
         {
             m_logger->error( "Failed to load UTXOs from storage" );
         }
-        if ( utxo_result.has_error() || !utxo_result.value() )
+
+        const bool has_local_utxos    = utxo_result.has_value() && utxo_result.value();
+        auto       monitored_networks = GetMonitoredNetworkIDs();
+
+        std::unordered_set<std::string> network_hashes;
+        bool                            has_network_utxos = false;
+
+        if ( !has_local_utxos )
+        {
+            auto network_utxos = account_m->RequestUTXOs( 8000, account_m->GetAddress() );
+            if ( network_utxos.has_value() && !network_utxos.value().empty() )
+            {
+                network_hashes    = network_utxos.value();
+                has_network_utxos = true;
+            }
+            else
+            {
+                m_logger->debug( "No UTXO response received from network during init" );
+            }
+        }
+
+        if ( !has_local_utxos && !has_network_utxos )
         {
             m_logger->info( "Loading transactions to mount UTXOs" );
             QueryTransactions();
             return;
         }
 
-        auto utxo_map           = utxo_manager_.GetAllUTXOs();
-        auto monitored_networks = GetMonitoredNetworkIDs();
+        auto utxo_map = utxo_manager_.GetAllUTXOs();
 
-        for ( const auto &[address, utxo_data_vector] : utxo_map )
+        if ( has_local_utxos )
         {
-            m_logger->debug( "[{} - full: {}] Loaded {} UTXOs for address {}",
-                             account_m->GetAddress().substr( 0, 8 ),
-                             full_node_m,
-                             utxo_data_vector.size(),
-                             address.substr( 0, 8 ) );
-            for ( auto &utxo_data : utxo_data_vector )
+            for ( const auto &[address, utxo_data_vector] : utxo_map )
             {
-                auto &[utxo_state, utxo] = utxo_data;
-                const auto tx_hash       = utxo.GetTxID().toReadableString();
-                m_logger->debug( "[{} - full: {}] UTXO - state: {}, tx_hash: {}, index: {}, amount: {}",
+                m_logger->debug( "[{} - full: {}] Loaded {} UTXOs for address {}",
                                  account_m->GetAddress().substr( 0, 8 ),
                                  full_node_m,
-                                 static_cast<uint8_t>( utxo_state ),
-                                 tx_hash,
-                                 utxo.GetOutputIdx(),
-                                 utxo.GetAmount() );
-
-                if ( utxo_state != UTXOManager::UTXOState::UTXO_READY )
+                                 utxo_data_vector.size(),
+                                 address.substr( 0, 8 ) );
+                for ( auto &utxo_data : utxo_data_vector )
                 {
-                    m_logger->debug( "[{} - full: {}] Skipping UTXO in state {} for tx {}",
+                    auto &[utxo_state, utxo] = utxo_data;
+                    const auto tx_hash       = utxo.GetTxID().toReadableString();
+                    m_logger->debug( "[{} - full: {}] UTXO - state: {}, tx_hash: {}, index: {}, amount: {}",
                                      account_m->GetAddress().substr( 0, 8 ),
                                      full_node_m,
                                      static_cast<uint8_t>( utxo_state ),
-                                     tx_hash );
-                    continue;
-                }
+                                     tx_hash,
+                                     utxo.GetOutputIdx(),
+                                     utxo.GetAmount() );
 
-                bool processed = false;
-                for ( auto network_id : monitored_networks )
-                {
-                    auto tx_path        = GetTransactionPath( network_id, tx_hash );
-                    auto process_result = FetchAndProcessTransaction( tx_path );
-                    if ( !process_result.has_error() )
+                    if ( utxo_state != UTXOManager::UTXOState::UTXO_READY )
                     {
-                        m_logger->debug( "[{} - full: {}] Processed transaction in {}",
+                        m_logger->debug( "[{} - full: {}] Skipping UTXO in state {} for tx {}",
                                          account_m->GetAddress().substr( 0, 8 ),
                                          full_node_m,
-                                         tx_path );
-                        processed = true;
-                        break;
+                                         static_cast<uint8_t>( utxo_state ),
+                                         tx_hash );
+                        continue;
+                    }
+
+                    bool processed = false;
+                    for ( auto network_id : monitored_networks )
+                    {
+                        auto tx_path        = GetTransactionPath( network_id, tx_hash );
+                        auto process_result = FetchAndProcessTransaction( tx_path );
+                        if ( !process_result.has_error() )
+                        {
+                            m_logger->debug( "[{} - full: {}] Processed transaction in {}",
+                                             account_m->GetAddress().substr( 0, 8 ),
+                                             full_node_m,
+                                             tx_path );
+                            processed = true;
+                            break;
+                        }
+                    }
+
+                    if ( !processed )
+                    {
+                        std::lock_guard missing_lock( missing_tx_mutex_ );
+                        missing_tx_hashes_.insert( tx_hash );
                     }
                 }
+            }
+            return;
+        }
 
-                if ( !processed )
+        for ( const auto &tx_hash : network_hashes )
+        {
+            bool processed = false;
+            for ( auto network_id : monitored_networks )
+            {
+                auto tx_path        = GetTransactionPath( network_id, tx_hash );
+                auto process_result = FetchAndProcessTransaction( tx_path );
+                if ( !process_result.has_error() )
                 {
-                    std::lock_guard missing_lock( missing_tx_mutex_ );
-                    missing_tx_hashes_.insert( tx_hash );
+                    m_logger->debug( "[{} - full: {}] Processed transaction in {}",
+                                     account_m->GetAddress().substr( 0, 8 ),
+                                     full_node_m,
+                                     tx_path );
+                    processed = true;
+                    break;
                 }
+            }
+
+            if ( !processed )
+            {
+                std::lock_guard missing_lock( missing_tx_mutex_ );
+                missing_tx_hashes_.insert( tx_hash );
             }
         }
     }
@@ -2543,8 +2594,7 @@ namespace sgns
         }
     }
 
-    outcome::result<void> TransactionManager::StoreTransactionCID( const std::string &key,
-                                                                   const std::string &cid )
+    outcome::result<void> TransactionManager::StoreTransactionCID( const std::string &key, const std::string &cid )
     {
         if ( cid.empty() )
         {
@@ -2686,6 +2736,37 @@ namespace sgns
                 }
             }
         }
+    }
+
+    outcome::result<std::string> TransactionManager::GetTransactionCID( const std::string &tx_hash ) const
+    {
+        auto datastore = globaldb_m->GetDataStore();
+        if ( !datastore )
+        {
+            return outcome::failure( std::errc::bad_file_descriptor );
+        }
+
+        auto monitored_networks = GetMonitoredNetworkIDs();
+        for ( auto network_id : monitored_networks )
+        {
+            m_logger->debug( "[{} - full: {}] Looking for CID of tx {} in network {}",
+                             account_m->GetAddress().substr( 0, 8 ),
+                             full_node_m,
+                             tx_hash,
+                             network_id );
+            auto                   key = GetTransactionPath( network_id, tx_hash );
+            crdt::GlobalDB::Buffer key_buffer;
+
+            key_buffer.put( key );
+
+            auto value_res = datastore->get( key_buffer );
+            if ( value_res.has_value() )
+            {
+                return std::string( value_res.value().toString() );
+            }
+        }
+
+        return outcome::failure( std::errc::no_such_file_or_directory );
     }
 
     outcome::result<std::shared_ptr<IGeniusTransactions>> TransactionManager::GetConflictingTransaction(

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -340,11 +340,12 @@ namespace sgns
         outcome::result<void> RemoveTransactionFromProcessedMaps( const std::string &transaction_key,
                                                                   bool               delete_from_crdt = false );
         outcome::result<void> AddTransactionToProcessedMaps( crdt::CRDTCallbackManager::NewDataPair new_data );
+        outcome::result<void> StoreTransactionCID( const std::string &key, const std::string &cid );
 
         void ProcessDeletion( std::string deleted_key );
         void ProcessNewData( crdt::CRDTCallbackManager::NewDataPair new_data );
 
-        void NewElementCallback( crdt::CRDTCallbackManager::NewDataPair new_data );
+        void NewElementCallback( crdt::CRDTCallbackManager::NewDataPair new_data, std::string cid );
         void DeleteElementCallback( std::string deleted_key );
 
         void ChangeState( State new_state );

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <deque>
 #include <cstdint>
+#include <chrono>
 #include <unordered_map>
 #include <unordered_set>
 #include <optional>
@@ -227,6 +228,7 @@ namespace sgns
 
         void InitializeUTXOs();
         void InitTransactions();
+        bool CheckNonce() const;
         void SyncNonce();
 
         /**
@@ -299,8 +301,10 @@ namespace sgns
 
         std::chrono::steady_clock::time_point last_loop_time_;
 
-        std::mutex                        missing_tx_mutex_;
-        std::unordered_set<std::string>   missing_tx_hashes_;
+        std::mutex                            missing_tx_mutex_;
+        std::unordered_set<std::string>       missing_tx_hashes_;
+        std::chrono::steady_clock::time_point last_init_tx_request_time_{};
+        static constexpr uint64_t             k_init_tx_request_cooldown_ms = 5000;
 
         outcome::result<void> ParseTransferTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
         outcome::result<void> ParseMintTransaction( const std::shared_ptr<IGeniusTransactions> &tx );

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -44,7 +44,7 @@ namespace sgns
         static constexpr std::string_view GNUS_FULL_NODES_TOPIC        = "SuperGNUSNode.TestNet.FullNode";
         static constexpr std::string_view GNUS_FULL_NODES_TOPIC_LEGACY = "SuperGNUSNode.TestNet.FullNode.963";
         static constexpr uint64_t         NONCE_REQUEST_TIMEOUT_MS =
-            10000; ///< Unified timeout for all nonce requests (10 seconds)
+            5000; ///< Unified timeout for all nonce requests (10 seconds)
 
         /**
          * @brief       State of the Transaction Manager

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -349,6 +349,9 @@ namespace sgns
         void DeleteElementCallback( std::string deleted_key );
 
         void ChangeState( State new_state );
+
+    public:
+        outcome::result<std::string> GetTransactionCID( const std::string &tx_hash ) const;
     };
 }
 

--- a/src/account/TransactionManager.hpp
+++ b/src/account/TransactionManager.hpp
@@ -225,7 +225,8 @@ namespace sgns
         outcome::result<void> ParseTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
         outcome::result<void> RevertTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
 
-        void InitNonce( uint64_t timeout_ms );
+        void InitializeUTXOs();
+        void InitTransactions();
         void SyncNonce();
 
         /**
@@ -297,6 +298,9 @@ namespace sgns
         std::mutex                                         deleted_data_queue_mutex_; // Separate mutex for the queue
 
         std::chrono::steady_clock::time_point last_loop_time_;
+
+        std::mutex                        missing_tx_mutex_;
+        std::unordered_set<std::string>   missing_tx_hashes_;
 
         outcome::result<void> ParseTransferTransaction( const std::shared_ptr<IGeniusTransactions> &tx );
         outcome::result<void> ParseMintTransaction( const std::shared_ptr<IGeniusTransactions> &tx );

--- a/src/account/proto/SGAccountComm.proto
+++ b/src/account/proto/SGAccountComm.proto
@@ -12,6 +12,7 @@ message AccountMessage {
     SignedBlockCidRequest block_cid_request = 6;
     SignedUTXORequest utxo_request = 7;
     SignedUTXOResponse utxo_response = 8;
+    SignedTransactionRequest transaction_request = 9;
   }
 }
 
@@ -62,6 +63,18 @@ message BlockCidRequest {
 
 message SignedBlockCidRequest {
   BlockCidRequest data = 1;
+  bytes signature = 2;
+}
+
+message TransactionRequest {
+  string requester_address = 1;
+  uint64 request_id = 2;
+  uint64 timestamp = 3;
+  string tx_hash = 4;
+}
+
+message SignedTransactionRequest {
+  TransactionRequest data = 1;
   bytes signature = 2;
 }
 

--- a/src/account/proto/SGAccountComm.proto
+++ b/src/account/proto/SGAccountComm.proto
@@ -10,6 +10,8 @@ message AccountMessage {
     SignedBlockResponse block_response = 4;
     SignedHeadRequest head_request = 5;
     SignedBlockCidRequest block_cid_request = 6;
+    SignedUTXORequest utxo_request = 7;
+    SignedUTXOResponse utxo_response = 8;
   }
 }
 
@@ -94,5 +96,32 @@ message HeadRequest {
 
 message SignedHeadRequest {
   HeadRequest data = 1;
+  bytes signature = 2;
+}
+
+message UTXORequest {
+  string requester_address = 1;
+  string target_address = 2;
+  uint64 request_id = 3;
+  uint64 timestamp = 4;
+}
+
+message SignedUTXORequest {
+  UTXORequest data = 1;
+  bytes signature = 2;
+}
+
+message UTXOResponse {
+  string responder_address = 1;
+  string requester_address = 2;
+  string target_address = 3;
+  uint64 request_id = 4;
+  uint64 timestamp = 5;
+  repeated string utxos = 6;
+  bool has_utxos = 7;
+}
+
+message SignedUTXOResponse {
+  UTXOResponse data = 1;
   bytes signature = 2;
 }

--- a/src/blockchain/ValidatorRegistry.cpp
+++ b/src/blockchain/ValidatorRegistry.cpp
@@ -456,6 +456,24 @@ namespace sgns::blockchain
         return outcome::failure( std::errc::no_such_file_or_directory );
     }
 
+    outcome::result<std::optional<uint64_t>> ValidatorRegistry::GetValidatorWeight(
+        const std::string &validator_id ) const
+    {
+        std::shared_lock<std::shared_mutex> lock( cache_mutex_ );
+        if ( !cache_initialized_ || !cached_registry_ )
+        {
+            return outcome::success( std::optional<uint64_t>{} );
+        }
+
+        const auto *validator = FindValidator( cached_registry_.value(), validator_id );
+        if ( !validator || validator->status() != Status::ACTIVE )
+        {
+            return outcome::success( std::optional<uint64_t>{} );
+        }
+
+        return outcome::success( std::optional<uint64_t>{ validator->weight() } );
+    }
+
     bool ValidatorRegistry::RegisterFilter()
     {
         logger_->trace( "{}: entry", __func__ );

--- a/src/blockchain/ValidatorRegistry.hpp
+++ b/src/blockchain/ValidatorRegistry.hpp
@@ -72,6 +72,7 @@ namespace sgns::blockchain
                                                               std::function<std::vector<uint8_t>( std::vector<uint8_t> )> sign );
         outcome::result<Registry>       LoadRegistry() const;
         outcome::result<RegistryUpdate> LoadRegistryUpdate() const;
+        outcome::result<std::optional<uint64_t>> GetValidatorWeight( const std::string &validator_id ) const;
         bool                            RegisterFilter();
 
         outcome::result<std::vector<uint8_t>> SerializeRegistry( const Registry &registry ) const;

--- a/src/blockchain/impl/Blockchain.cpp
+++ b/src/blockchain/impl/Blockchain.cpp
@@ -207,6 +207,17 @@ namespace sgns
                 return outcome::failure( std::errc::owner_dead );
             } );
 
+        instance->account_->SetGetValidatorWeightMethod(
+            [weak_ptr( std::weak_ptr<Blockchain>(
+                instance ) )]( const std::string &address ) -> outcome::result<std::optional<uint64_t>>
+            {
+                if ( auto strong = weak_ptr.lock() )
+                {
+                    return strong->validator_registry_->GetValidatorWeight( address );
+                }
+                return outcome::failure( std::errc::owner_dead );
+            } );
+
         instance->logger_->debug( "[{}] Block callback registered", instance->account_->GetAddress().substr( 0, 8 ) );
 
         return instance;

--- a/src/crdt/crdt_datastore.hpp
+++ b/src/crdt/crdt_datastore.hpp
@@ -451,7 +451,6 @@ namespace sgns::crdt
         std::condition_variable         rebroadcastCv_;
         std::unordered_set<std::string> topicNames_;
         mutable std::mutex              topicNamesMutex_;
-        bool                            isFullNode = false;
         std::mutex                      pendingBroadcastMutex_;
         std::unordered_set<std::string> pendingBroadcastTopics_;
 

--- a/src/crdt/globaldb/globaldb.cpp
+++ b/src/crdt/globaldb/globaldb.cpp
@@ -98,7 +98,7 @@ namespace sgns::crdt
 
     GlobalDB::~GlobalDB()
     {
-        m_logger->debug( "~GlobalDB CALLED" );
+        m_logger->debug( "~GlobalDB CALLED with count {} on {} ", m_datastore.use_count(), m_databasePath );
         if ( m_broadcaster )
         {
             m_broadcaster->Stop();
@@ -420,7 +420,7 @@ namespace sgns::crdt
             m_logger->error( "{}: CRDT datastore not initialized", __func__ );
             return outcome::failure( Error::CRDT_DATASTORE_NOT_CREATED );
         }
-        m_logger->debug( "{}: Forwarding request for {} topics", __func__ );
+        m_logger->debug( "{}: Forwarding request for topics", __func__ );
         return m_crdtDatastore->GetTopicNames();
     }
 

--- a/test/src/multiaccount/multi_account_sync.cpp
+++ b/test/src/multiaccount/multi_account_sync.cpp
@@ -343,6 +343,10 @@ TEST_F( MultiAccountTest, CRDTFilterDuplicateTx )
         transfer1_res.value(),
         std::chrono::milliseconds( INCOMING_TIMEOUT_MILLISECONDS ) );
 
+    test::assertWaitForCondition(
+        [&]() { return node_same_addr_2->GetBalance() == ( balance_node1_after_mint - 10000000000 ); },
+        std::chrono::milliseconds( 50000 ),
+        "node_same_addr_2 balance not synced" );
     test::assertWaitForCondition( [&]() { return node_same_addr_2->GetBalance() == node_same_addr_1->GetBalance(); },
                                   std::chrono::milliseconds( 50000 ),
                                   "node_same_addr_2 balance not synced" );

--- a/test/src/multiaccount/multi_account_sync.cpp
+++ b/test/src/multiaccount/multi_account_sync.cpp
@@ -149,96 +149,72 @@ TEST_F( MultiAccountTest, SyncThroughEachOther )
         [&]() { return node_full->GetTransactionManagerState() == TransactionManager::State::READY; },
         std::chrono::milliseconds( 30000 ),
         "node_full not synced" );
-    auto node_main = CreateNode( "node_multi_1",
-                                 "0xcafe",
-                                 "1.0",
-                                 TokenID::FromBytes( { 0x00 } ),
-                                 false, // not full node
-                                 false  // not processor
+    auto node_original = CreateNode( "node_multi_1",
+                                     "0xcafe",
+                                     "1.0",
+                                     TokenID::FromBytes( { 0x00 } ),
+                                     false, // not full node
+                                     false  // not processor
     );
 
-    auto node_proc1 = CreateNode( "node_multi_1",
-                                  "0xcafe",
-                                  "1.0",
-                                  TokenID::FromBytes( { 0x00 } ),
-                                  false, // not full node
-                                  true   // is processor
+    node_original->GetPubSub()->AddPeers( { node_full->GetPubSub()->GetInterfaceAddress() } );
+    test::assertWaitForCondition(
+        [&]() { return node_original->GetTransactionManagerState() == TransactionManager::State::READY; },
+        std::chrono::milliseconds( 30000 ),
+        "node_original not synced" );
+
+    auto balance_original_start = node_original->GetBalance();
+    // Mint some tokens
+    auto mint_result = node_original->MintTokens( 100,
+                                                  "",
+                                                  "",
+                                                  TokenID::FromBytes( { 0x00 } ),
+                                                  std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+    ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out on node_original";
+
+    mint_result = node_original->MintTokens( 2000,
+                                             "",
+                                             "",
+                                             TokenID::FromBytes( { 0x00 } ),
+                                             std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+    ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out on node_original";
+    mint_result = node_original->MintTokens( 30,
+                                             "",
+                                             "",
+                                             TokenID::FromBytes( { 0x00 } ),
+                                             std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+
+    ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out on node_original";
+
+    std::cout << " 3 mint transactions on original node completed, Creating duplicated node..." << std::endl;
+
+    auto node_duplicated = CreateNode( "node_multi_1",
+                                       "0xcafe",
+                                       "1.0",
+                                       TokenID::FromBytes( { 0x00 } ),
+                                       false, // not full node
+                                       true   // is processor
     );
-
-    node_main->GetPubSub()->AddPeers(
-        { node_proc1->GetPubSub()->GetInterfaceAddress(), node_full->GetPubSub()->GetInterfaceAddress() } );
-
-    node_full->GetPubSub()->AddPeers( { node_proc1->GetPubSub()->GetInterfaceAddress() } );
+    node_duplicated->GetPubSub()->AddPeers( { node_full->GetPubSub()->GetInterfaceAddress() } );
 
     test::assertWaitForCondition(
-        [&]() { return node_proc1->GetTransactionManagerState() == TransactionManager::State::READY; },
+        [&]() { return node_duplicated->GetTransactionManagerState() == TransactionManager::State::READY; },
         std::chrono::milliseconds( 30000 ),
-        "node_proc1 not synced" );
+        "node_duplicated not synced" );
+
+    mint_result = node_duplicated->MintTokens( 60000,
+                                               "",
+                                               "",
+                                               TokenID::FromBytes( { 0x00 } ),
+                                               std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+    ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out on node_duplicated";
+
     test::assertWaitForCondition(
-        [&]() { return node_main->GetTransactionManagerState() == TransactionManager::State::READY; },
+        [&] { return ( balance_original_start + 60000 + 2000 + 100 + 30 ) == node_duplicated->GetBalance(); },
         std::chrono::milliseconds( 30000 ),
-        "node_main not synced" );
+        "node_duplicated balance not synced" );
 
-    // Get initial state
-    auto transcount_main_start  = node_main->GetOutTransactions().size();
-    auto transcount_node1_start = node_proc1->GetOutTransactions().size();
-    auto main_balance_start     = node_main->GetBalance();
-    auto node1_balance_start    = node_proc1->GetBalance();
-
-    // Mint tokens on each node
-    auto mint_result = node_main->MintTokens( 50000000000,
-                                              "",
-                                              "",
-                                              TokenID::FromBytes( { 0x00 } ),
-                                              std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
-    ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out on node_main";
-
-    std::cout << "Mint transaction on main node completed, waiting for sync..." << std::endl;
-
-    test::assertWaitForCondition( [&] { return node_proc1->GetBalance() == 50000000000; },
-                                  std::chrono::milliseconds( 30000 ),
-                                  "node_proc1 balance not synced" );
-
-    //TODO - this is not working at the moment
-    //auto mint_received = node_proc1->WaitForTransactionOutgoing(
-    //    mint_result.value().first,
-    //    std::chrono::milliseconds( INCOMING_TIMEOUT_MILLISECONDS ) );
-    //EXPECT_EQ( mint_received, TransactionManager::TransactionStatus::CONFIRMED );
-    mint_result = node_proc1->MintTokens( 50000000000,
-                                          "",
-                                          "",
-                                          TokenID::FromBytes( { 0x00 } ),
-                                          std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
-    ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out on node_proc1";
-
-    test::assertWaitForCondition( [&] { return node_main->GetBalance() == 100000000000; },
-                                  std::chrono::milliseconds( 30000 ),
-                                  "node_main balance not synced" );
-    //TODO - this is not working at the moment
-    //auto mint_received2 = node_main->WaitForTransactionOutgoing(
-    //    mint_result.value().first,
-    //    std::chrono::milliseconds( INCOMING_TIMEOUT_MILLISECONDS ) );
-
-    // Get final state
-    auto transcount_main  = node_main->GetOutTransactions().size();
-    auto transcount_node1 = node_proc1->GetOutTransactions().size();
-
-    std::cout << "Count main: " << transcount_main << std::endl;
-    std::cout << "Count node1: " << transcount_node1 << std::endl;
-
-    double balance_main  = node_main->GetBalance();
-    double balance_node1 = node_proc1->GetBalance();
-
-    std::cout << "Balance main: " << balance_main << std::endl;
-    std::cout << "Balance node1: " << balance_node1 << std::endl;
-
-    // Verify results
-    ASSERT_EQ( transcount_main, transcount_main_start + 2 );
-    ASSERT_EQ( transcount_node1, transcount_node1_start + 2 );
-    ASSERT_EQ( balance_main, main_balance_start + 100000000000 );
-    ASSERT_EQ( balance_node1, node1_balance_start + 100000000000 );
-
-    // Nodes will be automatically destroyed when they go out of scope
+    ASSERT_EQ( node_duplicated->GetBalance(), node_original->GetBalance() );
 }
 
 TEST_F( MultiAccountTest, CRDTFilterDuplicateTx )
@@ -371,7 +347,7 @@ TEST_F( MultiAccountTest, CRDTFilterDuplicateTx )
                                   std::chrono::milliseconds( 50000 ),
                                   "node_same_addr_2 balance not synced" );
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
 
     // Get final balances after CRDT resolution
     auto balance_node1_final = node_same_addr_1->GetBalance();

--- a/test/src/processing_nodes/processing_nodes_test.cpp
+++ b/test/src/processing_nodes/processing_nodes_test.cpp
@@ -472,6 +472,14 @@ TEST_F( ProcessingNodesTest, PostProcessing )
     auto        procmgr   = sgns::sgprocessing::ProcessingManager::Create( json_data );
     auto        cost      = node_main->GetProcessCost( procmgr.value() );
 
+    auto mint_result = node_main->MintTokens( 50000000000,
+                                              "",
+                                              "",
+                                              sgns::TokenID::FromBytes( { 0x00 } ),
+                                              std::chrono::milliseconds( OUTGOING_TIMEOUT_MILLISECONDS ) );
+
+    ASSERT_TRUE( mint_result.has_value() ) << "Mint transaction failed or timed out";
+
     std::replace( bin_path.begin(), bin_path.end(), '\\', '/' );
     boost::replace_all( json_data, "[basepath]", bin_path );
     std::cout << "Json Data: " << json_data << std::endl;


### PR DESCRIPTION
The current state of the develop branch fails on already initialized databases that have UTXOs, because the parsing is not done in all transactions and the nonce grabbing checks if the transaction is in the in-memory structure, which not all of them will be. So these changes were implemented:

- InitNonce removed and replaced with InitTransactions:
    - Doesn't check on nonces from the network and instead check if we have all the UTXOs we need to start transactioning
    - Relies on local UTXOs. If no local UTXOs found, it's gonna request from the network.
    - An improvement should be to fetch the UTXOs form the network regardless and try to see which one is more updated.
- Request UTXOs on pubsub
    - Pubsub messages that request a list of UTXOs from other peers.
    - If we are outdated, we could grab the most trusted information from other peers (taking into account validators and soft consensus)
    - Done on initialization instead of requesting for nonces.
- Request Transactions on pubsub
    - We can request a transaction by hash on pubsub.
    - The grabbing of the content is still done by graphsync.
    - This is means to avoid having to go through all the CRDT graph (although this wasn't removed yet)
    - In order to allow this, CID info is being stored on local rocksdb as a look up table for transactions.
- Nonces stores in rocksdb.
    - With not all transactions being parsed anymore we need the latest nonce stored somewhere.
    - We record the confirmed nonce peers we receive data from to avoid re-parsing everything.
 
