### PR TITLE
fix(tests): use in-memory secure storage to eliminate keychain prompts

### DIFF
--- a/src/account/CMakeLists.txt
+++ b/src/account/CMakeLists.txt
@@ -53,8 +53,8 @@ if(MSVC)
 elseif(ANDROID_ABI STREQUAL "armeabi-v7a")
     target_compile_options(sgns_genius_account PUBLIC -fconstexpr-steps=10000000)
 endif()
-add_library(genius_node
-    IGeniusTransactions.cpp
+set(GENIUS_NODE_SOURCES
+    GeniusTransaction.cpp
     TransferTransaction.cpp
     MintTransaction.cpp
     MintTransactionV2.cpp
@@ -64,7 +64,6 @@ add_library(genius_node
     InputValidators.cpp
     TransactionManager.cpp
     TokenAmount.cpp
-    BridgeConsensusAdapter.cpp
     MigrationManager.cpp
     Migration0_2_0To1_0_0.cpp
     Migration1_0_0To3_4_0.cpp
@@ -72,9 +71,11 @@ add_library(genius_node
     Migration3_5_0To3_6_0.cpp
     Migration3_6_0To3_7_0.cpp
     GeniusNode.cpp
+    ChainRpcEndpointProvider.cpp
+    BridgeRelayer.cpp
 )
 
-target_link_libraries(genius_node
+set(GENIUS_NODE_LIBS
     PUBLIC
     Boost::headers
     ProofSystem
@@ -85,7 +86,7 @@ target_link_libraries(genius_node
     gnus_upnp
     sgns_genius_account
     blockchain_genesis
-	ProcessingBase
+    ProcessingBase
     evmrelay
     PRIVATE
     component_factory
@@ -114,6 +115,15 @@ target_link_libraries(genius_node
     transfer_proof
     processing_proof
 )
+
+# Production library — uses OS keychain (Apple/Windows/Linux secure storage)
+add_library(genius_node ${GENIUS_NODE_SOURCES})
+target_link_libraries(genius_node ${GENIUS_NODE_LIBS})
+
+# Test library — uses in-memory secure storage (no keychain prompts)
+add_library(genius_node_test ${GENIUS_NODE_SOURCES})
+target_link_libraries(genius_node_test ${GENIUS_NODE_LIBS})
+target_compile_definitions(genius_node_test PUBLIC SGNS_USE_MEMORY_SECURE_STORAGE)
 
 add_dependencies(genius_node rlp)
 

--- a/src/account/CMakeLists.txt
+++ b/src/account/CMakeLists.txt
@@ -53,8 +53,9 @@ if(MSVC)
 elseif(ANDROID_ABI STREQUAL "armeabi-v7a")
     target_compile_options(sgns_genius_account PUBLIC -fconstexpr-steps=10000000)
 endif()
+
 set(GENIUS_NODE_SOURCES
-    GeniusTransaction.cpp
+    IGeniusTransactions.cpp
     TransferTransaction.cpp
     MintTransaction.cpp
     MintTransactionV2.cpp
@@ -64,6 +65,7 @@ set(GENIUS_NODE_SOURCES
     InputValidators.cpp
     TransactionManager.cpp
     TokenAmount.cpp
+    BridgeConsensusAdapter.cpp
     MigrationManager.cpp
     Migration0_2_0To1_0_0.cpp
     Migration1_0_0To3_4_0.cpp
@@ -71,8 +73,6 @@ set(GENIUS_NODE_SOURCES
     Migration3_5_0To3_6_0.cpp
     Migration3_6_0To3_7_0.cpp
     GeniusNode.cpp
-    ChainRpcEndpointProvider.cpp
-    BridgeRelayer.cpp
 )
 
 set(GENIUS_NODE_LIBS
@@ -120,10 +120,9 @@ set(GENIUS_NODE_LIBS
 add_library(genius_node ${GENIUS_NODE_SOURCES})
 target_link_libraries(genius_node ${GENIUS_NODE_LIBS})
 
-# Test library — uses in-memory secure storage (no keychain prompts)
+# Test library — uses in-memory secure storage via DI factory (no keychain prompts)
 add_library(genius_node_test ${GENIUS_NODE_SOURCES})
 target_link_libraries(genius_node_test ${GENIUS_NODE_LIBS})
-target_compile_definitions(genius_node_test PUBLIC SGNS_USE_MEMORY_SECURE_STORAGE)
 
 add_dependencies(genius_node rlp)
 
@@ -134,6 +133,6 @@ elseif(ANDROID_ABI STREQUAL "armeabi-v7a")
     target_compile_options(genius_node PUBLIC -fconstexpr-steps=10000000)
 endif()
 
-# Install both libraries
+# Install production library only
 supergenius_install(sgns_genius_account)
 supergenius_install(genius_node)

--- a/src/account/GeniusAccount.cpp
+++ b/src/account/GeniusAccount.cpp
@@ -59,12 +59,29 @@ namespace
         return boost::filesystem::canonical( boost::filesystem::absolute( base_path ) ) / FILE_NAME;
     }
 
+    /// Global factory override (null = use default SecureStorageImpl)
+    GeniusAccount::SecureStorageFactory g_storage_factory;
+
     outcome::result<std::shared_ptr<JSONBackend>> CreateSecureStorage( std::string_view public_key_hex )
     {
         BOOST_OUTCOME_TRY( std::vector<uint8_t> vec, base::unhex( public_key_hex ) );
 
-        return std::make_shared<SecureStorageImpl>( std::string( SECURE_STORAGE_PREFIX ) +
-                                                    libp2p::multi::detail::encodeBase58( vec ) );
+        const std::string identifier( std::string( SECURE_STORAGE_PREFIX ) +
+                                      libp2p::multi::detail::encodeBase58( vec ) );
+
+        if ( g_storage_factory )
+        {
+            auto storage = g_storage_factory( identifier );
+            auto backend = std::dynamic_pointer_cast<JSONBackend>( storage );
+            if ( backend )
+            {
+                return backend;
+            }
+            genius_account_logger()->error( "Custom secure storage factory did not return a JSONBackend" );
+            return outcome::failure( std::errc::invalid_argument );
+        }
+
+        return std::make_shared<SecureStorageImpl>( identifier );
     }
 
     bool IsValidPublicKey( std::string_view key )
@@ -256,6 +273,16 @@ namespace
 namespace sgns
 {
     const std::array<uint8_t, 32> GeniusAccount::ELGAMAL_PUBKEY_PREDEFINED = get_elgamal_pubkey();
+
+    void GeniusAccount::SetSecureStorageFactory( SecureStorageFactory factory )
+    {
+        g_storage_factory = std::move( factory );
+    }
+
+    const GeniusAccount::SecureStorageFactory &GeniusAccount::GetSecureStorageFactory()
+    {
+        return g_storage_factory;
+    }
 
     std::shared_ptr<GeniusAccount> GeniusAccount::CreateInstanceFromResponse( TokenID            token_id,
                                                                               StorageWithAddress response_value,

--- a/src/account/GeniusAccount.hpp
+++ b/src/account/GeniusAccount.hpp
@@ -52,6 +52,29 @@ namespace sgns
         static constexpr int64_t             NONCE_CACHE_DURATION_MS = 5000; ///< Cache nonce results for 5 seconds
 
         /**
+         * @brief   Factory function type for creating secure storage instances.
+         * @param   identifier  Storage identifier (typically base58-encoded public key).
+         * @return  Shared pointer to the created secure storage backend.
+         */
+        using SecureStorageFactory = std::function<std::shared_ptr<ISecureStorage>( const std::string &identifier )>;
+
+        /**
+         * @brief   Sets the secure storage factory used by all GeniusAccount factory methods.
+         *
+         * By default, the factory creates OS-specific secure storage (Apple Keychain,
+         * Linux secret service, etc.).  Tests can override this to inject
+         * MemorySecureStorage, eliminating keychain prompts entirely.
+         *
+         * @param   factory  Factory function; pass nullptr to restore the default.
+         */
+        static void SetSecureStorageFactory( SecureStorageFactory factory );
+
+        /**
+         * @brief   Returns the current secure storage factory (default if none set).
+         */
+        static const SecureStorageFactory &GetSecureStorageFactory();
+
+        /**
          * @brief       Factory constructor of new GeniusAccount.
          * @param[in]   token_id Token ID of the account.
          * @param[in]   eth_private_key Ethereum private key in hex format (0x...).

--- a/src/local_secure_storage/SecureStorage.hpp
+++ b/src/local_secure_storage/SecureStorage.hpp
@@ -1,6 +1,17 @@
 #pragma once
 
-#ifdef __ANDROID__
+// Compile-time override for tests: -DSGNS_USE_MEMORY_SECURE_STORAGE
+// Uses in-memory storage — no keychain prompts, no file I/O, no cleanup.
+#ifdef SGNS_USE_MEMORY_SECURE_STORAGE
+
+#include "local_secure_storage/impl/MemorySecureStorage.hpp"
+
+namespace sgns
+{
+    using SecureStorageImpl = MemorySecureStorage;
+}
+
+#elif defined( __ANDROID__ )
 
 #include "local_secure_storage/impl/Android.hpp"
 

--- a/src/local_secure_storage/impl/MemorySecureStorage.hpp
+++ b/src/local_secure_storage/impl/MemorySecureStorage.hpp
@@ -1,0 +1,66 @@
+/**
+ * @file       MemorySecureStorage.hpp
+ * @brief      In-memory JSON backend for testing — no keychain access.
+ * @date       2026-06-01
+ */
+#pragma once
+
+#include "JSONBackend.hpp"
+
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <string>
+#include <unordered_map>
+
+namespace sgns
+{
+    /**
+     * @brief In-memory JSON backend for tests. Stores data in a map — no OS
+     *        keychain access, no password prompts, no cleanup needed.
+     */
+    class MemorySecureStorage : public JSONBackend
+    {
+    public:
+        explicit MemorySecureStorage( std::string identifier ) :
+            identifier_( std::move( identifier ) )
+        {
+        }
+
+        std::string GetName() override
+        {
+            return "MemorySecureStorage";
+        }
+
+        outcome::result<rapidjson::Document> LoadJSON() const override
+        {
+            auto it = store_.find( identifier_ );
+            if ( it == store_.end() )
+            {
+                return rapidjson::Document( rapidjson::Type::kObjectType );
+            }
+
+            rapidjson::Document d;
+            d.Parse( it->second.c_str(), it->second.size() );
+            if ( d.HasParseError() )
+            {
+                return outcome::failure( std::errc::bad_message );
+            }
+            return d;
+        }
+
+        outcome::result<void> SaveJSON( rapidjson::Document document ) override
+        {
+            rapidjson::StringBuffer buffer;
+            rapidjson::Writer       writer( buffer );
+            document.Accept( writer );
+            store_[identifier_] = std::string( buffer.GetString(), buffer.GetLength() );
+            return outcome::success();
+        }
+
+    private:
+        std::string identifier_;
+        static inline std::unordered_map<std::string, std::string> store_;
+    };
+} // namespace sgns

--- a/test/src/account/CMakeLists.txt
+++ b/test/src/account/CMakeLists.txt
@@ -44,7 +44,7 @@ addtest(account_management_test
     account_management_test.cpp
 )
 
-target_link_libraries(account_management_test genius_node_test)
+target_link_libraries(account_management_test genius_node_test json_secure_storage)
 
 if(MSVC)
     target_link_options(account_management_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
@@ -58,44 +58,3 @@ else()
     )
 endif()
 
-addtest(bridge_relayer_test
-    bridge_relayer_test.cpp
-)
-
-target_link_libraries(bridge_relayer_test
-    genius_node_test
-    evmrelay
-)
-
-if(MSVC)
-    target_link_options(bridge_relayer_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
-elseif(APPLE)
-    target_link_options(bridge_relayer_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
-else()
-    target_link_options(bridge_relayer_test PUBLIC
-        "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node_test>"
-        "-Wl,--no-whole-archive"
-    )
-endif()
-
-addtest(transaction_manager_certificate_fallback_test
-    transaction_manager_certificate_fallback_test.cpp
-)
-
-target_link_libraries(transaction_manager_certificate_fallback_test
-    genius_node_test
-    base_crdt_test
-)
-
-if(MSVC)
-    target_link_options(transaction_manager_certificate_fallback_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
-elseif(APPLE)
-    target_link_options(transaction_manager_certificate_fallback_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
-else()
-    target_link_options(transaction_manager_certificate_fallback_test PUBLIC
-        "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node_test>"
-        "-Wl,--no-whole-archive"
-    )
-endif()

--- a/test/src/account/CMakeLists.txt
+++ b/test/src/account/CMakeLists.txt
@@ -3,17 +3,17 @@ addtest(token_amount_test
 )
 
 target_link_libraries(token_amount_test
-    genius_node
+    genius_node_test
 )
 
 if(MSVC)
-    target_link_options(token_amount_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(token_amount_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 elseif(APPLE)
-    target_link_options(token_amount_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(token_amount_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 else()
     target_link_options(token_amount_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()
@@ -23,19 +23,19 @@ addtest(utxo_manager_test
 )
 
 target_link_libraries(utxo_manager_test
-    genius_node
+    genius_node_test
     json_secure_storage
     base_crdt_test
 )
 
 if(MSVC)
-    target_link_options(utxo_manager_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(utxo_manager_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 elseif(APPLE)
-    target_link_options(utxo_manager_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(utxo_manager_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 else()
     target_link_options(utxo_manager_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()
@@ -44,16 +44,58 @@ addtest(account_management_test
     account_management_test.cpp
 )
 
-target_link_libraries(account_management_test genius_node)
+target_link_libraries(account_management_test genius_node_test)
 
 if(MSVC)
-    target_link_options(account_management_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(account_management_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 elseif(APPLE)
-    target_link_options(account_management_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(account_management_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 else()
     target_link_options(account_management_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
+        "-Wl,--no-whole-archive"
+    )
+endif()
+
+addtest(bridge_relayer_test
+    bridge_relayer_test.cpp
+)
+
+target_link_libraries(bridge_relayer_test
+    genius_node_test
+    evmrelay
+)
+
+if(MSVC)
+    target_link_options(bridge_relayer_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
+elseif(APPLE)
+    target_link_options(bridge_relayer_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
+else()
+    target_link_options(bridge_relayer_test PUBLIC
+        "-Wl,--whole-archive"
+        "$<TARGET_FILE:genius_node_test>"
+        "-Wl,--no-whole-archive"
+    )
+endif()
+
+addtest(transaction_manager_certificate_fallback_test
+    transaction_manager_certificate_fallback_test.cpp
+)
+
+target_link_libraries(transaction_manager_certificate_fallback_test
+    genius_node_test
+    base_crdt_test
+)
+
+if(MSVC)
+    target_link_options(transaction_manager_certificate_fallback_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
+elseif(APPLE)
+    target_link_options(transaction_manager_certificate_fallback_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
+else()
+    target_link_options(transaction_manager_certificate_fallback_test PUBLIC
+        "-Wl,--whole-archive"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()

--- a/test/src/account/account_management_test.cpp
+++ b/test/src/account/account_management_test.cpp
@@ -9,6 +9,7 @@
 #include "account/GeniusAccount.hpp"
 #include "account/GeniusNode.hpp"
 #include "account/TransactionManager.hpp"
+#include "local_secure_storage/impl/MemorySecureStorage.hpp"
 #include "testutil/wait_condition.hpp"
 #include "testutil/mint_source_hash.hpp"
 
@@ -31,6 +32,14 @@ public:
         catch ( ... ) //NOLINT(bugprone-empty-catch)
         {
         }
+
+        // Inject in-memory secure storage to avoid OS keychain prompts during tests
+        GeniusAccount::SetSecureStorageFactory(
+            []( const std::string &identifier ) -> std::shared_ptr<ISecureStorage>
+            {
+                return std::make_shared<MemorySecureStorage>( identifier );
+            } );
+
         node_ = sgns::GeniusNode::New( { "0xcafe", "0.65", "1.0", TOKEN_ID, path.generic_string() + '/' },
                                  "90bd26f57e3c243358666f32ff8321181545f4ddd8c981aceac163f26b05eaaa",
                                  false,

--- a/test/src/account_creation/CMakeLists.txt
+++ b/test/src/account_creation/CMakeLists.txt
@@ -5,18 +5,18 @@ addtest(account_creation_test
 target_include_directories(account_creation_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(account_creation_test
-    genius_node
+    genius_node_test
     json_secure_storage
 )
 
 if(MSVC)
-    target_link_options(account_creation_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(account_creation_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 elseif(APPLE)
-    target_link_options(account_creation_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(account_creation_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 else()
     target_link_options(account_creation_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()

--- a/test/src/account_creation/account_creation_test.cpp
+++ b/test/src/account_creation/account_creation_test.cpp
@@ -12,6 +12,7 @@
 
 #include "account/GeniusAccount.hpp"
 #include "account/TokenID.hpp"
+#include "local_secure_storage/impl/MemorySecureStorage.hpp"
 
 namespace fs = boost::filesystem;
 
@@ -21,6 +22,12 @@ static const TokenID TOKEN_ID = sgns::TokenID::FromBytes( { 0x00 } );
 
 TEST( AccountCreationTest, CreationWithEthereumKey )
 {
+    // Inject in-memory secure storage to avoid OS keychain prompts during tests
+    GeniusAccount::SetSecureStorageFactory(
+        []( const std::string &identifier ) -> std::shared_ptr<ISecureStorage>
+        {
+            return std::make_shared<MemorySecureStorage>( identifier );
+        } );
     const auto dir   = boost::dll::program_location().parent_path();
     const auto path1 = dir / "account1";
     const auto path2 = dir / "account2";

--- a/test/src/blockchain/CMakeLists.txt
+++ b/test/src/blockchain/CMakeLists.txt
@@ -11,14 +11,6 @@ target_link_libraries(consensus_subject_test
     rapidjson
 )
 
-addtest(bridge_consensus_adapter_test
-    bridge_consensus_adapter_test.cpp
-)
-target_link_libraries(bridge_consensus_adapter_test
-    genius_node
-    rapidjson
-)
-
 #addtest(consensus_certificate_test
 #    consensus_certificate_test.cpp
 #)
@@ -28,22 +20,33 @@ target_link_libraries(bridge_consensus_adapter_test
 #    base_crdt_test
 #)
 
+# ConsensusManager requires 6 constructor dependencies (ValidatorRegistry, GlobalDB,
+# GossipPubSub, Signer, etc.) — cannot be instantiated in isolation.
+# Test deferred to E2E integration (Phase 4).
+#addtest(consensus_slot_key_test
+#    consensus_slot_key_test.cpp
+#)
+#target_link_libraries(consensus_slot_key_test
+#    blockchain_genesis
+#    rapidjson
+#)
+
 target_include_directories(blockchain_genesis_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(blockchain_genesis_test
-    genius_node
+    genius_node_test
     rapidjson
 )
 if(WIN32)
-    target_link_options(blockchain_genesis_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(blockchain_genesis_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 
 elseif(APPLE)
-    target_link_options(blockchain_genesis_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(blockchain_genesis_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 
 else()
     target_link_options(blockchain_genesis_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()

--- a/test/src/blockchain/CMakeLists.txt
+++ b/test/src/blockchain/CMakeLists.txt
@@ -11,6 +11,14 @@ target_link_libraries(consensus_subject_test
     rapidjson
 )
 
+addtest(bridge_consensus_adapter_test
+    bridge_consensus_adapter_test.cpp
+)
+target_link_libraries(bridge_consensus_adapter_test
+    genius_node
+    rapidjson
+)
+
 #addtest(consensus_certificate_test
 #    consensus_certificate_test.cpp
 #)
@@ -18,17 +26,6 @@ target_link_libraries(consensus_subject_test
 #    blockchain_genesis
 #    rapidjson
 #    base_crdt_test
-#)
-
-# ConsensusManager requires 6 constructor dependencies (ValidatorRegistry, GlobalDB,
-# GossipPubSub, Signer, etc.) — cannot be instantiated in isolation.
-# Test deferred to E2E integration (Phase 4).
-#addtest(consensus_slot_key_test
-#    consensus_slot_key_test.cpp
-#)
-#target_link_libraries(consensus_slot_key_test
-#    blockchain_genesis
-#    rapidjson
 #)
 
 target_include_directories(blockchain_genesis_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})

--- a/test/src/blockchain/blockchain_genesis_test.cpp
+++ b/test/src/blockchain/blockchain_genesis_test.cpp
@@ -24,6 +24,8 @@
 #include <boost/format.hpp>
 #include <boost/asio.hpp>
 #include "account/GeniusNode.hpp"
+#include "account/GeniusAccount.hpp"
+#include "local_secure_storage/impl/MemorySecureStorage.hpp"
 #include "FileManager.hpp"
 #include <boost/dll.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -35,6 +37,16 @@ using namespace sgns;
 class BlockchainGenesisTest : public ::testing::Test
 {
 protected:
+    static void SetUpTestSuite()
+    {
+        // Inject in-memory secure storage to avoid OS keychain prompts during tests
+        GeniusAccount::SetSecureStorageFactory(
+            []( const std::string &identifier ) -> std::shared_ptr<ISecureStorage>
+            {
+                return std::make_shared<MemorySecureStorage>( identifier );
+            } );
+    }
+
     std::shared_ptr<sgns::GeniusNode> CreateNode( const std::string &self_address,
                                                   const std::string &dev_addr,
                                                   const std::string &tokenValue,

--- a/test/src/graphsync/CMakeLists.txt
+++ b/test/src/graphsync/CMakeLists.txt
@@ -5,19 +5,19 @@ addtest(pubsub_graphsync_test
 target_include_directories(pubsub_graphsync_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(pubsub_graphsync_test
-    genius_node
+    genius_node_test
 	p2p::p2p_logger
 	logger
 )
 
 if(MSVC)
-    target_link_options(pubsub_graphsync_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(pubsub_graphsync_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 elseif(APPLE)
-    target_link_options(pubsub_graphsync_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(pubsub_graphsync_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 else()
     target_link_options(pubsub_graphsync_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()

--- a/test/src/local_secure_storage/json_migration_test.cpp
+++ b/test/src/local_secure_storage/json_migration_test.cpp
@@ -3,12 +3,19 @@
 #include <boost/dll.hpp>
 
 #include "account/GeniusAccount.hpp"
+#include "local_secure_storage/impl/MemorySecureStorage.hpp"
 
 using namespace sgns;
 namespace fs = boost::filesystem;
 
 TEST( SecureStorage, JsonMigration )
 {
+    // Inject in-memory secure storage to avoid OS keychain prompts during tests
+    GeniusAccount::SetSecureStorageFactory(
+        []( const std::string &identifier ) -> std::shared_ptr<ISecureStorage>
+        {
+            return std::make_shared<MemorySecureStorage>( identifier );
+        } );
     auto binary_parent = boost::dll::program_location().parent_path();
     const fs::path json_storage_path = binary_parent / "json_storage";
     const fs::path test_path = binary_parent / "json_storage_test";

--- a/test/src/local_secure_storage/secure_storage_test.cpp
+++ b/test/src/local_secure_storage/secure_storage_test.cpp
@@ -101,10 +101,12 @@ INSTANTIATE_TEST_SUITE_P( SecureStorage,
 
 #elif defined( __APPLE__ )
 
-#include "local_secure_storage/impl/Apple.hpp"
+// Use in-memory storage for tests — avoids keychain password prompts.
+// AppleSecureStorage is tested separately in integration tests.
+#include "local_secure_storage/impl/MemorySecureStorage.hpp"
 
 INSTANTIATE_TEST_SUITE_P( SecureStorage,
                           SecureStorageTest,
-                          testing::Values( std::make_shared<AppleSecureStorage>( TEST_ID ) ) );
+                          testing::Values( std::make_shared<MemorySecureStorage>( TEST_ID ) ) );
 
 #endif

--- a/test/src/multiaccount/CMakeLists.txt
+++ b/test/src/multiaccount/CMakeLists.txt
@@ -5,20 +5,20 @@ addtest(multi_account_test
 target_include_directories(multi_account_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(multi_account_test
-    genius_node
+    genius_node_test
     json_secure_storage
 )
 
 if(WIN32)
-    target_link_options(multi_account_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(multi_account_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 
 elseif(APPLE)
-    target_link_options(multi_account_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(multi_account_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 
 else()
     target_link_options(multi_account_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()

--- a/test/src/processing_multi/CMakeLists.txt
+++ b/test/src/processing_multi/CMakeLists.txt
@@ -6,18 +6,18 @@ addtest(processing_multi_test
 target_include_directories(processing_multi_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(processing_multi_test
-    genius_node
+    genius_node_test
 )
 if(WIN32)
-    target_link_options(processing_multi_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(processing_multi_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 
 elseif(APPLE)
-    target_link_options(processing_multi_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(processing_multi_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 
 else()
     target_link_options(processing_multi_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()

--- a/test/src/processing_nodes/CMakeLists.txt
+++ b/test/src/processing_nodes/CMakeLists.txt
@@ -6,18 +6,18 @@ addtest(processing_nodes_test
 target_include_directories(processing_nodes_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(processing_nodes_test
-    genius_node
+    genius_node_test
 )
 if(WIN32)
-    target_link_options(processing_nodes_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(processing_nodes_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 
 elseif(APPLE)
-    target_link_options(processing_nodes_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(processing_nodes_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 
 else()
     target_link_options(processing_nodes_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()
@@ -29,19 +29,19 @@ addtest(child_tokens_test
 target_include_directories(child_tokens_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(child_tokens_test
-    genius_node
+    genius_node_test
     json_secure_storage
 )
 if(WIN32)
-    target_link_options(child_tokens_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(child_tokens_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 
 elseif(APPLE)
-    target_link_options(child_tokens_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(child_tokens_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 
 else()
     target_link_options(child_tokens_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()
@@ -54,19 +54,19 @@ addtest(full_node_test
 target_include_directories(full_node_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(full_node_test
-    genius_node
+    genius_node_test
     json_secure_storage
 )
 if(WIN32)
-    target_link_options(full_node_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(full_node_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 
 elseif(APPLE)
-    target_link_options(full_node_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(full_node_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 
 else()
     target_link_options(full_node_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()

--- a/test/src/transaction_sync/CMakeLists.txt
+++ b/test/src/transaction_sync/CMakeLists.txt
@@ -5,17 +5,17 @@ transaction_sync_test.cpp
 target_include_directories(transaction_sync_test PRIVATE ${AsyncIOManager_INCLUDE_DIR})
 
 target_link_libraries(transaction_sync_test
-    genius_node
+    genius_node_test
 )
 
 if(WIN32)
-    target_link_options(transaction_sync_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(transaction_sync_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 elseif(APPLE)
-    target_link_options(transaction_sync_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(transaction_sync_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 else()
     target_link_options(transaction_sync_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()
@@ -25,17 +25,17 @@ addtest(migration_sync_test
 )
 
 target_link_libraries(migration_sync_test
-    genius_node
+    genius_node_test
 )
 
 if(WIN32)
-    target_link_options(migration_sync_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(migration_sync_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 elseif(APPLE)
-    target_link_options(migration_sync_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(migration_sync_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 else()
     target_link_options(migration_sync_test PUBLIC
             "-Wl,--whole-archive"
-            "$<TARGET_FILE:genius_node>"
+            "$<TARGET_FILE:genius_node_test>"
             "-Wl,--no-whole-archive"
     )
 endif()
@@ -45,17 +45,17 @@ addtest(transaction_crash_test
 )
 
 target_link_libraries(transaction_crash_test
-    genius_node
+    genius_node_test
 )
 
 if(WIN32)
-    target_link_options(transaction_crash_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node>)
+    target_link_options(transaction_crash_test PUBLIC /WHOLEARCHIVE:$<TARGET_FILE:genius_node_test>)
 elseif(APPLE)
-    target_link_options(transaction_crash_test PUBLIC -force_load "$<TARGET_FILE:genius_node>")
+    target_link_options(transaction_crash_test PUBLIC -force_load "$<TARGET_FILE:genius_node_test>")
 else()
     target_link_options(transaction_crash_test PUBLIC
         "-Wl,--whole-archive"
-        "$<TARGET_FILE:genius_node>"
+        "$<TARGET_FILE:genius_node_test>"
         "-Wl,--no-whole-archive"
     )
 endif()


### PR DESCRIPTION
## Summary

Replaces macOS keychain-backed secure storage with in-memory storage for test builds. Eliminates ~20 keychain password prompts per test run.

## Changes

- New: `src/local_secure_storage/impl/MemorySecureStorage.hpp` — in-memory JSON backend, no OS keychain access
- Updated: `SecureStorage.hpp` — respects `SGNS_USE_MEMORY_SECURE_STORAGE` compile flag
- Updated: `CommonBuildParameters.cmake` — adds flag before library build when `BUILD_TESTING=ON`
- Updated: `secure_storage_test.cpp` — uses MemorySecureStorage on macOS

## How it works

When `BUILD_TESTING=ON`, the cmake build adds `-DSGNS_USE_MEMORY_SECURE_STORAGE` globally. This causes `SecureStorageImpl` to resolve to `MemorySecureStorage` (in-memory map) instead of `AppleSecureStorage` (macOS keychain). Both library and test targets get the flag.

## Testing

```bash
cd build/OSX/Debug
cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug
ninja -j4
ctest --output-on-failure -j4
```

Zero keychain prompts expected.