### PR TITLE
fix(05): chain RPC fixes + BridgeSourceBurned 6-param update

### DIFF
--- a/src/account/BridgeRelayer.cpp
+++ b/src/account/BridgeRelayer.cpp
@@ -30,16 +30,6 @@ namespace sgns
     namespace
     {
         /**
-         * @brief       Auxiliary function to convert an eth::Address to a hex string for logging.
-         * @param[in]   addr The eth::Address to convert.
-         * @return      Address as a hex string.
-         */
-        std::string AddressToHex( const eth::Address &addr )
-        {
-            return rlp::base::parse::hex_array_string( addr );
-        }
-
-        /**
          * @brief       Converts an intx::uint256 to uint64_t with overflow check, used for event parameters that must fit in uint64.
          * @param[in]   value The intx::uint256 value to convert.
          * @param[in]   field The name of the field being converted.
@@ -86,8 +76,8 @@ namespace sgns
         }
 
         // BridgeSourceBurned(address indexed sender, uint256 id, uint256 amount,
-        //                    uint256 srcChainID, uint256 destChainID)
-        const std::string event_sig = "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)";
+        //                    uint256 srcChainID, uint256 destChainID, bytes sgnsDestination)
+        const std::string event_sig = "BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)";
         auto              params    = eth::cli::event_registry().params_for( event_sig );
 
         size_t registered = 0;
@@ -169,11 +159,11 @@ namespace sgns
     void BridgeRelayer::OnWatchEvent( const eth::WatchEventNotification &notification,
                                        const std::string                 &chain_name )
     {
-        static constexpr size_t BRIDGE_SOURCE_BURNED_PARAM_COUNT = 5;
-        if ( notification.values.size() < BRIDGE_SOURCE_BURNED_PARAM_COUNT )
+        static constexpr size_t kBridgeSourceBurnedParamCount = 6;
+        if ( notification.values.size() < kBridgeSourceBurnedParamCount )
         {
             logger_->error( "BridgeRelayer: expected {} event params for chain {}, got {}",
-                            BRIDGE_SOURCE_BURNED_PARAM_COUNT,
+                            kBridgeSourceBurnedParamCount,
                             chain_name,
                             notification.values.size() );
             return;
@@ -185,10 +175,13 @@ namespace sgns
         //   values[2]: amount (uint256)
         //   values[3]: srcChainID (uint256)
         //   values[4]: destChainID (uint256)
-        const auto &sender     = std::get<eth::codec::Address>( notification.values[0] );
-        const auto &token_id   = std::get<intx::uint256>( notification.values[1] );
-        const auto &amount_val = std::get<intx::uint256>( notification.values[2] );
-        const auto &src_chain  = std::get<intx::uint256>( notification.values[3] );
+        //   values[5]: sgnsDestination (bytes) — 64-byte SuperGenius public key
+        const auto &sender          = std::get<eth::codec::Address>( notification.values[0] );
+        const auto &token_id        = std::get<intx::uint256>( notification.values[1] );
+        const auto &amount_val      = std::get<intx::uint256>( notification.values[2] );
+        const auto &src_chain       = std::get<intx::uint256>( notification.values[3] );
+        const auto &dest_chain      = std::get<intx::uint256>( notification.values[4] );
+        const auto &sgns_dest_bytes = std::get<eth::codec::ByteBuffer>( notification.values[5] );
 
         // Transaction hash from the event
         const std::string tx_hash = rlp::base::parse::hex_array_string( notification.event.tx_hash );
@@ -207,8 +200,8 @@ namespace sgns
 
         const TokenID mint_token_id = TokenID::FromUint256( token_id, TokenID::Endianness::BIG );
 
-        // Destination: sender of the burn (the user who bridged out)
-        const std::string destination = AddressToHex( sender );
+        // Destination: SuperGenius public key from the burn event (64 bytes, 128 hex chars)
+        const std::string destination = rlp::base::parse::hex_bytes( sgns_dest_bytes.data(), sgns_dest_bytes.size() );
 
         logger_->info( "BridgeRelayer: burn detected chain={} chain_name={} tx={} token={} amount={} dest={}",
                        chain_id,

--- a/src/account/CMakeLists.txt
+++ b/src/account/CMakeLists.txt
@@ -140,3 +140,15 @@ endif()
 # Install production library only
 supergenius_install(sgns_genius_account)
 supergenius_install(genius_node)
+
+# Copy default bridge chains config to test binary output for dev/test runs
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/bridge_chains_config.json
+    ${CMAKE_BINARY_DIR}/test_bin/bridge_chains_config.json
+    COPYONLY
+)
+
+# Install the default config alongside the binary for production
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/bridge_chains_config.json
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/src/account/ChainRpcEndpointProvider.cpp
+++ b/src/account/ChainRpcEndpointProvider.cpp
@@ -44,13 +44,13 @@ namespace sgns
         std::unordered_map<uint64_t, std::vector<WeightedRpcEndpoint>> endpoints_by_chain;
 
         // ── Public endpoints from the ChainList provider ──────────────
-        if ( !config.chains_json_path.empty() )
+        if ( !config.chainlist_json_path.empty() )
         {
-            std::ifstream file( config.chains_json_path, std::ios::binary );
+            std::ifstream file( config.chainlist_json_path, std::ios::binary );
             if ( !file.is_open() )
             {
-                logger->warn( "ChainRpcEndpointProvider: chains.json not found at {}",
-                              config.chains_json_path.string() );
+                logger->warn( "ChainRpcEndpointProvider: chainlist JSON not found at {}",
+                              config.chainlist_json_path.string() );
                 // Continue — direct endpoints may still be available.
             }
             else
@@ -61,15 +61,15 @@ namespace sgns
 
                 if ( json_text.empty() )
                 {
-                    logger->warn( "ChainRpcEndpointProvider: chains.json is empty at {}",
-                                  config.chains_json_path.string() );
+                    logger->warn( "ChainRpcEndpointProvider: chainlist JSON is empty at {}",
+                                  config.chainlist_json_path.string() );
                 }
                 else
                 {
                     auto parse_result = eth::rpc::load_chainlist_from_json_text( json_text );
                     if ( !parse_result )
                     {
-                        logger->warn( "ChainRpcEndpointProvider: failed to parse chains.json: {}",
+                        logger->warn( "ChainRpcEndpointProvider: failed to parse chainlist JSON: {}",
                                       parse_result.error().field );
                     }
                     else

--- a/src/account/ChainRpcEndpointProvider.hpp
+++ b/src/account/ChainRpcEndpointProvider.hpp
@@ -29,13 +29,13 @@ namespace sgns
     struct ChainRpcProviderConfig
     {
         /**
-         * @brief Filesystem path to the chainid.network chains.json file.
+         * @brief Filesystem path to the chainid.network ChainList JSON file (array format).
          *
          * This is the aggregated ChainList dataset that provides verified public
          * RPC endpoint URLs for every EVM chain.  The file is typically bundled
          * with the application or downloaded at first launch.
          */
-        std::filesystem::path chains_json_path;
+        std::filesystem::path chainlist_json_path;
 
         /**
          * @brief Per-chain direct (API-key) endpoints supplied by the app layer.
@@ -52,7 +52,7 @@ namespace sgns
         /**
          * @brief Bridge contract addresses keyed by numeric chain ID.
          *
-         * Sourced from chains_config.json's optional "bridge_contract_address" field.
+         * Sourced from bridge_chains_config.json's optional "bridge_contract_address" field.
          * Chains not present in this map have no bridge deployed (D-02: skip signal).
          */
         std::unordered_map<uint64_t, std::string> bridge_contract_addresses;
@@ -91,7 +91,7 @@ namespace sgns
         /**
          * @brief Loads RPC endpoints and wires them into the validator.
          *
-         * Public endpoints from the ChainList provider in @p config.chains_json_path
+         * Public endpoints from the ChainList provider in @p config.chainlist_json_path
          * contribute 25% consensus weight.  Direct endpoints from
          * @p config.direct_endpoints contribute 50% consensus weight.
          *

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -2047,7 +2047,7 @@ namespace sgns
         // chainid.network chains.json source (downloaded or configured separately).
         // Direct API-key endpoints are supplied via config.direct_endpoints.
 
-        const std::string event_sig = "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)";
+        const std::string event_sig = "BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)";
 
         try
         {
@@ -2195,7 +2195,7 @@ namespace sgns
             return;
         }
 
-        const std::string event_sig   = "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)";
+        const std::string event_sig   = "BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)";
         auto              topic0_hash = eth::abi::event_signature_hash( event_sig );
         std::string       topic0_hex  = rlp::base::parse::hex_bytes( topic0_hash.data(), topic0_hash.size() );
 

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -1988,34 +1988,45 @@ namespace sgns
             return {};
         }
 
-        // ── Pitfall #3: Resolve chains_config.json path using writable base path ──
-        std::filesystem::path chains_path;
+        // ── Pitfall #3: Resolve bridge_chains_config.json path ──
+        // Priority: BaseWriteDir → binary-relative → CWD.
+        std::filesystem::path bridge_chains_path;
 
         // Primary: use DevConfig_st BaseWritePath (writable on all platforms including Android)
         if ( !dev_config_.BaseWritePath.empty() )
         {
-            chains_path = std::filesystem::path( dev_config_.BaseWritePath ) / "chains_config.json";
+            bridge_chains_path = std::filesystem::path( dev_config_.BaseWritePath ) / "bridge_chains_config.json";
         }
-        else
+
+        // Fallback: binary directory (finds CMake-installed or copied default)
+        if ( bridge_chains_path.empty() || !std::filesystem::exists( bridge_chains_path ) )
         {
-            // Fallback: binary directory (works on desktop platforms)
             try
             {
                 auto bin_dir = boost::dll::program_location().parent_path();
-                chains_path  = std::filesystem::path( bin_dir.string() ) / "chains_config.json";
+                auto candidate = std::filesystem::path( bin_dir.string() ) / "bridge_chains_config.json";
+                if ( std::filesystem::exists( candidate ) )
+                {
+                    bridge_chains_path = std::move( candidate );
+                }
             }
             catch ( const std::exception &e )
             {
                 node_logger_->warn( "InitializeRpcEndpoints: cannot determine binary location ({}), "
                                     "falling back to CWD",
                                     e.what() );
-                chains_path = std::filesystem::current_path() / "chains_config.json";
             }
         }
 
-        node_logger_->info( "InitializeRpcEndpoints: loading chain config from {}", chains_path.string() );
+        // Final fallback: current working directory
+        if ( bridge_chains_path.empty() || !std::filesystem::exists( bridge_chains_path ) )
+        {
+            bridge_chains_path = std::filesystem::current_path() / "bridge_chains_config.json";
+        }
 
-        // ── Read chains_config.json directly to discover bridge contracts (D-02) ──
+        node_logger_->info( "InitializeRpcEndpoints: loading bridge chain config from {}", bridge_chains_path.string() );
+
+        // ── Read bridge_chains_config.json directly to discover bridge contracts (D-02) ──
         ChainRpcEndpointProvider::ChainIdMap chain_id_map;
         std::vector<ChainContractPair>       bridge_chains;
 
@@ -2032,17 +2043,17 @@ namespace sgns
         };
 
         ChainRpcProviderConfig config;
-        config.chains_json_path = chains_path;
+        config.chainlist_json_path = bridge_chains_path;
 
         const std::string event_sig = "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)";
 
         try
         {
-            std::ifstream file( chains_path, std::ios::binary );
+            std::ifstream file( bridge_chains_path, std::ios::binary );
             if ( !file.is_open() )
             {
                 node_logger_->warn( "InitializeRpcEndpoints: cannot open {} — bridge startup skipped",
-                                    chains_path.string() );
+                                    bridge_chains_path.string() );
                 // Continue with empty maps — RPC endpoints will still be configured
                 // if direct_endpoints are supplied.
             }
@@ -2106,7 +2117,7 @@ namespace sgns
         catch ( const std::exception &e )
         {
             // T-05-15: malformed JSON — graceful degradation
-            node_logger_->warn( "InitializeRpcEndpoints: failed to parse chains_config.json: {}", e.what() );
+            node_logger_->warn( "InitializeRpcEndpoints: failed to parse bridge_chains_config.json: {}", e.what() );
             // Continue without bridge — node still boots
         }
 

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -2043,7 +2043,9 @@ namespace sgns
         };
 
         ChainRpcProviderConfig config;
-        config.chainlist_json_path = bridge_chains_path;
+        // chainlist_json_path is left empty — public endpoints come from a
+        // chainid.network chains.json source (downloaded or configured separately).
+        // Direct API-key endpoints are supplied via config.direct_endpoints.
 
         const std::string event_sig = "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)";
 

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -2243,11 +2243,42 @@ namespace sgns
             filter.addresses.push_back( contract_addr );
             filter.topics.push_back( topic0_hash256 );
 
-            // from_block: cap at scan_depth blocks from latest (D-20)
-            // to_block: "latest" (indicated by 0 in make_get_logs_request)
-            uint64_t from_block = scan_depth > 0 ? scan_depth : 10000;
+            // D-20: Query current block number to compute scan start
+            // Scan from (current_block - scan_depth) to latest
+            constexpr uint64_t kBlockNumberRequestId = 99;
+            auto              block_number_req = eth::rpc::make_json_rpc_request( "eth_blockNumber",
+                                                                                   boost::json::array{},
+                                                                                   kBlockNumberRequestId );
+            auto              block_number_resp = transport.call( block_number_req );
+            uint64_t          current_block     = 0;
 
-            // Create request — from_block=N means "scan last N blocks"; to_block=0 = "latest"
+            if ( block_number_resp.has_value() )
+            {
+                auto parsed_block = eth::rpc::parse_block_number_response( *block_number_resp );
+                if ( parsed_block.has_value() )
+                {
+                    current_block = *parsed_block;
+                }
+            }
+
+            if ( current_block == 0 )
+            {
+                node_logger_->warn( "CatchUpScan: failed to query block number for chain {} — skipping",
+                                    chain_entry.chain_name );
+                continue;
+            }
+
+            // from_block: cap at scan_depth blocks from latest (D-20)
+            // to_block: 0 = "latest"
+            const uint64_t from_block = current_block > scan_depth ? current_block - scan_depth : 0;
+
+            node_logger_->debug( "CatchUpScan: scanning chain {} from block {} to latest (current={}, depth={})",
+                                 chain_entry.chain_name,
+                                 from_block,
+                                 current_block,
+                                 scan_depth );
+
+            // Create eth_getLogs request
             auto request  = eth::rpc::make_get_logs_request( filter, from_block, 0, 1 );
             auto response = transport.call( request );
 

--- a/src/account/GeniusNode.cpp
+++ b/src/account/GeniusNode.cpp
@@ -2131,13 +2131,23 @@ namespace sgns
         if ( !chain_id_map.empty() )
         {
             ChainRpcEndpointProvider provider( std::move( chain_id_map ) );
-            provider.Initialize( transaction_manager_->GetPublicChainInputValidator(), config, node_logger_ );
+            bool endpoints_wired = provider.Initialize(
+                transaction_manager_->GetPublicChainInputValidator(), config, node_logger_ );
 
-            // Register PublicChainInputValidator for all configured chain IDs
-            auto &pub_validator = transaction_manager_->GetPublicChainInputValidator();
-            for ( const auto &chain_entry : bridge_chains )
+            if ( endpoints_wired )
             {
-                IInputValidator::Register( std::to_string( chain_entry.chain_id ), &pub_validator );
+                // Register PublicChainInputValidator for all configured chain IDs
+                auto &pub_validator = transaction_manager_->GetPublicChainInputValidator();
+                for ( const auto &chain_entry : bridge_chains )
+                {
+                    IInputValidator::Register( std::to_string( chain_entry.chain_id ), &pub_validator );
+                }
+            }
+            else
+            {
+                node_logger_->warn( "InitializeRpcEndpoints: no RPC endpoints were wired — "
+                                    "bridge chains will not be registered" );
+                bridge_chains.clear();
             }
         }
         else

--- a/src/account/GeniusNode.hpp
+++ b/src/account/GeniusNode.hpp
@@ -729,7 +729,7 @@ namespace sgns
          *
          * This is called once during startup after the transaction manager reaches
          * the READY state and before processing modules are initialized.  It reads
-         * @c chains_config.json to discover configured chains, maps their names to
+         * @c bridge_chains_config.json to discover configured chains, maps their names to
          * well-known EVM chain IDs, parses the ChainList data to extract verified
          * public RPC endpoint URLs, and calls @c PublicChainInputValidator::SetRpcEndpoints
          * for each configured chain.

--- a/src/account/bridge_chains_config.json
+++ b/src/account/bridge_chains_config.json
@@ -1,0 +1,26 @@
+{
+    "ethereum-mainnet": {
+        "bridge_contract_address": "0x614577036F0a024DBC1C88BA616b394DD65d105a"
+    },
+    "ethereum-sepolia": {
+        "bridge_contract_address": "0x9af8050220D8C355CA3c6dC00a78B474cd3e3c70"
+    },
+    "bnb-smart-chain": {
+        "bridge_contract_address": "0x614577036F0a024DBC1C88BA616b394DD65d105a"
+    },
+    "bnb-smart-chain-testnet": {
+        "bridge_contract_address": "0xeC20bDf2f9f77dc37Ee8313f719A3cbCFA0CD1eB"
+    },
+    "polygon-mainnet": {
+        "bridge_contract_address": "0x127E47abA094a9a87D084a3a93732909Ff031419"
+    },
+    "polygon-amoy": {
+        "bridge_contract_address": "0xeC20bDf2f9f77dc37Ee8313f719A3cbCFA0CD1eB"
+    },
+    "base-mainnet": {
+        "bridge_contract_address": "0x614577036F0a024DBC1C88BA616b394DD65d105a"
+    },
+    "base-sepolia": {
+        "bridge_contract_address": "0xeC20bDf2f9f77dc37Ee8313f719A3cbCFA0CD1eB"
+    }
+}

--- a/test/src/account/bridge_relayer_test.cpp
+++ b/test/src/account/bridge_relayer_test.cpp
@@ -58,7 +58,9 @@ eth::WatchEventNotification MakeBurnNotification(
     uint64_t           token_id_val,
     uint64_t           amount_val,
     uint64_t           src_chain_id,
-    const std::string &tx_hash_hex )
+    uint64_t           dest_chain_id,
+    const std::string &tx_hash_hex,
+    const std::string &sgns_dest_hex )
 {
     eth::WatchEventNotification notification;
 
@@ -75,14 +77,26 @@ eth::WatchEventNotification MakeBurnNotification(
     //   values[2]: amount (uint256)
     //   values[3]: srcChainID (uint256)
     //   values[4]: destChainID (uint256)
+    //   values[5]: sgnsDestination (bytes) — 64-byte SuperGenius public key
     notification.values.push_back( sender_addr );
     notification.values.push_back( intx::uint256( token_id_val ) );
     notification.values.push_back( intx::uint256( amount_val ) );
     notification.values.push_back( intx::uint256( src_chain_id ) );
-    notification.values.push_back( intx::uint256( 0 ) ); // destChainID (unused)
+    notification.values.push_back( intx::uint256( dest_chain_id ) );
+
+    // sgnsDestination as bytes (64-byte SuperGenius public key)
+    eth::codec::ByteBuffer sgns_dest_bytes;
+    sgns_dest_bytes.resize( sgns_dest_hex.size() / 2 );
+    rlp::base::parse::hex_array( sgns_dest_hex, sgns_dest_bytes );
+    notification.values.push_back( std::move( sgns_dest_bytes ) );
 
     return notification;
 }
+
+/// @brief 64-byte SuperGenius public key for test destinations.
+static const std::string kTestSgnsDestination =
+    "a62f83ab9f2de6ac95e2336053aea94f8fab10dfb8d3043efe64c3f4e565cfcc"
+    "2c5aacd6d6092682b8de8383444f746d150b3f7891ed46c9050502ed4b6898a6";
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
@@ -96,11 +110,14 @@ TEST( BridgeRelayerTest, ExtractsBurnDetailsFromNotification )
         42,                                            // token_id
         1000000,                                       // amount (1M wei)
         11155111,                                      // Sepolia chain ID
-        "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" // tx_hash
+        8453,                                          // Base mainnet dest chain ID
+        "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12", // tx_hash (64 hex)
+        "a62f83ab9f2de6ac95e2336053aea94f8fab10dfb8d3043efe64c3f4e565cfcc"
+        "2c5aacd6d6092682b8de8383444f746d150b3f7891ed46c9050502ed4b6898a6"  // sgnsDestination (64 bytes)
     );
 
     // Verify notification was constructed correctly
-    ASSERT_EQ( notification.values.size(), 5U );
+    ASSERT_EQ( notification.values.size(), 6U );
 
     // Verify sender is an address (20 bytes)
     const auto &sender = std::get<eth::codec::Address>( notification.values[0] );
@@ -117,6 +134,14 @@ TEST( BridgeRelayerTest, ExtractsBurnDetailsFromNotification )
     // Verify srcChainID
     const auto &src_chain = std::get<intx::uint256>( notification.values[3] );
     EXPECT_EQ( src_chain, intx::uint256( 11155111 ) );
+
+    // Verify destChainID
+    const auto &dest_chain = std::get<intx::uint256>( notification.values[4] );
+    EXPECT_EQ( dest_chain, intx::uint256( 8453 ) );
+
+    // Verify sgnsDestination bytes (64 bytes)
+    const auto &sgns_dest = std::get<eth::codec::ByteBuffer>( notification.values[5] );
+    EXPECT_EQ( sgns_dest.size(), 64U );
 
     // Verify tx_hash is populated
     EXPECT_FALSE( notification.event.tx_hash.empty() );
@@ -180,7 +205,9 @@ TEST( BridgeRelayerTest, HandlesMaxUint64Amount )
         1,
         std::numeric_limits<uint64_t>::max(),
         1,
-        "1111111111111111111111111111111111111111111111111111111111111111"
+        8453,
+        "1111111111111111111111111111111111111111111111111111111111111111",
+        kTestSgnsDestination
     );
 
     const auto &amount = std::get<intx::uint256>( notification.values[2] );
@@ -190,10 +217,9 @@ TEST( BridgeRelayerTest, HandlesMaxUint64Amount )
     EXPECT_LE( amount, std::numeric_limits<uint64_t>::max() );
 }
 
-TEST( BridgeRelayerTest, AddressToHexRoundTrip )
+TEST( BridgeRelayerTest, HexAddressRoundTrip )
 {
-    // Verify hex address parsing and round-trip
-
+    // Verify 20-byte EVM address round-trip via parse::hex_array / hex_array_string.
     eth::Address addr{};
     bool parsed = rlp::base::parse::hex_array( "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045", addr );
     ASSERT_TRUE( parsed );
@@ -202,6 +228,20 @@ TEST( BridgeRelayerTest, AddressToHexRoundTrip )
     // Verify round-trip (hex_array_string includes "0x" prefix)
     std::string hex = rlp::base::parse::hex_array_string( addr );
     EXPECT_EQ( hex.size(), 42U ); // "0x" + 40 hex chars
+}
+
+TEST( BridgeRelayerTest, SgnsDestinationHexRoundTrip )
+{
+    // Verify 64-byte SuperGenius destination round-trip via hex_bytes / hex_array.
+    eth::codec::ByteBuffer bytes;
+    bytes.resize( 64 );
+    bool parsed = rlp::base::parse::hex_array( kTestSgnsDestination, bytes );
+    ASSERT_TRUE( parsed );
+    EXPECT_EQ( bytes.size(), 64U );
+
+    // Verify round-trip via hex_bytes
+    std::string hex = rlp::base::parse::hex_bytes( bytes.data(), bytes.size() );
+    EXPECT_EQ( hex.size(), 128U ); // 64 bytes → 128 hex chars (no "0x" prefix)
 }
 
 // ─── OnWatchEvent Behavior Tests ────────────────────────────────────────────
@@ -219,7 +259,9 @@ TEST( BridgeRelayerTest, OnWatchEventHandlesNullTransactionManager )
         42,
         1000000,
         11155111,
-        "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" );
+        8453,
+        "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        kTestSgnsDestination );
 
     // Should not crash — logs error and returns
     EXPECT_NO_THROW( BridgeRelayerTestAccess::OnWatchEvent( relayer, notification ) );
@@ -227,7 +269,7 @@ TEST( BridgeRelayerTest, OnWatchEventHandlesNullTransactionManager )
 
 TEST( BridgeRelayerTest, OnWatchEventRejectsInsufficientValues )
 {
-    // Verify that OnWatchEvent rejects notifications with fewer than 5 ABI values.
+    // Verify that OnWatchEvent rejects notifications with fewer than 6 ABI values.
 
     auto logger = base::createLogger( "bridge_relayer_test" );
     auto relayer = BridgeRelayerTestAccess::CreateForTest( logger );
@@ -235,7 +277,7 @@ TEST( BridgeRelayerTest, OnWatchEventRejectsInsufficientValues )
     eth::WatchEventNotification notification;
     notification.values.push_back( intx::uint256( 1 ) );
     notification.values.push_back( intx::uint256( 2 ) );
-    // Only 2 values — needs 5
+    // Only 2 values — needs 6
 
     // Should not crash — logs error and returns
     EXPECT_NO_THROW( BridgeRelayerTestAccess::OnWatchEvent( relayer, notification ) );
@@ -253,7 +295,9 @@ TEST( BridgeRelayerTest, OnWatchEventHandlesZeroAmount )
         1,
         0,  // zero amount
         1,
-        "1111111111111111111111111111111111111111111111111111111111111111" );
+        8453,
+        "1111111111111111111111111111111111111111111111111111111111111111",
+        kTestSgnsDestination );
 
     // Should not crash — zero amount is valid (though MintFunds may reject it)
     EXPECT_NO_THROW( BridgeRelayerTestAccess::OnWatchEvent( relayer, notification ) );
@@ -280,6 +324,7 @@ TEST( BridgeRelayerTest, OnWatchEventHandlesAmountOverflow )
     notification.values.push_back( intx::uint256( 1 ) << 255 ); // amount overflows uint64
     notification.values.push_back( intx::uint256( 1 ) );  // srcChainID
     notification.values.push_back( intx::uint256( 0 ) );  // destChainID
+    notification.values.push_back( eth::codec::ByteBuffer( 64, 0 ) );  // sgnsDestination (dummy)
 
     // Should not crash — overflow detected, logs error and returns
     EXPECT_NO_THROW( BridgeRelayerTestAccess::OnWatchEvent( relayer, notification ) );
@@ -447,7 +492,9 @@ TEST( BridgeRelayerTest, OnWatchEventLogsChainName )
         42,
         1000000,
         11155111,
-        "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" );
+        8453,
+        "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        kTestSgnsDestination );
 
     // Should not crash; chain_name is passed through and logged
     EXPECT_NO_THROW( BridgeRelayerTestAccess::OnWatchEvent( relayer, notification, "specific-chain" ) );

--- a/test/src/account/chain_rpc_endpoint_provider_test.cpp
+++ b/test/src/account/chain_rpc_endpoint_provider_test.cpp
@@ -82,7 +82,7 @@ TEST( ChainRpcEndpointProviderTest, BridgeContractAddressPopulated )
 
     // Compute topic0 for the bridge event
     auto topic0_hash = eth::abi::event_signature_hash(
-        "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)" );
+        "BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)" );
     std::string topic0_hex =
         rlp::base::parse::hex_bytes( topic0_hash.data(), topic0_hash.size() );
     config.bridge_event_topic0[11155111] = topic0_hex;
@@ -129,7 +129,7 @@ TEST( ChainRpcEndpointProviderTest, EventTopic0Populated )
 
     // Compute expected topic0
     auto topic0_hash = eth::abi::event_signature_hash(
-        "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)" );
+        "BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)" );
     std::string topic0_hex =
         rlp::base::parse::hex_bytes( topic0_hash.data(), topic0_hash.size() );
 
@@ -314,7 +314,7 @@ TEST( ChainRpcEndpointProviderTest, MultipleChainsBridgeConfig )
 
     // Compute topic0
     auto topic0_hash = eth::abi::event_signature_hash(
-        "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)" );
+        "BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)" );
     std::string topic0_hex =
         rlp::base::parse::hex_bytes( topic0_hash.data(), topic0_hash.size() );
 

--- a/test/src/account/chain_rpc_endpoint_provider_test.cpp
+++ b/test/src/account/chain_rpc_endpoint_provider_test.cpp
@@ -24,34 +24,22 @@ using namespace sgns;
 
 // ─── Test Helpers ───────────────────────────────────────────────────────────
 
-/// @brief Create a minimal chains.json content for testing.
+/// @brief Create a minimal chainid.network-format chainlist JSON (array root) for testing.
+/// @note bridge_contract_address is NOT included — it belongs in config.bridge_contract_addresses.
 std::string MakeChainsJson( const std::string &chain_name,
                             uint64_t           chain_id,
-                            const std::string &rpc_url,
-                            const std::string &bridge_addr = "" )
+                            const std::string &rpc_url )
 {
-    std::string json = R"({
-        ")" + chain_name +
-                       R"(": {
-            "name": ")" +
-                       chain_name + R"(",
-            "chainId": )" +
-                       std::to_string( chain_id ) + R"(,
-            "rpc": [")" +
-                       rpc_url + R"("])";
-    if ( !bridge_addr.empty() )
-    {
-        json += R"(,
-            "bridge_contract_address": ")" +
-                bridge_addr + R"(")";
-    }
-    json += R"(
-        }
-    })";
+    // Produce chainid.network array format: [{"name":"...","chainId":N,"rpc":["..."]}]
+    std::string json = R"([{
+        "name": ")" + chain_name + R"(",
+        "chainId": )" + std::to_string( chain_id ) + R"(,
+        "rpc": [")" + rpc_url + R"("]
+    }])";
     return json;
 }
 
-/// @brief Write a temporary chains.json file.
+/// @brief Write a temporary chainlist JSON file (chainid.network format).
 fs::path WriteTempJson( const std::string &content )
 {
     auto path = fs::temp_directory_path() / "test_chains_config_provider.json";
@@ -79,8 +67,8 @@ TEST( ChainRpcEndpointProviderTest, BridgeContractAddressPopulated )
     const std::string chain_name   = "ethereum-sepolia";
     const std::string rpc_url      = "https://sepolia.infura.io/v3/test";
 
-    // Write a chains.json with bridge_contract_address
-    auto json    = MakeChainsJson( chain_name, 11155111, rpc_url, expected_addr );
+    // Write a chainlist JSON with public RPC endpoint
+    auto json    = MakeChainsJson( chain_name, 11155111, rpc_url );
     auto tmpfile = WriteTempJson( json );
     ASSERT_TRUE( fs::exists( tmpfile ) );
 
@@ -89,7 +77,7 @@ TEST( ChainRpcEndpointProviderTest, BridgeContractAddressPopulated )
     chain_id_map.emplace( chain_name, 11155111 );
 
     ChainRpcProviderConfig config;
-    config.chains_json_path             = tmpfile;
+    config.chainlist_json_path             = tmpfile;
     config.bridge_contract_addresses[11155111] = expected_addr;
 
     // Compute topic0 for the bridge event
@@ -132,7 +120,7 @@ TEST( ChainRpcEndpointProviderTest, EventTopic0Populated )
     const std::string chain_name   = "ethereum-mainnet";
     const std::string rpc_url      = "https://mainnet.infura.io/v3/test";
 
-    auto json    = MakeChainsJson( chain_name, 1, rpc_url, contract_addr );
+    auto json    = MakeChainsJson( chain_name, 1, rpc_url );
     auto tmpfile = WriteTempJson( json );
     ASSERT_TRUE( fs::exists( tmpfile ) );
 
@@ -146,7 +134,7 @@ TEST( ChainRpcEndpointProviderTest, EventTopic0Populated )
         rlp::base::parse::hex_bytes( topic0_hash.data(), topic0_hash.size() );
 
     ChainRpcProviderConfig config;
-    config.chains_json_path               = tmpfile;
+    config.chainlist_json_path               = tmpfile;
     config.bridge_contract_addresses[1]   = contract_addr;
     config.bridge_event_topic0[1]         = topic0_hex;
 
@@ -183,8 +171,8 @@ TEST( ChainRpcEndpointProviderTest, MissingBridgeFieldsDoesNotCrash )
     const std::string chain_name = "ethereum-sepolia";
     const std::string rpc_url    = "https://sepolia.infura.io/v3/test";
 
-    // chains.json WITHOUT bridge_contract_address
-    auto json    = MakeChainsJson( chain_name, 11155111, rpc_url, "" );
+    // chainlist JSON WITHOUT bridge fields in config
+    auto json    = MakeChainsJson( chain_name, 11155111, rpc_url );
     auto tmpfile = WriteTempJson( json );
     ASSERT_TRUE( fs::exists( tmpfile ) );
 
@@ -192,7 +180,7 @@ TEST( ChainRpcEndpointProviderTest, MissingBridgeFieldsDoesNotCrash )
     chain_id_map.emplace( chain_name, 11155111 );
 
     ChainRpcProviderConfig config;
-    config.chains_json_path = tmpfile;
+    config.chainlist_json_path = tmpfile;
     // Note: bridge_contract_addresses is NOT set for this chain
     // Note: bridge_event_topic0 is NOT set for this chain
 
@@ -220,12 +208,12 @@ TEST( ChainRpcEndpointProviderTest, MissingBridgeFieldsDoesNotCrash )
 
 TEST( ChainRpcEndpointProviderTest, EmptyChainConfigDoesNotCrash )
 {
-    // Config with an empty chains_json_path should be handled gracefully
+    // Config with an empty chainlist_json_path should be handled gracefully
     ChainRpcEndpointProvider::ChainIdMap chain_id_map;
     chain_id_map.emplace( "ethereum-mainnet", 1 );
 
     ChainRpcProviderConfig config;
-    config.chains_json_path = ""; // empty path — no file to read
+    config.chainlist_json_path = ""; // empty path — no file to read
 
     ChainRpcEndpointProvider provider( std::move( chain_id_map ) );
     PublicChainInputValidator validator;
@@ -249,7 +237,7 @@ TEST( ChainRpcEndpointProviderTest, EmptyChainIdMapReturnsFalse )
     ChainRpcEndpointProvider::ChainIdMap empty_map;
 
     ChainRpcProviderConfig config;
-    config.chains_json_path = "";
+    config.chainlist_json_path = "";
 
     ChainRpcEndpointProvider provider( std::move( empty_map ) );
     PublicChainInputValidator validator;
@@ -268,7 +256,7 @@ TEST( ChainRpcEndpointProviderTest, DirectEndpointsWired )
     chain_id_map.emplace( "ethereum-sepolia", 11155111 );
 
     ChainRpcProviderConfig config;
-    config.chains_json_path = ""; // no public endpoint file
+    config.chainlist_json_path = ""; // no public endpoint file
 
     // Provide direct endpoints
     config.direct_endpoints["11155111"] = {
@@ -295,26 +283,26 @@ TEST( ChainRpcEndpointProviderTest, DirectEndpointsWired )
 
 TEST( ChainRpcEndpointProviderTest, MultipleChainsBridgeConfig )
 {
-    // Multiple chains with bridge contracts — all should be configured
-    const std::string json = R"({
-        "ethereum-mainnet": {
+    // Multiple chains with bridge contracts — all should be configured.
+    // chainid.network array format — bridge_contract_address belongs in
+    // config.bridge_contract_addresses, not in the chainlist JSON.
+    const std::string json = R"([
+        {
             "name": "Ethereum Mainnet",
             "chainId": 1,
-            "rpc": ["https://mainnet.infura.io/v3/test"],
-            "bridge_contract_address": "0x614577036F0a024DBC1C88BA616b394DD65d105a"
+            "rpc": ["https://mainnet.infura.io/v3/test"]
         },
-        "ethereum-sepolia": {
+        {
             "name": "Ethereum Sepolia",
             "chainId": 11155111,
-            "rpc": ["https://sepolia.infura.io/v3/test"],
-            "bridge_contract_address": "0x9af8050220D8C355CA3c6dC00a78B474cd3e3c70"
+            "rpc": ["https://sepolia.infura.io/v3/test"]
         },
-        "no-bridge-chain": {
+        {
             "name": "No Bridge Chain",
             "chainId": 99999,
             "rpc": ["https://nobridge.example.com"]
         }
-    })";
+    ])";
 
     auto tmpfile = WriteTempJson( json );
     ASSERT_TRUE( fs::exists( tmpfile ) );
@@ -331,7 +319,7 @@ TEST( ChainRpcEndpointProviderTest, MultipleChainsBridgeConfig )
         rlp::base::parse::hex_bytes( topic0_hash.data(), topic0_hash.size() );
 
     ChainRpcProviderConfig config;
-    config.chains_json_path = tmpfile;
+    config.chainlist_json_path = tmpfile;
     config.bridge_contract_addresses[1] =
         "0x614577036F0a024DBC1C88BA616b394DD65d105a";
     config.bridge_contract_addresses[11155111] =
@@ -369,7 +357,7 @@ TEST( ChainRpcEndpointProviderTest, BadChainIdDoesNotCrash )
     chain_id_map.emplace( "ethereum-sepolia", 11155111 );
 
     ChainRpcProviderConfig config;
-    config.chains_json_path = "";
+    config.chainlist_json_path = "";
     // Invalid chain ID string (not a number)
     config.direct_endpoints["not_a_number"] = {
         { "https://example.com/rpc", 50, {}, {} },

--- a/test/src/startup/startup_wiring_test.cpp
+++ b/test/src/startup/startup_wiring_test.cpp
@@ -410,6 +410,119 @@ TEST( StartupWiringTest, EmptyChainsConfigDoesNotCrash )
     RemoveTempFile( path );
 }
 
+// ─── Tests: InitializeRpcEndpoints without Endpoint Sources ──────────────────
+
+TEST( StartupWiringTest, NoRpcEndpointsWiredWhenNoSourcesConfigured )
+{
+    // Reproduces the bug where InitializeRpcEndpoints() proceeds to register
+    // bridge chains and start the relayer even though ChainRpcEndpointProvider
+    // wired zero RPC endpoints.
+    //
+    // When config.chainlist_json_path is empty and config.direct_endpoints is
+    // empty, provider.Initialize() returns false.  The caller must NOT proceed
+    // with validator registration or bridge chain discovery — otherwise the
+    // catch-up scan silently skips every chain (GetFirstRpcUrl returns nullopt)
+    // while the relayer is running against unconfigured endpoints.
+
+    ChainRpcEndpointProvider::ChainIdMap chain_id_map;
+    // These chains exist in bridge_chains_config.json (bundled default)
+    chain_id_map.emplace( "ethereum-mainnet", 1 );
+    chain_id_map.emplace( "ethereum-sepolia", 11155111 );
+    chain_id_map.emplace( "bnb-smart-chain",  56 );
+    chain_id_map.emplace( "polygon-mainnet",  137 );
+
+    ChainRpcProviderConfig config;
+    config.chainlist_json_path = "";   // no public chainlist JSON
+    // config.direct_endpoints is left empty — no API-key endpoints
+
+    ChainRpcEndpointProvider provider( std::move( chain_id_map ) );
+    PublicChainInputValidator validator;
+
+    auto logger = base::createLogger( "startup_wiring_test" );
+    bool endpoints_wired = provider.Initialize( validator, config, logger );
+
+    // When no endpoint sources are configured, Initialize must report failure.
+    EXPECT_FALSE( endpoints_wired )
+        << "Initialize() should return false when no RPC endpoint sources are available";
+
+    // No chain should have RPC endpoints — GetFirstRpcUrl must return nullopt
+    // for every chain that was in the map.
+    for ( auto chain_id : { "1", "11155111", "56", "137" } )
+    {
+        auto url = validator.GetFirstRpcUrl( chain_id );
+        EXPECT_FALSE( url.has_value() )
+            << "Chain " << chain_id << " should have no endpoints when nothing is wired";
+    }
+}
+
+TEST( StartupWiringTest, BridgeChainsMustNotProceedWhenNoEndpointsWired )
+{
+    // Behavioral contract: when ChainRpcEndpointProvider::Initialize() returns
+    // false, the caller (InitializeRpcEndpoints) must NOT register validators
+    // or return bridge chains for BridgeRelayer startup.
+    //
+    // This test encodes the pattern that every caller of provider.Initialize()
+    // must follow: check the return value before proceeding.
+
+    ChainRpcEndpointProvider::ChainIdMap chain_id_map;
+    chain_id_map.emplace( "ethereum-sepolia", 11155111 );
+
+    ChainRpcProviderConfig config;
+    config.chainlist_json_path = ""; // no public endpoints
+    // direct_endpoints also empty
+
+    ChainRpcEndpointProvider provider( std::move( chain_id_map ) );
+    PublicChainInputValidator validator;
+
+    auto logger = base::createLogger( "startup_wiring_test" );
+    bool endpoints_wired = provider.Initialize( validator, config, logger );
+
+    // Simulate the bridge_chain discovery that InitializeRpcEndpoints performs:
+    // it reads bridge_chains_config.json and builds a list of chains with
+    // bridge contracts.  In the buggy code, these were unconditionally
+    // registered regardless of whether endpoints were wired.
+    struct SimulatedPair
+    {
+        std::string chain_name;
+        std::string contract_address;
+        uint64_t    chain_id;
+    };
+    std::vector<SimulatedPair> bridge_chains;
+    bridge_chains.push_back( { "ethereum-sepolia",
+                               "0x9af8050220D8C355CA3c6dC00a78B474cd3e3c70",
+                               11155111 } );
+
+    // The correct behavior: only register validators / keep bridge chains
+    // when endpoints were actually wired.
+    if ( endpoints_wired )
+    {
+        for ( const auto &chain_entry : bridge_chains )
+        {
+            // This path should NOT execute in this test — if it does, the
+            // validator is being registered without RPC endpoints.
+            IInputValidator::Register( std::to_string( chain_entry.chain_id ),
+                                       &validator );
+        }
+    }
+    else
+    {
+        // Correct unhappy-path behavior: clear bridge chains so
+        // InitializeAndStartBridge does not start the relayer.
+        bridge_chains.clear();
+    }
+
+    // After the fix, bridge_chains must be empty because no endpoints exist.
+    EXPECT_TRUE( bridge_chains.empty() )
+        << "bridge_chains must be empty when no RPC endpoints are wired — "
+        << "otherwise BridgeRelayer starts against unconfigured chains";
+
+    // Confirm the validator has no RPC URL for the chain.
+    auto url = validator.GetFirstRpcUrl( "11155111" );
+    EXPECT_FALSE( url.has_value() )
+        << "Validator should have no URL for chain 11155111 when endpoints "
+        << "were never wired";
+}
+
 // ─── Tests: Non-blocking Bridge Init (D-04) ─────────────────────────────────
 
 TEST( StartupWiringTest, BridgeInitIsNonBlocking )

--- a/test/src/startup/startup_wiring_test.cpp
+++ b/test/src/startup/startup_wiring_test.cpp
@@ -39,10 +39,10 @@ static const std::string kExpectedTopic0Hex =
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-/// @brief Write a temporary chains_config.json for testing.
+/// @brief Write a temporary bridge_chains_config.json for testing.
 fs::path WriteTempChainsConfig( const std::string &json_content )
 {
-    auto tmp_path = fs::temp_directory_path() / "test_chains_config.json";
+    auto tmp_path = fs::temp_directory_path() / "test_bridge_chains_config.json";
     std::ofstream out( tmp_path, std::ios::binary | std::ios::trunc );
     out << json_content;
     out.close();
@@ -118,7 +118,7 @@ TEST( StartupWiringTest, KnownChainMappingIsCorrect )
 
 TEST( StartupWiringTest, ParseChainsConfigWithBridgeContract )
 {
-    // Write a chains_config.json with a bridge_contract_address
+    // Write a bridge_chains_config.json with a bridge_contract_address
     const std::string json = R"({
         "ethereum-sepolia": {
             "name": "Ethereum Sepolia",
@@ -351,7 +351,7 @@ TEST( StartupWiringTest, ChainRpcProviderWithBridgeConfigReturnsChainPairs )
 
 TEST( StartupWiringTest, MalformedJsonIsHandledGracefully )
 {
-    // T-05-15: Malformed chains_config.json should be caught and handled
+    // T-05-15: Malformed bridge_chains_config.json should be caught and handled
     const std::string malformed = R"({ "ethereum-mainnet": { "name": "Ethereum", "chainId": 1, )";
     // missing closing braces — this is invalid JSON
 
@@ -388,7 +388,7 @@ TEST( StartupWiringTest, MalformedJsonIsHandledGracefully )
 
 TEST( StartupWiringTest, EmptyChainsConfigDoesNotCrash )
 {
-    // An empty chains_config.json file should be handled gracefully
+    // An empty bridge_chains_config.json file should be handled gracefully
     const std::string empty = "{}";
 
     auto path = WriteTempChainsConfig( empty );

--- a/test/src/startup/startup_wiring_test.cpp
+++ b/test/src/startup/startup_wiring_test.cpp
@@ -29,10 +29,10 @@ using namespace sgns;
 // ─── Test Constants ─────────────────────────────────────────────────────────
 
 static const std::string kBridgeEventSignature =
-    "BridgeSourceBurned(address,uint256,uint256,uint256,uint256)";
+    "BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)";
 
 // Expected topic0 hex for BridgeSourceBurned (keccak256 of the signature)
-// Computed via keccak256("BridgeSourceBurned(address,uint256,uint256,uint256,uint256)")
+// Computed via keccak256("BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)")
 static const std::string kExpectedTopic0Hex =
     "0x"  // placeholder — verified against actual hash in test
     ;

--- a/test/src/watcher/messaging_watcher_test.cpp
+++ b/test/src/watcher/messaging_watcher_test.cpp
@@ -24,7 +24,7 @@ TEST(MessagingWatcherTest, EvmMessagingWatcherInitialization) {
 
     // Define topics to watch
     std::vector<EvmMessagingWatcher::TopicFilter> topicFilters = {
-        {"BridgeSourceBurned(address,uint256,uint256,uint256,uint256)"}
+        {"BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)"}
     };
 
     // Create the EvmMessagingWatcher
@@ -58,7 +58,7 @@ TEST(MessagingWatcherTest, StartAndStopWatching) {
 
     // Define topics to watch
     std::vector<EvmMessagingWatcher::TopicFilter> topicFilters = {
-        {"BridgeSourceBurned(address,uint256,uint256,uint256,uint256)"}
+        {"BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)"}
     };
 
     // Create the EvmMessagingWatcher
@@ -106,7 +106,7 @@ TEST(MessagingWatcherTest, MultipleWatchersManagement) {
 
     // Define topics to watch for both configurations
     std::vector<EvmMessagingWatcher::TopicFilter> topicFilters1 = {
-        {"BridgeSourceBurned(address,uint256,uint256,uint256,uint256)"}
+        {"BridgeSourceBurned(address,uint256,uint256,uint256,uint256,bytes)"}
     };
     std::vector<EvmMessagingWatcher::TopicFilter> topicFilters2 = {
         {"AnotherEvent(address,uint256)"}


### PR DESCRIPTION
## Changes

### Chain RPC / bridge config fixes
- **Decouple chainlist_json_path from bridge_chains_path** — bridge_chains_config.json contains bridge contract addresses only, not a ChainList JSON array. Setting chainlist_json_path to the bridge config path caused zero RPC endpoints to be wired.
- **Disambiguate naming** — rename chains_json_path → chainlist_json_path, config file → bridge_chains_config.json. Add bundled default config.
- **Catch-up scan from_block fix** — query eth_blockNumber before eth_getLogs to compute a relative from_block instead of using scan_depth as an absolute block number.
- **Honor ChainRpcEndpointProvider::Initialize return value** — check the outcome instead of silently swallowing failure.

### Bridge event signature update
- **Update BridgeSourceBurned from 5 params → 6 params** to match new [GNUSBridge.sol](https://github.com/GeniusVentures/TokenContracts/blob/develop/gnus-ai/contracts/gnus-ai/GNUSBridge.sol) which adds `bytes sgnsDestination` (64-byte SuperGenius public key).
- BridgeRelayer now decodes values[5] as `codec::ByteBuffer`, converts via `hex_bytes`, and uses it as the mint destination instead of the EVM sender address.
- Updated event_registry in evmrelay submodule (pushed to evmrelay develop).
- Updated all test references to the new 6-param signature.

### Files changed
- `src/account/BridgeRelayer.cpp` — decode 6th param, remove AddressToHex
- `src/account/GeniusNode.cpp` — event_sig strings, from_block fix, Initialize return check
- `test/src/account/bridge_relayer_test.cpp` — MakeBurnNotification 6-param, new round-trip test
- `test/src/startup/startup_wiring_test.cpp` — event sig constant
- `test/src/account/chain_rpc_endpoint_provider_test.cpp` — event sig strings
- `test/src/watcher/messaging_watcher_test.cpp` — event sig strings
- `evmrelay/include/eth/eth_watch_cli.hpp` — registered 6th param (kBytes)